### PR TITLE
Better way to handle torch version with JIT

### DIFF
--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -389,25 +389,27 @@ class RandomRotation(nn.Module):
     Apply random rotation transforms on a NCHW tensor, using a sequence of degrees.
     """
 
-    __constants__ = ["degrees", "mode", "padding_mode", "torch_version"]
+    __constants__ = ["degrees", "mode", "padding_mode", "align_corners", "has_align_corners"]
 
     def __init__(
         self,
         degrees: Union[List[float], Tuple[float, ...], torch.Tensor],
         mode: str = "bilinear",
         padding_mode: str = "zeros",
+        align_corners: bool = False,
     ) -> None:
         """
         Args:
 
             degrees (float, sequence): Tuple, List, or Tensor of degrees to randomly
                 select from.
-            mode (str): Interpolation mode to use. One of; 'bilinear', 'nearest',
-                or 'bicubic'.
+            mode (str, optional): Interpolation mode to use. One of; 'bilinear',
+                'nearest', or 'bicubic'.
                 Default: "bilinear"
-            padding_mode (str): Padding mode for values that fall outside of the grid.
-                One of; 'zeros', 'border', or 'reflection'.
+            padding_mode (str, optional): Padding mode for values that fall outside of
+                the grid. One of; 'zeros', 'border', or 'reflection'.
                 Default: "zeros"
+            align_corners (bool, optional): 
         """
         super().__init__()
         assert hasattr(degrees, "__iter__")
@@ -418,6 +420,7 @@ class RandomRotation(nn.Module):
         self.degrees = [float(d) for d in degrees]
         self.mode = mode
         self.padding_mode = padding_mode
+        self.align_corners = align_corners
         self.has_align_corners = torch.__version__ >= "1.3.0"
 
     def _get_rot_mat(
@@ -464,13 +467,13 @@ class RandomRotation(nn.Module):
         )
         if self.has_align_corners:
             # Pass align_corners explicitly for torch >= 1.3.0
-            grid = F.affine_grid(rot_matrix, x.size(), align_corners=False)
+            grid = F.affine_grid(rot_matrix, x.size(), align_corners=self.align_corners)
             x = F.grid_sample(
                 x,
                 grid,
                 mode=self.mode,
                 padding_mode=self.padding_mode,
-                align_corners=False,
+                align_corners=self.align_corners,
             )
         else:
             grid = F.affine_grid(rot_matrix, x.size())

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -409,11 +409,13 @@ class RandomRotation(nn.Module):
 
             degrees (float, sequence): Tuple, List, or Tensor of degrees to randomly
                 select from.
-            mode (str, optional): Interpolation mode to use. One of; 'bilinear',
-                'nearest', or 'bicubic'.
+            mode (str, optional): Interpolation mode to use. See documentation of
+                F.grid_sample for more details. One of; "bilinear", "nearest", or
+                "bicubic".
                 Default: "bilinear"
             padding_mode (str, optional): Padding mode for values that fall outside of
-                the grid. One of; 'zeros', 'border', or 'reflection'.
+                the grid. See documentation of F.grid_sample for more details. One of;
+                "zeros", "border", or "reflection".
                 Default: "zeros"
             align_corners (bool, optional): Whether or not to align corners. See
                 documentation of F.affine_grid & F.grid_sample for more details.

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -418,7 +418,7 @@ class RandomRotation(nn.Module):
         self.degrees = [float(d) for d in degrees]
         self.mode = mode
         self.padding_mode = padding_mode
-        self.torch_version = torch.__version__
+        self.torch_version = torch.__version__ >= "1.3.0"
 
     def _get_rot_mat(
         self,
@@ -462,7 +462,7 @@ class RandomRotation(nn.Module):
         rot_matrix = self._get_rot_mat(theta, x.device, x.dtype)[None, ...].repeat(
             x.shape[0], 1, 1
         )
-        if self.torch_version >= "1.3.0":
+        if self.torch_version:
             # Pass align_corners explicitly for torch >= 1.3.0
             grid = F.affine_grid(rot_matrix, x.size(), align_corners=False)
             x = F.grid_sample(

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -415,7 +415,9 @@ class RandomRotation(nn.Module):
             padding_mode (str, optional): Padding mode for values that fall outside of
                 the grid. One of; 'zeros', 'border', or 'reflection'.
                 Default: "zeros"
-            align_corners (bool, optional):
+            align_corners (bool, optional): Whether or not to align corners. See
+                documentation of F.affine_grid & F.grid_sample for more details.
+                Default: False
         """
         super().__init__()
         assert hasattr(degrees, "__iter__")

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -418,7 +418,7 @@ class RandomRotation(nn.Module):
         self.degrees = [float(d) for d in degrees]
         self.mode = mode
         self.padding_mode = padding_mode
