### PR TITLE
Add sum_loss_list() function & correct target type hints

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -720,8 +720,6 @@ def sum_loss_list(
         ]
         for target in targets
     ]
-    #  Only use unique targets to avoid unnecessary duplication
-    target = list(set(target))
     return CompositeLoss(loss_fn, name=name, target=target)
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -684,7 +684,7 @@ class ActivationWeights(BaseLoss):
 
 
 def sum_loss_list(
-    loss_list: List[Loss],
+    loss_list: List,
     to_scalar_fn: Callable[[torch.Tensor], torch.Tensor] = torch.mean,
 ) -> CompositeLoss:
     """
@@ -715,7 +715,7 @@ def sum_loss_list(
     target = [
         target
         for targets in [
-            [l.target] if not hasattr(l.target, "__iter__") else l.target
+            [loss.target] if not hasattr(loss.target, "__iter__") else loss.target
             for l in loss_list
         ]
         for target in targets

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -713,7 +713,12 @@ def sum_loss_list(
     name = "Sum(" + ", ".join([loss.__name__ for loss in loss_list]) + ")"
     #  Only use unique targets to avoid unnecessary duplication
     #target = list(set([loss.target for loss in loss_list]))
-    target = [l.target if not hasattr(l.target, "__iter__") else *l.target for l in loss_list]
+    target = []
+    for l in loss_list:
+        if hasattr(l.target, "__iter__"):
+            target += l.target
+        else:
+            target += [l.target]
     target = list(set(target))
     return CompositeLoss(loss_fn, name=name, target=target)
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -713,8 +713,8 @@ def sum_loss_list(
     name = "Sum(" + ", ".join([loss.__name__ for loss in loss_list]) + ")"
     #  Only use unique targets to avoid unnecessary duplication
     #target = list(set([loss.target for loss in loss_list]))
-    targets = [l.target for l in loss_list if not hasattr(l.target, "__iter__") else *l.target]
-    target = list(set(targets))
+    [target + [l.target] for l in loss_list if not hasattr(l.target, "__iter__") else target + l.target]
+    target = list(set(target))
     return CompositeLoss(loss_fn, name=name, target=target)
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -105,7 +105,7 @@ class Loss(ABC):
         """Summarize a large number of losses without recursion errors"""
 
         def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
-            return sum([l(module) for l in loss_fn_list])
+            return sum([torch.mean(l(module)) for l in loss_fn_list])
 
         name = ', '.join([l.__name__ for l in loss_fn_list])
         target = list(set([loss_fn_list[i].target for i in range(len(loss_fn_list))]))

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -683,8 +683,8 @@ class ActivationWeights(BaseLoss):
         return activations
 
 
-def sum_loss_fn_list(
-    loss_fn_list: List,
+def sum_loss_list(
+    loss_list: List,
     to_scalar_fn: Callable[[torch.Tensor], torch.Tensor] = torch.mean,
 ) -> CompositeLoss:
     """
@@ -698,21 +698,21 @@ def sum_loss_fn_list(
 
     Args:
 
-        loss_fn_list (list): A list of loss function objectives.
+        loss_list (list): A list of loss function objectives.
         to_scalar_fn (Callable): A function for converting loss function outputs to
             scalar values, in order to prevent size mismatches.
 
     Returns:
         loss_fn (CompositeLoss): A composite loss function containing all the loss
-            functions from `loss_fn_list`.
+            functions from `loss_list`.
     """
 
     def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
-        return sum([to_scalar_fn(loss_fn(module)) for loss_fn in loss_fn_list])
+        return sum([to_scalar_fn(loss_fn(module)) for loss_fn in loss_list])
 
-    name = ", ".join([loss_fn.__name__ for loss_fn in loss_fn_list])
+    name = ", ".join([loss_fn.__name__ for loss_fn in loss_list])
     #  Only use unique targets to avoid unnecessary duplication
-    target = list(set([loss_fn.target for loss_fn in loss_fn_list]))
+    target = list(set([loss_fn.target for loss_fn in loss_list]))
     return CompositeLoss(loss_fn, name=name, target=target)
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -708,11 +708,11 @@ def sum_loss_list(
     """
 
     def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
-        return sum([to_scalar_fn(loss_fn(module)) for loss_fn in loss_list])
+        return sum([to_scalar_fn(loss(module)) for loss in loss_list])
 
-    name = ", ".join([loss_fn.__name__ for loss_fn in loss_list])
+    name = ", ".join([loss.__name__ for loss in loss_list])
     #  Only use unique targets to avoid unnecessary duplication
-    target = list(set([loss_fn.target for loss_fn in loss_list]))
+    target = list(set([loss.target for loss in loss_list]))
     return CompositeLoss(loss_fn, name=name, target=target)
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -100,15 +100,15 @@ class Loss(ABC):
             )
         return CompositeLoss(loss_fn, name=name, target=target)
 
