### PR TITLE
Remove ImageTensor test skips & add new tests

### DIFF
--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -503,53 +503,6 @@ class RandomCrop(nn.Module):
         )
 
 
-class AlphaChannelLoss(nn.Module):
-    """
-        TODO: Fix AlphaChannelLoss
-        Transform for calculating alpha channel loss, without altering the input tensor.
-        Loss values are calculated in such a way that opaque and transparent regions of
-        the tensor are automatically balanced.
-    ​
-        See: https://distill.pub/2018/differentiable-parameterizations/
-        Mordvintsev, et al., "Differentiable Image Parameterizations", Distill, 2018.
-    ​
-        Args:
-            scale (float, sequence): Tuple of rescaling values to randomly select from.
-            crop_size (int, sequence, int, optional): The desired cropped output size
-                for secondary alpha channel loss.
-            background (tensor, optional):  An NCHW image tensor to be used as the
-                alpha channel's background.
-    """
-
-    def __init__(
-        self,
-        scale: NumSeqOrTensorType,
-        crop_size: Optional[Tuple[int, int]] = None,
-        background: Optional[torch.Tensor] = None,
-    ) -> None:
-        raise NotImplementedError  # We are not ready for this
-        super().__init__()
-        self.random_scale = RandomScale(scale=scale)
-        self.crop_size = crop_size
-        self.random_crop = RandomCrop(crop_size)
-        self.blend_alpha = BlendAlpha(background=background)
-        self.loss = 0
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        assert x.dim() == 4  # Should be of shape (batch, channel, height, width)
-        assert x.size(1) == 4  # Channel dim should be rgba
-
-        x_shifted = torch.cat([self.blend_alpha(x.clone()), x.clone()[:, 3:]], 1)
-
-        x_shifted = self.random_scale(x_shifted)
-        x_shifted_crop = self.random_crop(x_shifted)
-
-        self.loss = (1.0 - x_shifted[:, 3:].mean()) + (
-            (1.0 - x_shifted_crop[:, 3:].mean()) * 0.5
-        )
-        return x
-
-
 __all__ = [
     "BlendAlpha",
     "IgnoreAlpha",

--- a/tests/optim/core/test_optimization.py
+++ b/tests/optim/core/test_optimization.py
@@ -9,7 +9,6 @@ from tests.helpers.basic_models import BasicModel_ConvNet_Optim
 
 
 class TestInputOptimization(BaseTest):
-    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_input_optimization(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -23,7 +22,6 @@ class TestInputOptimization(BaseTest):
         self.assertTrue(history[0] > history[-1])
         self.assertTrue(len(history) == n_steps)
 
-    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_input_optimization_param(self) -> None:
         """Test for optimizing param without model"""
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -566,7 +566,6 @@ class TestSharedImage(BaseTest):
 
 
 class TestNaturalImage(BaseTest):
-    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_natural_image_0(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -576,7 +575,6 @@ class TestNaturalImage(BaseTest):
         image_np = image_param.forward().detach().numpy()
         assertArraysAlmostEqual(image_np, np.ones_like(image_np) * 0.5)
 
-    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_natural_image_1(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -15,9 +15,45 @@ from tests.helpers.basic import (
 from tests.optim.helpers import numpy_image
 
 
-class TestImageTensor(BaseTest):
     def test_repr(self) -> None:
         self.assertEqual(str(images.ImageTensor()), "ImageTensor([])")
+
+    def test_new(self) -> None:
+        try:
+            x = torch.ones(5)
+            test_tensor = images.ImageTensor(x)
+            test_works = True
+        except Exception as e:
+            test_works = False
+        self.assertTrue(test_works)
+
+    def test_torch_function(self) -> None:
+        x = torch.ones(5)
+        image_tensor = images.ImageTensor(x)
+        image_tensor = (image_tensor * 5) * torch.ones(5)
+        self.assertEqual((image_tensor).sum().item(), (torch.ones(5) * 5).sum().item())
+
+    def test_load_image_from_url(self) -> None:
+        img_url = (
+            "https://github.com/pytorch/captum"
+            + "/raw/master/website/static/img/captum_logo.png"
+        )
+        try:
+            new_tensor = images.ImageTensor().open(img_url)
+            test_works = True
+        except Exception as e:
+            test_works = False
+        self.assertTrue(test_works)
+
+    def test_export_and_open_local_image(self) -> None:
+        x = torch.ones(5) * 2
+        image_tensor = images.ImageTensor(x)
+
+        filename = "image_tensor.jpg"
+        image_tensor.export(filename)
+        new_tensor = images.ImageTensor().open(filename)
+
+        assertTensorAlmostEqual(self, image_tensor(), new_tensor())
 
     def test_natural_image_cuda(self) -> None:
         if not torch.cuda.is_available():

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -15,6 +15,7 @@ from tests.helpers.basic import (
 from tests.optim.helpers import numpy_image
 
 
+class TestImageTensor(BaseTest):
     def test_repr(self) -> None:
         self.assertEqual(str(images.ImageTensor()), "ImageTensor([])")
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -31,8 +31,8 @@ class TestImageTensor(BaseTest):
     def test_torch_function(self) -> None:
         x = torch.ones(5)
         image_tensor = images.ImageTensor(x)
-        image_tensor = (image_tensor * 5) * torch.ones(5)
-        self.assertEqual(image_tensor.sum().item(), (torch.ones(5) * 5).sum().item())
+        image_tensor = (image_tensor * 1) * torch.ones(5)
+        self.assertEqual(image_tensor.sum().item(), torch.ones(5).sum().item())
 
     def test_load_image_from_url(self) -> None:
         img_url = (

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -24,6 +24,16 @@ class TestImageTensor(BaseTest):
         test_tensor = images.ImageTensor(x)
         self.assertEqual(x.shape, test_tensor.shape)
 
+    def test_new_numpy(self) -> None:
+        x = torch.ones(5).numpy()
+        test_tensor = images.ImageTensor(x)
+        self.assertEqual(x.shape, test_tensor.shape)
+
+    def test_new_list(self) -> None:
+        x = torch.ones(5).tolist()
+        test_tensor = images.ImageTensor(x)
+        self.assertEqual(x.shape, test_tensor.shape)
+
     def test_torch_function(self) -> None:
         x = torch.ones(5)
         image_tensor = images.ImageTensor(x)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -20,13 +20,9 @@ class TestImageTensor(BaseTest):
         self.assertEqual(str(images.ImageTensor()), "ImageTensor([])")
 
     def test_new(self) -> None:
-        try:
-            x = torch.ones(5)
-            test_tensor = images.ImageTensor(x)
-            test_works = True
-        except Exception as e:
-            test_works = False
-        self.assertTrue(test_works)
+        x = torch.ones(5)
+        test_tensor = images.ImageTensor(x)
+        self.assertEqual(x.shape, test_tensor.shape)
 
     def test_torch_function(self) -> None:
         x = torch.ones(5)
@@ -39,12 +35,8 @@ class TestImageTensor(BaseTest):
             "https://github.com/pytorch/captum"
             + "/raw/master/website/static/img/captum_logo.png"
         )
-        try:
-            new_tensor = images.ImageTensor().open(img_url)
-            test_works = True
-        except Exception as e:
-            test_works = False
-        self.assertTrue(test_works)
+        new_tensor = images.ImageTensor().open(img_url)
+        self.assertEqual(list(new_tensor.shape), [3, 54, 208])
 
     def test_export_and_open_local_image(self) -> None:
         x = torch.ones(1, 3, 5, 5)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -16,7 +16,6 @@ from tests.optim.helpers import numpy_image
 
 
 class TestImageTensor(BaseTest):
-    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_repr(self) -> None:
         self.assertEqual(str(images.ImageTensor()), "ImageTensor([])")
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -22,16 +22,19 @@ class TestImageTensor(BaseTest):
     def test_new(self) -> None:
         x = torch.ones(5)
         test_tensor = images.ImageTensor(x)
+        self.assertTrue(torch.is_tensor(test_tensor))
         self.assertEqual(x.shape, test_tensor.shape)
 
     def test_new_numpy(self) -> None:
         x = torch.ones(5).numpy()
         test_tensor = images.ImageTensor(x)
+        self.assertTrue(torch.is_tensor(test_tensor))
         self.assertEqual(x.shape, test_tensor.shape)
 
     def test_new_list(self) -> None:
         x = torch.ones(5).tolist()
         test_tensor = images.ImageTensor(x)
+        self.assertTrue(torch.is_tensor(test_tensor))
         self.assertEqual(x.shape, test_tensor.shape)
 
     def test_torch_function(self) -> None:
@@ -46,6 +49,7 @@ class TestImageTensor(BaseTest):
             + "/raw/master/website/static/img/captum_logo.png"
         )
         new_tensor = images.ImageTensor().open(img_url)
+        self.assertTrue(torch.is_tensor(new_tensor))
         self.assertEqual(list(new_tensor.shape), [3, 54, 208])
 
     def test_export_and_open_local_image(self) -> None:
@@ -56,6 +60,7 @@ class TestImageTensor(BaseTest):
         image_tensor.export(filename)
         new_tensor = images.ImageTensor().open(filename)
 
+        self.assertTrue(torch.is_tensor(new_tensor))
         assertTensorAlmostEqual(self, image_tensor, new_tensor)
 
     def test_natural_image_cuda(self) -> None:

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -31,7 +31,7 @@ from tests.optim.helpers import numpy_image
         x = torch.ones(5)
         image_tensor = images.ImageTensor(x)
         image_tensor = (image_tensor * 5) * torch.ones(5)
-        self.assertEqual((image_tensor).sum().item(), (torch.ones(5) * 5).sum().item())
+        self.assertEqual(image_tensor.sum().item(), (torch.ones(5) * 5).sum().item())
 
     def test_load_image_from_url(self) -> None:
         img_url = (
@@ -46,14 +46,14 @@ from tests.optim.helpers import numpy_image
         self.assertTrue(test_works)
 
     def test_export_and_open_local_image(self) -> None:
-        x = torch.ones(5) * 2
+        x = torch.ones(1, 3, 5, 5)
         image_tensor = images.ImageTensor(x)
 
         filename = "image_tensor.jpg"
         image_tensor.export(filename)
         new_tensor = images.ImageTensor().open(filename)
 
-        assertTensorAlmostEqual(self, image_tensor(), new_tensor())
+        assertTensorAlmostEqual(self, image_tensor, new_tensor)
 
     def test_natural_image_cuda(self) -> None:
         if not torch.cuda.is_available():

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -650,22 +650,3 @@ class TestRandomCrop(BaseTest):
         x_out = crop_transform(x)
 
         self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
-
-
-class TestAlphaChannelLoss(BaseTest):
-    def test_alpha_channel_loss_forward(self) -> None:
-        raise unittest.SkipTest(
-            "Skipping AlphaChannelLoss test until function is ready."
-        )
-        # crop_size = [160, 160]
-        # scale = [0.6, 0.7, 0.8, 0.9, 1.0, 1.1]
-
-        # alpha_loss_transform = transforms.AlphaChannelLoss(
-        #     scale=scale, crop_size=crop_size
-        # )
-        # x = torch.randn(1, 4, 224, 224)
-
-        # x_out = alpha_loss_transform(x)
-
-        # assertTensorAlmostEqual(self, x_out, x, 0)
-        # self.assertNotEqual(alpha_loss_transforms.loss, 0)


### PR DESCRIPTION
* Remove `ImageTensor` test skips as the `torch.Tensor`'s `__new__` function has been fixed.
* Add tests for `ImageTensor` functions.
* Removed old `AlphaChannelLoss` code.