-        self.torch_version = torch.__version__ >= "1.3.0"
+        self.has_align_corners = torch.__version__ >= "1.3.0"
 
     def _get_rot_mat(
         self,
@@ -462,7 +462,7 @@ class RandomRotation(nn.Module):
         rot_matrix = self._get_rot_mat(theta, x.device, x.dtype)[None, ...].repeat(
             x.shape[0], 1, 1
         )
-        if self.torch_version:
+        if self.has_align_corners:
             # Pass align_corners explicitly for torch >= 1.3.0
             grid = F.affine_grid(rot_matrix, x.size(), align_corners=False)
             x = F.grid_sample(

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -389,7 +389,13 @@ class RandomRotation(nn.Module):
     Apply random rotation transforms on a NCHW tensor, using a sequence of degrees.
     """
 
-    __constants__ = ["degrees", "mode", "padding_mode", "align_corners", "has_align_corners"]
+    __constants__ = [
+        "degrees",
+        "mode",
+        "padding_mode",
+        "align_corners",
+        "has_align_corners",
+    ]
 
     def __init__(
         self,
@@ -409,7 +415,7 @@ class RandomRotation(nn.Module):
             padding_mode (str, optional): Padding mode for values that fall outside of
                 the grid. One of; 'zeros', 'border', or 'reflection'.
                 Default: "zeros"
-            align_corners (bool, optional): 
+            align_corners (bool, optional):
         """
         super().__init__()
         assert hasattr(degrees, "__iter__")

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -389,7 +389,7 @@ class RandomRotation(nn.Module):
     Apply random rotation transforms on a NCHW tensor, using a sequence of degrees.
     """
 
-    __constants__ = ["degrees", "mode", "padding_mode"]
+    __constants__ = ["degrees", "mode", "padding_mode", "torch_version"]
 
     def __init__(
         self,
@@ -418,6 +418,7 @@ class RandomRotation(nn.Module):
         self.degrees = [float(d) for d in degrees]
         self.mode = mode
         self.padding_mode = padding_mode
+        self.torch_version = torch.__version__
 
     def _get_rot_mat(
         self,
@@ -461,7 +462,7 @@ class RandomRotation(nn.Module):
         rot_matrix = self._get_rot_mat(theta, x.device, x.dtype)[None, ...].repeat(
             x.shape[0], 1, 1
         )
-        if torch.__version__ >= "1.3.0" or torch.jit.is_scripting():
+        if self.torch_version >= "1.3.0":
             # Pass align_corners explicitly for torch >= 1.3.0
             grid = F.affine_grid(rot_matrix, x.size(), align_corners=False)
             x = F.grid_sample(

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -93,11 +93,6 @@ class TestRandomRotation(BaseTest):
         assertTensorAlmostEqual(self, rot_matrix, expected_matrix)
 
     def test_random_rotation_rotate_tensor(self) -> None:
-        if torch.__version__ <= "1.8.0":
-            raise unittest.SkipTest(
-                "Skipping RandomRotation rotate tensor test due to"
-                + "insufficient Torch version."
-            )
         rot_mod = transforms.RandomRotation([25.0])
 
         test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
@@ -118,11 +113,6 @@ class TestRandomRotation(BaseTest):
         assertTensorAlmostEqual(self, test_output, expected_output, 0.005)
 
     def test_random_rotation_forward(self) -> None:
-        if torch.__version__ <= "1.8.0":
-            raise unittest.SkipTest(
-                "Skipping RandomRotation forward test due to insufficient"
-                + " Torch version."
-            )
         rotate_transform = transforms.RandomRotation(list(range(-25, 25)))
         x = torch.ones(1, 3, 224, 224)
         output = rotate_transform(x)
@@ -134,11 +124,6 @@ class TestRandomRotation(BaseTest):
             raise unittest.SkipTest(
                 "Skipping RandomRotation forward CUDA test due to not supporting"
                 + " CUDA."
-            )
-        if torch.__version__ <= "1.8.0":
-            raise unittest.SkipTest(
-                "Skipping RandomRotation forward CUDA test due to insufficient"
-                + " Torch Version."
             )
         rotate_transform = transforms.RandomRotation(list(range(-25, 25)))
         x = torch.ones(1, 3, 224, 224).cuda()


### PR DESCRIPTION
* The `torch.jit.is_scripting()` function isn't supported by earlier versions of PyTorch. So I've come up with a better solution that will still support earlier versions of PyTorch.
* Exposed `align_corners` parameter to `RandomRotation` class initialization.
* Improved `RandomRotation` class documentation.