-  @staticmethod
-  def sum_list(loss_fn_list: List) -> "CompositeLoss":
-      def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
-          return sum([l(module) for l in loss_fn_list])
+    @staticmethod
+    def sum_list(loss_fn_list: List) -> "CompositeLoss":
+        def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
+            return sum([l(module) for l in loss_fn_list])
 
 
-      name = ', '.join([l.__name__ for l in loss_fn_list])
-      target = loss_fn_list[0].target
-      return CompositeLoss(loss_fn, name=name, target=target)
+        name = ', '.join([l.__name__ for l in loss_fn_list])
+        target = loss_fn_list[0].target
+        return CompositeLoss(loss_fn, name=name, target=target)
 
 
 def module_op(

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -713,13 +713,14 @@ def sum_loss_list(
     name = "Sum(" + ", ".join([loss.__name__ for loss in loss_list]) + ")"
     #  Only use unique targets to avoid unnecessary duplication
     #target = list(set([loss.target for loss in loss_list]))
-    target = []
-    for l in loss_list:
-        if hasattr(l.target, "__iter__"):
-            target += l.target
-        else:
-            target += [l.target]
-    target = list(set(target))
+    #target = []
+    #for l in loss_list:
+    #    if hasattr(l.target, "__iter__"):
+    #        target += l.target
+    #   else:
+    #        target += [l.target]
+    #target = list(set(target))
+    target = list(set([loss for targets in [[l.target] if not hasattr(l.target, "__iter__") else l.target for l in loss_list] for loss in targets]))
     return CompositeLoss(loss_fn, name=name, target=target)
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -1,7 +1,7 @@
 import functools
 import operator
 from abc import ABC, abstractmethod, abstractproperty
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -160,7 +160,7 @@ class BaseLoss(Loss):
 
 class CompositeLoss(BaseLoss):
     def __init__(
-        self, loss_fn: Callable, name: str = "", target: nn.Module = []
+        self, loss_fn: Callable, name: str = "", target: Union[nn.Module, List[nn.Module]] = []
     ) -> None:
         super(CompositeLoss, self).__init__(target)
         self.__name__ = name

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -140,7 +140,9 @@ def module_op(
 
 class BaseLoss(Loss):
     def __init__(
-        self, target: Union[nn.Module, List[nn.Module]] = [], batch_index: Optional[int] = None
+        self,
+        target: Union[nn.Module, List[nn.Module]] = [],
+        batch_index: Optional[int] = None,
     ) -> None:
         super(BaseLoss, self).__init__()
         self._target = target
@@ -150,7 +152,7 @@ class BaseLoss(Loss):
             self._batch_index = (batch_index, batch_index + 1)
 
     @property
-    def target(self) -> nn.Module:
+    def target(self) -> Union[nn.Module, List[nn.Module]]:
         return self._target
 
     @property
@@ -160,7 +162,10 @@ class BaseLoss(Loss):
 
 class CompositeLoss(BaseLoss):
     def __init__(
-        self, loss_fn: Callable, name: str = "", target: Union[nn.Module, List[nn.Module]] = []
+        self,
+        loss_fn: Callable,
+        name: str = "",
+        target: Union[nn.Module, List[nn.Module]] = [],
     ) -> None:
         super(CompositeLoss, self).__init__(target)
         self.__name__ = name

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -755,6 +755,6 @@ __all__ = [
     "AngledNeuronDirection",
     "TensorDirection",
     "ActivationWeights",
-    "sum_loss_fn_list",
+    "sum_loss_list",
     "default_loss_summarize",
 ]

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -703,9 +703,9 @@ def sum_loss_fn_list(
     """
 
     def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
-        return sum([to_scalar_fn(l(module)) for l in loss_fn_list])
+        return sum([to_scalar_fn(loss_fn(module)) for loss_fn in loss_fn_list])
 
-    name = ", ".join([l.__name__ for l in loss_fn_list])
+    name = ", ".join([loss_fn.__name__ for loss_fn in loss_fn_list])
     #  Only use unique targets to avoid unnecessary duplication
     target = list(set([loss_fn.target for loss_fn in loss_fn_list]))
     return CompositeLoss(loss_fn, name=name, target=target)

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -694,7 +694,7 @@ def sum_loss_list(
     recursion depth limit for tasks such as summarizing a large list of loss functions
     with the built-in sum() function.
 
-    This functions works similar to Lucid's optvis.objectives.Objective.sum() function.
+    This function works similar to Lucid's optvis.objectives.Objective.sum() function.
 
     Args:
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -100,6 +100,16 @@ class Loss(ABC):
             )
         return CompositeLoss(loss_fn, name=name, target=target)
 
+  @staticmethod
+  def sum_list(loss_fn_list: List) -> "CompositeLoss":
+      def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
+          return sum([l(module) for l in loss_fn_list])
+
+
+      name = ', '.join([l.__name__ for l in loss_fn_list])
+      target = loss_fn_list[0].target
+      return CompositeLoss(loss_fn, name=name, target=target)
+
 
 def module_op(
     self: Loss, other: Union[None, int, float, Loss], math_op: Callable

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -688,7 +688,7 @@ def sum_loss_fn_list(
     default maximum recursion depth limit. This function can be used to avoid the
     recursion depth limit for tasks such as summarizing a large list of loss functions
     with the built-in sum() function.
-    
+
     This functions works similar to Lucid's optvis.objectives.Objective.sum() function.
 
     Args:

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -698,9 +698,10 @@ def sum_loss_list(
 
     Args:
 
-        loss_list (list of Loss): A list of loss function objectives.
+        loss_list (list): A list of loss function objectives.
         to_scalar_fn (Callable): A function for converting loss function outputs to
             scalar values, in order to prevent size mismatches.
+            Default: torch.mean
 
     Returns:
         loss_fn (CompositeLoss): A composite loss function containing all the loss

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -711,16 +711,17 @@ def sum_loss_list(
         return sum([to_scalar_fn(loss(module)) for loss in loss_list])
 
     name = "Sum(" + ", ".join([loss.__name__ for loss in loss_list]) + ")"
+    # Collect targets from losses
+    target = [
+        target
+        for targets in [
+            [l.target] if not hasattr(l.target, "__iter__") else l.target
+            for l in loss_list
+        ]
+        for target in targets
+    ]
     #  Only use unique targets to avoid unnecessary duplication
-    #target = list(set([loss.target for loss in loss_list]))
-    #target = []
-    #for l in loss_list:
-    #    if hasattr(l.target, "__iter__"):
-    #        target += l.target
-    #   else:
-    #        target += [l.target]
-    #target = list(set(target))
-    target = list(set([loss for targets in [[l.target] if not hasattr(l.target, "__iter__") else l.target for l in loss_list] for loss in targets]))
+    target = list(set(target))
     return CompositeLoss(loss_fn, name=name, target=target)
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -713,7 +713,7 @@ def sum_loss_list(
     name = "Sum(" + ", ".join([loss.__name__ for loss in loss_list]) + ")"
     #  Only use unique targets to avoid unnecessary duplication
     #target = list(set([loss.target for loss in loss_list]))
-    [target + [l.target] for l in loss_list if not hasattr(l.target, "__iter__") else target + l.target]
+    target = [l.target if not hasattr(l.target, "__iter__") else *l.target for l in loss_list]
     target = list(set(target))
     return CompositeLoss(loss_fn, name=name, target=target)
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -710,7 +710,7 @@ def sum_loss_list(
     def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
         return sum([to_scalar_fn(loss(module)) for loss in loss_list])
 
-    name = ", ".join([loss.__name__ for loss in loss_list])
+    name = "Sum(" + ", ".join([loss.__name__ for loss in loss_list]) + ")"
     #  Only use unique targets to avoid unnecessary duplication
     target = list(set([loss.target for loss in loss_list]))
     return CompositeLoss(loss_fn, name=name, target=target)

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -140,7 +140,7 @@ def module_op(
 
 class BaseLoss(Loss):
     def __init__(
-        self, target: nn.Module = [], batch_index: Optional[int] = None
+        self, target: Union[nn.Module, List[nn.Module]] = [], batch_index: Optional[int] = None
     ) -> None:
         super(BaseLoss, self).__init__()
         self._target = target

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -102,12 +102,13 @@ class Loss(ABC):
 
     @staticmethod
     def sum_list(loss_fn_list: List) -> "CompositeLoss":
+        """Summarize a large number of losses without recursion errors"""
+
         def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
             return sum([l(module) for l in loss_fn_list])
 
-
         name = ', '.join([l.__name__ for l in loss_fn_list])
-        target = loss_fn_list[0].target
+        target = list(set([loss_fn_list[i].target for i in range(len(loss_fn_list))]))
         return CompositeLoss(loss_fn, name=name, target=target)
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -716,7 +716,7 @@ def sum_loss_list(
         target
         for targets in [
             [loss.target] if not hasattr(loss.target, "__iter__") else loss.target
-            for l in loss_list
+            for loss in loss_list
         ]
         for target in targets
     ]

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -27,7 +27,7 @@ class Loss(ABC):
         super(Loss, self).__init__()
 
     @abstractproperty
-    def target(self) -> nn.Module:
+    def target(self) -> Union[nn.Module, List[nn.Module]]:
         pass
 
     @abstractmethod

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -712,7 +712,9 @@ def sum_loss_list(
 
     name = "Sum(" + ", ".join([loss.__name__ for loss in loss_list]) + ")"
     #  Only use unique targets to avoid unnecessary duplication
-    target = list(set([loss.target for loss in loss_list]))
+    #target = list(set([loss.target for loss in loss_list]))
+    targets = [l.target for l in loss_list if not hasattr(l.target, "__iter__") else *l.target]
+    target = list(set(targets))
     return CompositeLoss(loss_fn, name=name, target=target)
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -683,17 +683,19 @@ def sum_loss_fn_list(
     to_scalar_fn: Callable[[torch.Tensor], torch.Tensor] = torch.mean,
 ) -> CompositeLoss:
     """
-    Summarize a large number of losses without recursion errors. By default using
-    300+ loss functions for a single optimization task will result in exceeding
-    Python's default maximum recursion depth limit. This function can be used to
-    avoid the recursion depth limit for tasks such as summarizing a large list of
-    loss functions with the built-in sum() function.
+    Summarize a large number of losses without recursion errors. By default using 300+
+    loss functions for a single optimization task will result in exceeding Python's
+    default maximum recursion depth limit. This function can be used to avoid the
+    recursion depth limit for tasks such as summarizing a large list of loss functions
+    with the built-in sum() function.
+    
+    This functions works similar to Lucid's optvis.objectives.Objective.sum() function.
 
     Args:
 
         loss_fn_list (list): A list of loss function objectives.
-        to_scalar_fn (Callable): A function for converting loss function outputs
-            to scalar values, in order to prevent size mismatches.
+        to_scalar_fn (Callable): A function for converting loss function outputs to
+            scalar values, in order to prevent size mismatches.
 
     Returns:
         loss_fn (CompositeLoss): A composite loss function containing all the loss

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -684,7 +684,7 @@ class ActivationWeights(BaseLoss):
 
 
 def sum_loss_list(
-    loss_list: List,
+    loss_list: List[Loss],
     to_scalar_fn: Callable[[torch.Tensor], torch.Tensor] = torch.mean,
 ) -> CompositeLoss:
     """
@@ -698,7 +698,7 @@ def sum_loss_list(
 
     Args:
 
-        loss_list (list): A list of loss function objectives.
+        loss_list (list of Loss): A list of loss function objectives.
         to_scalar_fn (Callable): A function for converting loss function outputs to
             scalar values, in order to prevent size mismatches.
 

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -275,3 +275,11 @@ class TestCompositeLoss(BaseTest):
         loss_fn = opt_loss.sum_loss_list(loss_fn_list)
         out = get_loss_value(model, loss_fn, [n_batch, 3, 1, 1])
         self.assertEqual(out, float(n_batch))
+
+    def test_sum_loss_list_compose(self) -> None:
+        n_batch = 400
+        model = torch.nn.Identity()
+        loss_fn_list = [opt_loss.LayerActivation(model) for i in range(n_batch)]
+        loss_fn = opt_loss.sum_loss_list(loss_fn_list) + opt_loss.LayerActivation(model)
+        out = get_loss_value(model, loss_fn, [n_batch, 3, 1, 1])
+        self.assertEqual(out, float(n_batch + 1.0))

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -268,10 +268,10 @@ class TestCompositeLoss(BaseTest):
     #             model.layer, 1
     #         )
 
-    def test_sum_list(self) -> None:
+    def test_sum_loss_fn_list(self) -> None:
         n_batch = 400
         model = torch.nn.Identity()
         loss_fn_list = [opt_loss.LayerActivation(model) for i in range(n_batch)]
-        loss_fn = opt_loss.Loss.sum_list(loss_fn_list)
+        loss_fn = opt_loss.sum_loss_fn_list(loss_fn_list)
         out = get_loss_value(model, loss_fn, [n_batch, 3, 1, 1])
         self.assertEqual(out, float(n_batch))

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -268,10 +268,10 @@ class TestCompositeLoss(BaseTest):
     #             model.layer, 1
     #         )
 
-    def test_sum_loss_fn_list(self) -> None:
+    def test_sum_loss_list(self) -> None:
         n_batch = 400
         model = torch.nn.Identity()
         loss_fn_list = [opt_loss.LayerActivation(model) for i in range(n_batch)]
-        loss_fn = opt_loss.sum_loss_fn_list(loss_fn_list)
+        loss_fn = opt_loss.sum_loss_list(loss_fn_list)
         out = get_loss_value(model, loss_fn, [n_batch, 3, 1, 1])
         self.assertEqual(out, float(n_batch))

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -276,7 +276,7 @@ class TestCompositeLoss(BaseTest):
         out = get_loss_value(model, loss_fn, [n_batch, 3, 1, 1])
         self.assertEqual(out, float(n_batch))
 
-    def test_sum_loss_list_compose(self) -> None:
+    def test_sum_loss_list_compose_add(self) -> None:
         n_batch = 400
         model = torch.nn.Identity()
         loss_fn_list = [opt_loss.LayerActivation(model) for i in range(n_batch)]

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -267,3 +267,11 @@ class TestCompositeLoss(BaseTest):
     #         opt_loss.ChannelActivation(model.layer, 0) ** opt_loss.ChannelActivation(
     #             model.layer, 1
     #         )
+
+    def test_sum_list(self) -> None:
+        n_batch = 400
+        model = torch.nn.Identity()
+        loss_fn_list = [opt_loss.LayerActivation(model) for i in range(n_batch)]
+        loss_fn = opt_loss.Loss.sum_list(loss_fn_list)
+        out = get_loss_value(model, loss_fn, [n_batch, 3, 1, 1])
+        self.assertEqual(out, float(n_batch))


### PR DESCRIPTION
* Add `sum_loss_list()` to `optim/_core/loss.py` with tests.
* Replace `sum()` with `opt.loss.sum_loss_list()` in ActivationAtlas tutorial notebook.
* Correct `target` type hints for `Loss`, `BaseLoss`, and `CompositeLoss`. The correct type hint should be `Union[nn.Module, List[nn.Module]]` as that is what the code supports and uses.