### PR TITLE
Replace model input range assertion with UserWarning

### DIFF
--- a/captum/optim/models/_image/inception_v1.py
+++ b/captum/optim/models/_image/inception_v1.py
@@ -1,4 +1,5 @@
 from typing import Optional, Tuple, Type, Union, cast
+from warnings import warn
 
 import torch
 import torch.nn as nn
@@ -165,7 +166,8 @@ class InceptionV1(nn.Module):
     def _transform_input(self, x: torch.Tensor) -> torch.Tensor:
         if self.transform_input:
             assert x.dim() == 3 or x.dim() == 4
-            assert x.min() >= 0.0 and x.max() <= 1.0
+            if x.min() < 0.0 or x.max() > 1.0:
+                warn("Model input has values outside of the range [0, 1].")
             x = x.unsqueeze(0) if x.dim() == 3 else x
             x = x * 255 - 117
             x = x[:, [2, 1, 0]] if self.bgr_transform else x

--- a/captum/optim/models/_image/inception_v1_places365.py
+++ b/captum/optim/models/_image/inception_v1_places365.py
@@ -1,4 +1,5 @@
 from typing import Any, Optional, Tuple, Type, Union, cast
+from warnings import warn
 
 import torch
 import torch.nn as nn
@@ -178,7 +179,8 @@ class InceptionV1Places365(nn.Module):
     def _transform_input(self, x: torch.Tensor) -> torch.Tensor:
         if self.transform_input:
             assert x.dim() == 3 or x.dim() == 4
-            assert x.min() >= 0.0 and x.max() <= 1.0
+            if x.min() < 0.0 or x.max() > 1.0:
+                warn("Model input has values outside of the range [0, 1].")
             x = x.unsqueeze(0) if x.dim() == 3 else x
             x = x * 255 - torch.tensor(
                 [116.7894, 112.6004, 104.0437], device=x.device

--- a/tests/optim/models/test_models.py
+++ b/tests/optim/models/test_models.py
@@ -80,6 +80,19 @@ class TestInceptionV1(BaseTest):
         expected_output = x * 255 - 117
         assertTensorAlmostEqual(self, output, expected_output, 0)
 
+    def test_inceptionv1_transform_warning(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping InceptionV1 internal transform warning test due to"
+                + " insufficient Torch version."
+            )
+        x = torch.stack(
+            [torch.ones(3, 112, 112) * -1, torch.ones(3, 112, 112) * 2], dim=0
+        )
+        model = googlenet(pretrained=True)
+        with self.assertWarns(UserWarning):
+            output = model._transform_input(x)
+
     def test_inceptionv1_transform_bgr(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -197,6 +210,19 @@ class TestInceptionV1Places365(BaseTest):
         ).view(3, 1, 1)
         expected_output = expected_output[:, [2, 1, 0]]
         assertTensorAlmostEqual(self, output, expected_output, 0)
+
+    def test_inceptionv1_places365_transform_warning(self) -> None:
+        if torch.__version__ <= "1.6.0":
+            raise unittest.SkipTest(
+                "Skipping InceptionV1 Places365 internal transform warning test due"
+                + " to insufficient Torch version."
+            )
+        x = torch.stack(
+            [torch.ones(3, 112, 112) * -1, torch.ones(3, 112, 112) * 2], dim=0
+        )
+        model = googlenet_places365(pretrained=True)
+        with self.assertWarns(UserWarning):
+            output = model._transform_input(x)
 
     def test_inceptionv1_places365_load_and_forward(self) -> None:
         if torch.__version__ <= "1.6.0":


### PR DESCRIPTION
Sometimes input tensors can have values higher than 1 or lower than 0, like for example when using some of the features from Captum's attr module. Rather than disabling these checks, I've changed them into UserWarnings instead.