### PR TITLE
RandomRotation JIT support

### DIFF
--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -404,18 +404,17 @@ class RandomRotation(nn.Module):
         assert hasattr(degrees, "__iter__")
         if torch.is_tensor(degrees):
             assert cast(torch.Tensor, degrees).dim() == 1
+            degrees = degrees.tolist()
         assert len(degrees) > 0
-        self.degrees = degrees
+        self.degrees = [float(d) for d in degrees]
 
     def _get_rot_mat(
         self,
-        theta: Union[int, float, torch.Tensor],
+        theta: float,
         device: torch.device,
         dtype: torch.dtype,
     ) -> torch.Tensor:
-        if isinstance(theta, torch.Tensor):
-            theta = float(theta.item())
-        theta = float(theta) * math.pi / 180
+        theta = theta * math.pi / 180
         rot_mat = torch.tensor(
             [
                 [math.cos(theta), -math.sin(theta), 0.0],
@@ -427,7 +426,7 @@ class RandomRotation(nn.Module):
         return rot_mat
 
     def _rotate_tensor(
-        self, x: torch.Tensor, theta: Union[int, float, torch.Tensor]
+        self, x: torch.Tensor, theta: float
     ) -> torch.Tensor:
         rot_matrix = self._get_rot_mat(theta, x.device, x.dtype)[None, ...].repeat(
             x.shape[0], 1, 1

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -445,7 +445,7 @@ class RandomRotation(nn.Module):
             theta (float): The amount to rotate the NCHW image, in degrees.
 
         Returns:
-            **x** (torch.Tensor): A rotated tensor.
+            **x** (torch.Tensor): A rotated NCHW image tensor.
         """
         rot_matrix = self._get_rot_mat(theta, x.device, x.dtype)[None, ...].repeat(
             x.shape[0], 1, 1
@@ -465,11 +465,13 @@ class RandomRotation(nn.Module):
 
         Args:
 
-            x (torch.Tensor): Input to randomly rotate.
+            x (torch.Tensor): NCHW image tensor to randomly rotate.
 
         Returns:
             **x** (torch.Tensor): A randomly rotated NCHW image *tensor*.
         """
+        assert x.dim() == 4
+
         n = int(
             torch.randint(
                 low=0,

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -414,7 +414,7 @@ class RandomRotation(nn.Module):
         device: torch.device,
         dtype: torch.dtype,
     ) -> torch.Tensor:
-        theta = theta * math.pi / 180
+        theta = theta * math.pi / 180.0
         rot_mat = torch.tensor(
             [
                 [math.cos(theta), -math.sin(theta), 0.0],

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -461,14 +461,14 @@ class RandomRotation(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
-        Randomly rotate an input tensor.
+        Randomly rotate an NCHW image tensor.
 
         Args:
 
             x (torch.Tensor): Input to randomly rotate.
 
         Returns:
-            **tensor** (torch.Tensor): A randomly rotated *tensor*.
+            **x** (torch.Tensor): A randomly rotated NCHW image *tensor*.
         """
         n = int(
             torch.randint(

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -396,6 +396,7 @@ class RandomRotation(nn.Module):
     ) -> None:
         """
         Args:
+
             degrees (float, sequence): Tuple, List, or Tensor of degrees to randomly
                 select from.
         """
@@ -447,6 +448,7 @@ class RandomRotation(nn.Module):
         Randomly rotate an input tensor.
 
         Args:
+
             x (torch.Tensor): Input to randomly rotate.
 
         Returns:

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -392,7 +392,10 @@ class RandomRotation(nn.Module):
     __constants__ = ["degrees", "mode", "padding_mode"]
 
     def __init__(
-        self, degrees: Union[List[float], Tuple[float, ...], torch.Tensor], mode: str ="bilinear", padding_mode: str = "zeros",
+        self,
+        degrees: Union[List[float], Tuple[float, ...], torch.Tensor],
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
     ) -> None:
         """
         Args:
@@ -424,11 +427,11 @@ class RandomRotation(nn.Module):
     ) -> torch.Tensor:
         """
         Create a rotation matrix tensor.
-        
+
         Args:
-        
+
             theta (float): The rotation value in degrees.
-            
+
         Returns:
             **rot_mat** (torch.Tensor): A rotation matrix.
         """
@@ -446,12 +449,12 @@ class RandomRotation(nn.Module):
     def _rotate_tensor(self, x: torch.Tensor, theta: float) -> torch.Tensor:
         """
         Rotate an NCHW image tensor based on a specified degree value.
-        
+
         Args:
-        
+
             x (torch.Tensor): The NCHW image tensor to rotate.
             theta (float): The amount to rotate the NCHW image, in degrees.
-            
+
         Returns:
             **x** (torch.Tensor): A rotated NCHW image tensor.
         """
@@ -461,7 +464,13 @@ class RandomRotation(nn.Module):
         if torch.__version__ >= "1.3.0" or torch.jit.is_scripting():
             # Pass align_corners explicitly for torch >= 1.3.0
             grid = F.affine_grid(rot_matrix, x.size(), align_corners=False)
-            x = F.grid_sample(x, grid, mode=self.mode, padding_mode=self.padding_mode, align_corners=False)
+            x = F.grid_sample(
+                x,
+                grid,
+                mode=self.mode,
+                padding_mode=self.padding_mode,
+                align_corners=False,
+            )
         else:
             grid = F.affine_grid(rot_matrix, x.size())
             x = F.grid_sample(x, grid, mode=self.mode, padding_mode=self.padding_mode)
@@ -470,11 +479,11 @@ class RandomRotation(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Randomly rotate an NCHW image tensor.
-        
+
         Args:
-        
+
             x (torch.Tensor): NCHW image tensor to randomly rotate.
-            
+
         Returns:
             **x** (torch.Tensor): A randomly rotated NCHW image *tensor*.
         """

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -450,7 +450,7 @@ class RandomRotation(nn.Module):
         rot_matrix = self._get_rot_mat(theta, x.device, x.dtype)[None, ...].repeat(
             x.shape[0], 1, 1
         )
-        if torch.__version__ >= "1.3.0":
+        if torch.__version__ >= "1.3.0" or torch.jit.is_scripting():
             # Pass align_corners explicitly for torch >= 1.3.0
             grid = F.affine_grid(rot_matrix, x.size(), align_corners=False)
             x = F.grid_sample(x, grid, align_corners=False)

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -418,9 +418,9 @@ class RandomRotation(nn.Module):
         Create a rotation matrix tensor.
 
         Args:
-        
+
             theta (float): The rotation value in degrees.
-            
+
         Returns:
             **rot_mat** (torch.Tensor): A rotation matrix.
         """
@@ -440,10 +440,10 @@ class RandomRotation(nn.Module):
         Rotate an NCHW image tensor based on a specified degree value.
 
         Args:
-        
+
             x (torch.Tensor): The NCHW image tensor to rotate.
             theta (float): The amount to rotate the NCHW image, in degrees.
-            
+
         Returns:
             **x** (torch.Tensor): A rotated tensor.
         """

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -425,9 +425,7 @@ class RandomRotation(nn.Module):
         )
         return rot_mat
 
-    def _rotate_tensor(
-        self, x: torch.Tensor, theta: float
-    ) -> torch.Tensor:
+    def _rotate_tensor(self, x: torch.Tensor, theta: float) -> torch.Tensor:
         rot_matrix = self._get_rot_mat(theta, x.device, x.dtype)[None, ...].repeat(
             x.shape[0], 1, 1
         )

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -414,14 +414,13 @@ class RandomRotation(nn.Module):
         dtype: torch.dtype,
     ) -> torch.Tensor:
         if isinstance(theta, torch.Tensor):
-            theta = theta.to(device=device, dtype=dtype)
-        else:
-            theta = torch.tensor(float(theta), device=device, dtype=dtype)
+            theta = float(theta.item())
+        theta = float(theta)
         theta = theta * math.pi / 180
         rot_mat = torch.tensor(
             [
-                [torch.cos(theta), -torch.sin(theta), 0],
-                [torch.sin(theta), torch.cos(theta), 0],
+                [math.cos(theta), -math.sin(theta), 0.0],
+                [math.sin(theta), math.cos(theta), 0.0],
             ],
             device=device,
             dtype=dtype,

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -414,6 +414,16 @@ class RandomRotation(nn.Module):
         device: torch.device,
         dtype: torch.dtype,
     ) -> torch.Tensor:
+        """
+        Create a rotation matrix tensor.
+
+        Args:
+        
+            theta (float): The rotation value in degrees.
+            
+        Returns:
+            **rot_mat** (torch.Tensor): A rotation matrix.
+        """
         theta = theta * math.pi / 180.0
         rot_mat = torch.tensor(
             [
@@ -426,6 +436,17 @@ class RandomRotation(nn.Module):
         return rot_mat
 
     def _rotate_tensor(self, x: torch.Tensor, theta: float) -> torch.Tensor:
+        """
+        Rotate an NCHW image tensor based on a specified degree value.
+
+        Args:
+        
+            x (torch.Tensor): The NCHW image tensor to rotate.
+            theta (float): The amount to rotate the NCHW image, in degrees.
+            
+        Returns:
+            **x** (torch.Tensor): A rotated tensor.
+        """
         rot_matrix = self._get_rot_mat(theta, x.device, x.dtype)[None, ...].repeat(
             x.shape[0], 1, 1
         )

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -415,8 +415,7 @@ class RandomRotation(nn.Module):
     ) -> torch.Tensor:
         if isinstance(theta, torch.Tensor):
             theta = float(theta.item())
-        theta = float(theta)
-        theta = theta * math.pi / 180
+        theta = float(theta) * math.pi / 180
         rot_mat = torch.tensor(
             [
                 [math.cos(theta), -math.sin(theta), 0.0],

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -82,7 +82,6 @@ class TestRandomRotation(BaseTest):
 
     def test_random_rotation_matrix(self) -> None:
         theta = 25.1
-        theta = theta * 3.141592653589793 / 180
         rot_mod = transforms.RandomRotation([25.1])
         rot_matrix = rot_mod._get_rot_mat(
             theta, device=torch.device("cpu"), dtype=torch.float32

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -139,7 +139,7 @@ class TestRandomRotation(BaseTest):
             theta, device=torch.device("cpu"), dtype=torch.float32
         )
 
-        theta_expected = theta * 3.141592653589793 / 180.0
+        theta_expected = torch.tensor(theta) * 3.141592653589793 / 180.0
         expected_matrix = torch.tensor(
             [
                 [torch.cos(theta_expected), -torch.sin(theta_expected), 0.0],

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -145,7 +145,7 @@ class TestRandomRotation(BaseTest):
                 [torch.cos(theta_expected), -torch.sin(theta_expected), 0.0],
                 [torch.sin(theta_expected), torch.cos(theta_expected), 0.0],
             ],
-        ).float()
+        )
 
         assertTensorAlmostEqual(self, rot_matrix, expected_matrix, 0.0)
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -155,7 +155,7 @@ class TestRandomRotation(BaseTest):
                 "Skipping RandomRotation JIT test due to insufficient Torch version."
             )
         rotation_module = transforms.RandomRotation([25.0])
-        jit_rotation_module = torch.script.jit(rotation_module)
+        jit_rotation_module = torch.jit.script(rotation_module)
         test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
 
         test_output = jit_rotation_module(test_input)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -82,7 +82,7 @@ class TestRandomRotation(BaseTest):
 
     def test_random_rotation_matrix(self) -> None:
         theta = 25.1
-        rot_mod = transforms.RandomRotation([25.1])
+        rot_mod = transforms.RandomRotation([theta])
         rot_matrix = rot_mod._get_rot_mat(
             theta, device=torch.device("cpu"), dtype=torch.float32
         )
@@ -134,7 +134,7 @@ class TestRandomRotation(BaseTest):
 
     def test_random_rotation_matrix_torch_math_module(self) -> None:
         theta = 25.1
-        rot_mod = transforms.RandomRotation([25.1])
+        rot_mod = transforms.RandomRotation([theta])
         rot_matrix = rot_mod._get_rot_mat(
             theta, device=torch.device("cpu"), dtype=torch.float32
         )


### PR DESCRIPTION
TorchScript / JIT is much more strict regarding type hints than Mypy. So a few changes had to made:

* JIT does not support the `torch.is_tensor` function yet, but does support the `isinstance(x, torch.Tensor)` function that it calls.

* The `torch.cos` and `torch.sin` require a `torch.Tensor` input, which means we'd have to convert the input to a tensor before converting them back to float for `torch.Tensor` which requires an `int` or `float` input. So, I replaced them with `math.cos` and `math.sin`. I've added an additional test to verify that `torch.cos` & `torch.sin` behavior matches the `math.cos` & `math.sin` behavior. This change also made it easier to just simple work with a list of floats for `self.degrees`, so now tensor inputs are automatically converted to a list of floats to make it easier for JIT to optimize things. Tensor inputs also wouldn't work for JIT's `__constants__` variable declarations.

* The `_rand_select` function does not work with JIT due to a bug with the `Union[List[...], torch.Tensor]` type hint, so I moved it into the `RandomRotation` class. The `torch.randint()` function then required a few additional parameters to work with JIT. The `Sequence` type hint is also not supported by JIT, so we can't use it either.

* Added a test for JIT module support.

* Added missing `RandomRotation` class function documentation.

* Added input size check for `RandomRotation` forward function.

* Added `torch.jit.is_scripting()` check to avoid warning messages when using JIT.

* Exposed `torch.nn.functional.grid_sample`'s interpolation `mode` and `padding_mode` parameters for  `RandomRotation` due to their potential influence on the optimization process.