### PR TITLE
Render entire atlases at once with batch targeting

### DIFF
--- a/tutorials/optimviz/ClassActivationAtlas_OptimViz.ipynb
+++ b/tutorials/optimviz/ClassActivationAtlas_OptimViz.ipynb
@@ -494,13 +494,18 @@
         "def vis_neuron_direction(\n",
         "    model: torch.nn.Module,\n",
         "    target: torch.nn.Module,\n",
-        "    vec: torch.Tensor,\n",
-        "    vec_whitened: Optional[torch.tensor] = None,\n",
-        ") -> torch.Tensor:\n",
-        "    image = opt.images.NaturalImage((80, 80)).to(device)\n",
-        "    loss_fn = opt.loss.AngledNeuronDirection(\n",
-        "        target, vec, vec_whitened, cossim_pow=4.0\n",
-        "    )\n",
+        "    vecs: torch.Tensor,\n",
+        "    vec_whitened: Optional[torch.Tensor] = None,\n",
+        ") -> Tuple[torch.Tensor, torch.Tensor]:\n",
+        "    image = opt.images.NaturalImage((80, 80), batch=vecs.shape[0]).to(device)\n",
+        "    loss_fn_list = [\n",
+        "        opt.loss.AngledNeuronDirection(\n",
+        "            target, vec, vec_whitened, cossim_pow=4.0, batch_index=i\n",
+        "        )\n",
+        "        for i, vec in enumerate(vecs)\n",
+        "    ]\n",
+        "    loss_fn = sum(loss_fn_list)\n",
+        "\n",
         "    transforms = torch.nn.Sequential(\n",
         "        torch.nn.ConstantPad2d(2, value=1.0),\n",
         "        opt.transforms.RandomSpatialJitter(4),\n",
@@ -521,8 +526,13 @@
         "        opt.transforms.RandomSpatialJitter(2),\n",
         "    )\n",
         "    obj = opt.InputOptimization(model, loss_fn, image, transforms)\n",
-        "    history = obj.optimize(opt.optimization.n_steps(256, False), lr=0.021)\n",
-        "    return image(), history[-1]"
+        "    history = obj.optimize(opt.optimization.n_steps(256, True), lr=0.020)\n",
+        "\n",
+        "    # Collect the final loss values separately for each batch element\n",
+        "    final_activations = opt.models.collect_activations(model, target, image().detach())\n",
+        "    final_losses = torch.stack([l(final_activations).mean() for l in loss_fn_list])\n",
+        "\n",
+        "    return image(), final_losses"
       ],
       "execution_count": null,
       "outputs": []
@@ -557,7 +567,7 @@
         "id": "O_MuXhcErCbl"
       },
       "source": [
-        "To generate all of the activation atlas images, we'll iterate through all the previously calculated direction vectors. To monitor our progress, we will use the `tqdm` library. To maximize atlas quality, we can optionally try rendering multiple attempts of each visualization and then keeping the attempt with the lowest final loss value."
+        "To generate all of the activation atlas images, we'll iterate through all the previously calculated direction vectors. To maximize atlas quality, we can optionally try rendering multiple attempts of each visualization and then keeping the attempt with the lowest final loss value."
       ]
     },
     {
@@ -570,21 +580,21 @@
         "outputId": "79dc4890-969e-41ab-e372-11df3957eedd"
       },
       "source": [
-        "from tqdm import tqdm\n",
-        "\n",
-        "A = []\n",
         "num_attempts = 2\n",
         "\n",
-        "for i in tqdm(range(vecs.size(0)), position=0, leave=True):\n",
-        "    attempts, loss_list = [], []\n",
-        "    for a in range(num_attempts):\n",
-        "        img, loss = vis_neuron_direction(\n",
-        "            model, model.mixed5b_relu, vec=vecs[i], vec_whitened=whitend_activation_samples\n",
-        "        )\n",
-        "        attempts.append(img.detach().cpu())\n",
-        "        loss_list.append(loss)\n",
+        "attempts, attempt_losses = [], []\n",
+        "for a in range(num_attempts):\n",
+        "    imgs, losses = vis_neuron_direction(\n",
+        "        model, model.mixed5b_relu, vecs=vecs, vec_whitened=whitend_activation_samples\n",
+        "    )\n",
+        "    attempts.append(imgs.detach().cpu())\n",
+        "    attempt_losses.append(losses)\n",
         "\n",
-        "    A.append(attempts[torch.argmin(torch.stack(loss_list))])"
+        "A = []\n",
+        "attempt_losses = torch.stack(attempt_losses)\n",
+        "for i in range(vecs.shape[0]):\n",
+        "    idx = torch.argmax(attempt_losses[:,i])\n",
+        "    A.append(attempts[idx][i].unsqueeze(0))"
       ],
       "execution_count": null,
       "outputs": [
@@ -607,7 +617,7 @@
         "\n",
         "To put the atlas cells together, we'll use the `create_atlas` function. The `create_atlas` takes the following inputs and returns a complete atlas:\n",
         "\n",
-        "* `cells`: A list of NCHW image tensors that are all the same shape.\n",
+        "* `cells`: A list of NCHW image tensors that are all the same shape, or a set of NCHW image tensors stacked along the batch dimension.\n",
         "\n",
         "* `coords`: A list of coordinates that correspond to the inputs to `cells`.\n",
         "\n",
@@ -863,21 +873,21 @@
         "outputId": "47dfafdd-2daa-4bca-bf8e-e1e862037c41"
       },
       "source": [
-        "from tqdm import tqdm\n",
+        "num_attempts = 2\n",
+        "\n",
+        "attempts, attempt_losses = [], []\n",
+        "for a in range(num_attempts):\n",
+        "    imgs, losses = vis_neuron_direction(\n",
+        "        model, model.mixed5b_relu, vecs=vecs, vec_whitened=whitend_activation_samples\n",
+        "    )\n",
+        "    attempts.append(imgs.detach().cpu())\n",
+        "    attempt_losses.append(losses)\n",
         "\n",
         "B = []\n",
-        "num_attempts = 1\n",
-        "\n",
-        "for i in tqdm(range(vecs.size(0)), position=0, leave=True):\n",
-        "    attempts, loss_list = [], []\n",
-        "    for a in range(num_attempts):\n",
-        "        img, loss = vis_neuron_direction(\n",
-        "            model, model.mixed5b_relu, vec=vecs[i], vec_whitened=whitend_activation_samples\n",
-        "        )\n",
-        "        attempts.append(img.detach().cpu())\n",
-        "        loss_list.append(loss)\n",
-        "\n",
-        "    B.append(attempts[torch.argmin(torch.stack(loss_list))])"
+        "attempt_losses = torch.stack(attempt_losses)\n",
+        "for i in range(vecs.shape[0]):\n",
+        "    idx = torch.argmax(attempt_losses[:,i])\n",
+        "    B.append(attempts[idx][i].unsqueeze(0))"
       ],
       "execution_count": null,
       "outputs": [


### PR DESCRIPTION
There is an insane increase in render speed when utilizing batch targeting!

* Using the same settings, the Mixed4c activation atlas render time has been reduced from 21 minutes 26 seconds to 1 minute 39 seconds.