### PR TITLE
Add JIT support to most transforms

### DIFF
--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -362,11 +362,7 @@ class RandomScale(nn.Module):
         )
         return scale_mat
 
-    def _scale_tensor(
-        self,
-        x: torch.Tensor,
-        scale: float,
-    ) -> torch.Tensor:
+    def _scale_tensor(self, x: torch.Tensor, scale: float) -> torch.Tensor:
         """
         Scale an NCHW image tensor based on a specified scale value.
 

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -202,10 +202,7 @@ class CenterCrop(torch.nn.Module):
                 Default: False
         """
         super().__init__()
-        crop_vals = [crop_vals] * 2 if not hasattr(crop_vals, "__iter__") else crop_vals
-        crop_vals = list(crop_vals) * 2 if len(crop_vals) == 1 else crop_vals
-        assert len(crop_vals) == 2
-        self.crop_vals = [int(s) for s in size]
+        self.crop_vals = size
         self.pixels_from_edges = pixels_from_edges
         self.offset_left = offset_left
 

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -759,7 +759,9 @@ class RandomCrop(nn.Module):
         h_crop = h - int(math.ceil((h - self.crop_size[0]) / 2.0))
         w_crop = w - int(math.ceil((w - self.crop_size[1]) / 2.0))
         return input[
-            ..., h_crop - elf.crop_size[0] : h_crop, w_crop - self.crop_size[1] : w_crop
+            ...,
+            h_crop - self.crop_size[0] : h_crop,
+            w_crop - self.crop_size[1] : w_crop,
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -743,6 +743,7 @@ class RandomCrop(nn.Module):
         crop_size = cast(Union[List[int], Tuple[int, int]], crop_size)
         assert len(crop_size) == 2
         self.crop_size = crop_size
+        self.center_crop = center_crop
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 4
@@ -767,7 +768,8 @@ class RandomCrop(nn.Module):
             ),
         ]
         x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
-        return center_crop(input=x, crop_vals=self.crop_size)
+        x = self.center_crop(input=x, crop_vals=self.crop_size)
+        return x
 
 
 __all__ = [

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -228,7 +228,7 @@ class CenterCrop(torch.nn.Module):
 @torch.jit.ignore
 def center_crop(
     input: torch.Tensor,
-    crop_vals: List[int],
+    crop_vals: IntSeqOrIntType,
     pixels_from_edges: bool = False,
     offset_left: bool = False,
 ) -> torch.Tensor:

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -744,7 +744,7 @@ class RandomCrop(nn.Module):
         assert len(crop_size) == 2
         self.crop_size = crop_size
 
-    def center_crop_image(self, x: torch.Tensor) -> torch.Tensor:
+    def center_crop(self, x: torch.Tensor) -> torch.Tensor:
         h, w = x.shape[2:]
         h_crop = h - int(math.ceil((h - self.crop_size[0]) / 2.0))
         w_crop = w - int(math.ceil((w - self.crop_size[1]) / 2.0))
@@ -775,7 +775,7 @@ class RandomCrop(nn.Module):
             ),
         ]
         x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
-        return self.center_crop_image(x)
+        return self.center_crop(x)
 
 
 __all__ = [

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -251,7 +251,6 @@ def center_crop(
     assert input.dim() == 3 or input.dim() == 4
     crop_vals = [crop_vals] * 2 if not hasattr(crop_vals, "__iter__") else crop_vals
     crop_vals = list(crop_vals) * 2 if len(crop_vals) == 1 else crop_vals
-    crop_vals = cast(Union[List[int], Tuple[int, int]], crop_vals)
     assert len(crop_vals) == 2
 
     if input.dim() == 4:

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -778,6 +778,7 @@ class RandomCrop(nn.Module):
             x,
             crop_vals=self.crop_size,
             pixels_from_edges=False,
+            offset_left=False,
         )
 
 

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -744,7 +744,7 @@ class RandomCrop(nn.Module):
         assert len(crop_size) == 2
         self.crop_size = crop_size
 
-    def center_crop(self, x: torch.Tensor) -> torch.Tensor:
+    def _center_crop(self, x: torch.Tensor) -> torch.Tensor:
         h, w = x.shape[2:]
         h_crop = h - int(math.ceil((h - self.crop_size[0]) / 2.0))
         w_crop = w - int(math.ceil((w - self.crop_size[1]) / 2.0))
@@ -775,7 +775,7 @@ class RandomCrop(nn.Module):
             ),
         ]
         x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
-        return self.center_crop(x)
+        return self._center_crop(x)
 
 
 __all__ = [

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -743,7 +743,6 @@ class RandomCrop(nn.Module):
         crop_size = cast(Union[List[int], Tuple[int, int]], crop_size)
         assert len(crop_size) == 2
         self.crop_size = crop_size
-        self.center_crop = center_crop
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 4
@@ -768,7 +767,7 @@ class RandomCrop(nn.Module):
             ),
         ]
         x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
-        x = self.center_crop(input=x, crop_vals=self.crop_size)
+        x = center_crop(input=x, crop_vals=self.crop_size)
         return x
 
 

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from captum.optim._utils.image.common import nchannels_to_rgb
-from captum.optim._utils.typing import IntSeqOrIntType
+from captum.optim._utils.typing import IntSeqOrIntType, NumSeqOrTensorType
 
 
 class BlendAlpha(nn.Module):
@@ -291,7 +291,7 @@ class RandomScale(nn.Module):
 
     def __init__(
         self,
-        scale: Union[List[float], Tuple[float, ...], torch.Tensor],
+        scale: NumSeqOrTensorType,
         mode: str = "bilinear",
         padding_mode: str = "zeros",
         align_corners: bool = False,

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -744,10 +744,10 @@ class RandomCrop(nn.Module):
         assert len(crop_size) == 2
         self.crop_size = crop_size
 
-    def crop_image(self, x: torch.Tensor) -> torch.Tensor:
+    def center_crop_image(self, x: torch.Tensor) -> torch.Tensor:
         h, w = x.shape[2:]
         h_crop = h - int(math.ceil((h - self.crop_size[0]) / 2.0))
-        w_crop = w - int(math.ceil((w - elf.crop_size[1]) / 2.0))
+        w_crop = w - int(math.ceil((w - self.crop_size[1]) / 2.0))
         return input[
             ..., h_crop - elf.crop_size[0] : h_crop, w_crop - self.crop_size[1] : w_crop
         ]
@@ -775,7 +775,7 @@ class RandomCrop(nn.Module):
             ),
         ]
         x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
-        return self.crop_image(x)
+        return self.center_crop_image(x)
 
 
 __all__ = [

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -767,12 +767,7 @@ class RandomCrop(nn.Module):
             ),
         ]
         x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
-        return center_crop(
-            input=x,
-            crop_vals=self.crop_size,
-            pixels_from_edges=False,
-            offset_left=False,
-        )
+        return center_crop(input=x, crop_vals=self.crop_size)
 
 
 __all__ = [

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -746,9 +746,11 @@ class RandomCrop(nn.Module):
 
     def crop_image(self, x: torch.Tensor) -> torch.Tensor:
         h, w = x.shape[2:]
-        h_crop = h - int(math.ceil((h - self.crop_vals[0]) / 2.0))
-        w_crop = w - int(math.ceil((w - elf.crop_vals[1]) / 2.0))
-        return input[..., h_crop - elf.crop_vals[0] : h_crop, w_crop - self.crop_vals[1] : w_crop]
+        h_crop = h - int(math.ceil((h - self.crop_size[0]) / 2.0))
+        w_crop = w - int(math.ceil((w - elf.crop_size[1]) / 2.0))
+        return input[
+            ..., h_crop - elf.crop_size[0] : h_crop, w_crop - self.crop_size[1] : w_crop
+        ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 4
@@ -773,7 +775,7 @@ class RandomCrop(nn.Module):
             ),
         ]
         x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
-        return self.crop_image(input=x, crop_vals=self.crop_size)
+        return self.crop_image(x)
 
 
 __all__ = [

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -202,7 +202,10 @@ class CenterCrop(torch.nn.Module):
                 Default: False
         """
         super().__init__()
-        self.crop_vals = size
+        crop_vals = [crop_vals] * 2 if not hasattr(crop_vals, "__iter__") else crop_vals
+        crop_vals = list(crop_vals) * 2 if len(crop_vals) == 1 else crop_vals
+        assert len(crop_vals) == 2
+        self.crop_vals = [int(s) for s in size]
         self.pixels_from_edges = pixels_from_edges
         self.offset_left = offset_left
 
@@ -224,7 +227,7 @@ class CenterCrop(torch.nn.Module):
 
 def center_crop(
     input: torch.Tensor,
-    crop_vals: IntSeqOrIntType,
+    crop_vals: List[int],
     pixels_from_edges: bool = False,
     offset_left: bool = False,
 ) -> torch.Tensor:
@@ -234,7 +237,7 @@ def center_crop(
     Args:
 
         input (tensor):  A CHW or NCHW image tensor to center crop.
-        size (int, sequence, int): Number of pixels to center crop away.
+        size (list of int): Number of pixels to center crop away.
         pixels_from_edges (bool, optional): Whether to treat crop size
             values as the number of pixels from the tensor's edge, or an
             exact shape in the center.
@@ -249,8 +252,7 @@ def center_crop(
     """
 
     assert input.dim() == 3 or input.dim() == 4
-    crop_vals = [crop_vals] * 2 if not hasattr(crop_vals, "__iter__") else crop_vals
-    crop_vals = list(crop_vals) * 2 if len(crop_vals) == 1 else crop_vals
+    assert crop_vals hasattr(crop_vals, "__iter__")
     assert len(crop_vals) == 2
 
     if input.dim() == 4:

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -741,7 +741,7 @@ class RandomCrop(nn.Module):
         h, w = x.shape[2:]
         h_crop = h - int(math.ceil((h - self.crop_size[0]) / 2.0))
         w_crop = w - int(math.ceil((w - self.crop_size[1]) / 2.0))
-        return input[
+        return x[
             ...,
             h_crop - self.crop_size[0] : h_crop,
             w_crop - self.crop_size[1] : w_crop,

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -744,6 +744,12 @@ class RandomCrop(nn.Module):
         assert len(crop_size) == 2
         self.crop_size = crop_size
 
+    def crop_image(self, x: torch.Tensor) -> torch.Tensor:
+        h, w = x.shape[2:]
+        h_crop = h - int(math.ceil((h - self.crop_vals[0]) / 2.0))
+        w_crop = w - int(math.ceil((w - elf.crop_vals[1]) / 2.0))
+        return input[..., h_crop - elf.crop_vals[0] : h_crop, w_crop - self.crop_vals[1] : w_crop]
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 4
         hs = x.shape[2] - self.crop_size[0]
@@ -767,8 +773,7 @@ class RandomCrop(nn.Module):
             ),
         ]
         x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
-        x = center_crop(input=x, crop_vals=self.crop_size)
-        return x
+        return self.crop_image(input=x, crop_vals=self.crop_size)
 
 
 __all__ = [

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -350,9 +350,9 @@ class RandomScale(nn.Module):
         Create a rotation matrix tensor.
 
         Args:
-        
+
             m (float): The scale value to use.
-            
+
         Returns:
             **scale_mat** (torch.Tensor): A scale matrix.
         """
@@ -362,7 +362,9 @@ class RandomScale(nn.Module):
         return scale_mat
 
     def _scale_tensor(
-        self, x: torch.Tensor, scale: float,
+        self,
+        x: torch.Tensor,
+        scale: float,
     ) -> torch.Tensor:
         """
         Scale an NCHW image tensor based on a specified scale value.
@@ -371,7 +373,7 @@ class RandomScale(nn.Module):
 
             x (torch.Tensor): The NCHW image tensor to scale.
             scale (float): The amount to scale the NCHW image by.
-            
+
         Returns:
             **x** (torch.Tensor): A scaled NCHW image tensor.
         """
@@ -380,7 +382,9 @@ class RandomScale(nn.Module):
         )
         if self.has_align_corners:
             # Pass align_corners explicitly for torch >= 1.3.0
-            grid = F.affine_grid(scale_matrix, x.size(), align_corners=self.align_corners)
+            grid = F.affine_grid(
+                scale_matrix, x.size(), align_corners=self.align_corners
+            )
             x = F.grid_sample(
                 x,
                 grid,

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -225,6 +225,7 @@ class CenterCrop(torch.nn.Module):
         )
 
 
+@torch.jit.ignore
 def center_crop(
     input: torch.Tensor,
     crop_vals: List[int],
@@ -237,7 +238,7 @@ def center_crop(
     Args:
 
         input (tensor):  A CHW or NCHW image tensor to center crop.
-        size (list of int): Number of pixels to center crop away.
+        size (int, sequence, int): Number of pixels to center crop away.
         pixels_from_edges (bool, optional): Whether to treat crop size
             values as the number of pixels from the tensor's edge, or an
             exact shape in the center.
@@ -252,7 +253,9 @@ def center_crop(
     """
 
     assert input.dim() == 3 or input.dim() == 4
-    assert crop_vals hasattr(crop_vals, "__iter__")
+    crop_vals = [crop_vals] * 2 if not hasattr(crop_vals, "__iter__") else crop_vals
+    crop_vals = list(crop_vals) * 2 if len(crop_vals) == 1 else crop_vals
+    crop_vals = cast(Union[List[int], Tuple[int, int]], crop_vals)
     assert len(crop_vals) == 2
 
     if input.dim() == 4:

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -745,6 +745,16 @@ class RandomCrop(nn.Module):
         self.crop_size = crop_size
 
     def _center_crop(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Center crop an NCHW image tensor based on self.crop_size.
+
+        Args:
+
+            x (torch.Tensor): The NCHW image tensor to center crop.
+
+        Returns
+            x (torch.Tensor): The center cropped NCHW image tensor.
+        """
         h, w = x.shape[2:]
         h_crop = h - int(math.ceil((h - self.crop_size[0]) / 2.0))
         w_crop = w - int(math.ceil((w - self.crop_size[1]) / 2.0))

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -768,7 +768,7 @@ class RandomCrop(nn.Module):
         ]
         x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
         return center_crop(
-            x,
+            input=x,
             crop_vals=self.crop_size,
             pixels_from_edges=False,
             offset_left=False,

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from captum.optim._utils.image.common import nchannels_to_rgb
-from captum.optim._utils.typing import IntSeqOrIntType, NumSeqOrTensorType
+from captum.optim._utils.typing import IntSeqOrIntType
 
 
 class BlendAlpha(nn.Module):
@@ -274,23 +274,6 @@ def center_crop(
             w_crop = w_crop + 1 if offset_left else w_crop
         x = input[..., h_crop - crop_vals[0] : h_crop, w_crop - crop_vals[1] : w_crop]
     return x
-
-
-def _rand_select(
-    transform_values: NumSeqOrTensorType,
-) -> Union[int, float, torch.Tensor]:
-    """
-    Randomly return a single value from the provided tuple, list, or tensor.
-
-    Args:
-
-        transform_values (sequence):  A sequence of values to randomly select from.
-
-    Returns:
-        **value**:  A single value from the specified sequence.
-    """
-    n = torch.randint(low=0, high=len(transform_values), size=[1]).item()
-    return transform_values[n]
 
 
 class RandomScale(nn.Module):

--- a/captum/optim/_utils/image/common.py
+++ b/captum/optim/_utils/image/common.py
@@ -110,6 +110,7 @@ def _dot_cossim(
     return dot * torch.clamp(torch.cosine_similarity(x, y, eps=eps), 0.1) ** cossim_pow
 
 
+@torch.jit.ignore
 def nchannels_to_rgb(x: torch.Tensor, warp: bool = True) -> torch.Tensor:
     """
     Convert an NCHW image with n channels into a 3 channel RGB image.

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -424,6 +424,39 @@ class TestCenterCropFunction(BaseTest):
         )
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
+    def test_center_crop_one_number_exact_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping center_crop JIT module test due to insufficient"
+                + " Torch version."
+            )
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+
+        crop_vals = 5
+
+        jit_center_crop = transforms.center_crop
+        cropped_tensor = jit_center_crop(test_tensor, crop_vals, False)
+        expected_tensor = torch.stack(
+            [
+                torch.tensor(
+                    [
+                        [1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                )
+            ]
+            * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
 
 class TestBlendAlpha(BaseTest):
     def test_blend_alpha(self) -> None:

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -23,14 +23,14 @@ class TestRandomScale(BaseTest):
         # Test rescaling
         assertTensorAlmostEqual(
             self,
-            scale_module.scale_tensor(test_tensor, 0.5),
+            scale_module._scale_tensor(test_tensor, 0.5),
             torch.ones(3, 1).repeat(3, 1, 3).unsqueeze(0),
             0,
         )
 
         assertTensorAlmostEqual(
             self,
-            scale_module.scale_tensor(test_tensor, 1.5),
+            scale_module._scale_tensor(test_tensor, 1.5),
             torch.tensor(
                 [
                     [0.2500, 0.5000, 0.2500],
@@ -50,14 +50,14 @@ class TestRandomScale(BaseTest):
 
         assertTensorAlmostEqual(
             self,
-            scale_module.get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
+            scale_module._get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
             torch.tensor([[0.5000, 0.0000, 0.0000], [0.0000, 0.5000, 0.0000]]),
             0,
         )
 
         assertTensorAlmostEqual(
             self,
-            scale_module.get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
+            scale_module._get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
             torch.tensor([[1.2400, 0.0000, 0.0000], [0.0000, 1.2400, 0.0000]]),
             0,
         )

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -844,7 +844,7 @@ class TestRandomCrop(BaseTest):
         crop_transform = transforms.RandomCrop(crop_size=crop_size)
         x = torch.ones(1, 4, 224, 224)
 
-        x_out = crop_transform.center_crop(x)
+        x_out = crop_transform._center_crop(x)
 
         self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -311,6 +311,26 @@ class TestCenterCrop(BaseTest):
 
 
 class TestCenterCropFunction(BaseTest):
+    def test_center_crop_one_number(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        crop_vals = 3
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
+        cropped_array = numpy_transforms.center_crop(
+            test_tensor.numpy(), crop_vals, True
+        )
+
+        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        expected_tensor = torch.stack(
+            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
     def test_center_crop_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
@@ -318,7 +338,7 @@ class TestCenterCropFunction(BaseTest):
             .repeat(3, 1, 1)
             .unsqueeze(0)
         )
-        crop_vals = [4, 2]
+        crop_vals = (4, 2)
 
         cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
         cropped_array = numpy_transforms.center_crop(
@@ -339,7 +359,7 @@ class TestCenterCropFunction(BaseTest):
             .unsqueeze(0)
         )
 
-        crop_vals = [5, 5]
+        crop_vals = 5
 
         cropped_tensor = transforms.center_crop(test_tensor, crop_vals, False)
         cropped_array = numpy_transforms.center_crop(
@@ -371,7 +391,7 @@ class TestCenterCropFunction(BaseTest):
             .unsqueeze(0)
         )
 
-        crop_vals = [4, 2]
+        crop_vals = (4, 2)
 
         cropped_tensor = transforms.center_crop(test_tensor, crop_vals, False)
         cropped_array = numpy_transforms.center_crop(
@@ -413,7 +433,7 @@ class TestCenterCropFunction(BaseTest):
             .unsqueeze(0)
         )
 
-        crop_vals = [5, 5]
+        crop_vals = 5
 
         jit_center_crop = transforms.center_crop
         cropped_tensor = jit_center_crop(test_tensor, crop_vals, False)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -453,6 +453,18 @@ class TestIgnoreAlpha(BaseTest):
         rgb_tensor = ignore_alpha(test_input)
         assert rgb_tensor.size(1) == 3
 
+    def test_ignore_alpha_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping IgnoreAlpha JIT module test due to insufficient"
+                + " Torch version."
+            )
+        ignore_alpha = transforms.IgnoreAlpha()
+        jit_ignore_alpha = torch.jit.script(ignore_alpha)
+        test_input = torch.ones(1, 4, 3, 3)
+        rgb_tensor = jit_ignore_alpha(test_input)
+        assert rgb_tensor.size(1) == 3
+
 
 class TestToRGB(BaseTest):
     def test_to_rgb_i1i2i3(self) -> None:
@@ -760,6 +772,11 @@ class TestNChannelsToRGB(BaseTest):
         self.assertEqual(list(test_output.size()), [1, 3, 224, 224])
 
     def test_nchannels_to_rgb_collapse_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NChannelsToRGB collapse JIT module test due to insufficient"
+                + " Torch version."
+            )
         test_input = torch.randn(1, 6, 224, 224)
         nchannels_to_rgb = transforms.NChannelsToRGB()
         jit_nchannels_to_rgb = torch.jit.script(nchannels_to_rgb)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -311,26 +311,6 @@ class TestCenterCrop(BaseTest):
 
 
 class TestCenterCropFunction(BaseTest):
-    def test_center_crop_one_number(self) -> None:
-        pad = (1, 1, 1, 1)
-        test_tensor = (
-            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
-            .repeat(3, 1, 1)
-            .unsqueeze(0)
-        )
-        crop_vals = 3
-
-        cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
-        cropped_array = numpy_transforms.center_crop(
-            test_tensor.numpy(), crop_vals, True
-        )
-
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
-        expected_tensor = torch.stack(
-            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
-        ).unsqueeze(0)
-        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
-
     def test_center_crop_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
@@ -338,7 +318,7 @@ class TestCenterCropFunction(BaseTest):
             .repeat(3, 1, 1)
             .unsqueeze(0)
         )
-        crop_vals = (4, 2)
+        crop_vals = [4, 2]
 
         cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
         cropped_array = numpy_transforms.center_crop(
@@ -359,7 +339,7 @@ class TestCenterCropFunction(BaseTest):
             .unsqueeze(0)
         )
 
-        crop_vals = 5
+        crop_vals = [5, 5]
 
         cropped_tensor = transforms.center_crop(test_tensor, crop_vals, False)
         cropped_array = numpy_transforms.center_crop(
@@ -391,7 +371,7 @@ class TestCenterCropFunction(BaseTest):
             .unsqueeze(0)
         )
 
-        crop_vals = (4, 2)
+        crop_vals = [4, 2]
 
         cropped_tensor = transforms.center_crop(test_tensor, crop_vals, False)
         cropped_array = numpy_transforms.center_crop(
@@ -433,7 +413,7 @@ class TestCenterCropFunction(BaseTest):
             .unsqueeze(0)
         )
 
-        crop_vals = 5
+        crop_vals = [5, 5]
 
         jit_center_crop = transforms.center_crop
         cropped_tensor = jit_center_crop(test_tensor, crop_vals, False)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -839,6 +839,15 @@ class TestNChannelsToRGB(BaseTest):
 
 
 class TestRandomCrop(BaseTest):
+    def test_random_crop_center_crop(self) -> None:
+        crop_size = [160, 160]
+        crop_transform = transforms.RandomCrop(crop_size=crop_size)
+        x = torch.ones(1, 4, 224, 224)
+
+        x_out = crop_transform.center_crop(x)
+
+        self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
+
     def test_random_crop(self) -> None:
         crop_size = [160, 160]
         crop_transform = transforms.RandomCrop(crop_size=crop_size)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -74,7 +74,7 @@ class TestRandomScale(BaseTest):
 
         assertTensorAlmostEqual(
             self,
-            jit_scale_module(test_tensor, 1.5),
+            jit_scale_module(test_tensor),
             torch.tensor(
                 [
                     [0.2500, 0.5000, 0.2500],

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -145,12 +145,10 @@ class TestRandomSpatialJitter(BaseTest):
 
         spatialjitter = transforms.RandomSpatialJitter(t_val)
         test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
-        jittered_tensor = jit_spatialjitter(
-            test_input, torch.tensor(translate_vals)
-        )
+        jittered_tensor = spatialjitter(test_input)
         self.assertEqual(list(jittered_tensor.shape), list(test_input.shape))
 
-    def test_random_spatial_jitter_jit_module(self) -> None:
+    def test_random_spatial_jitter_forward_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
                 "Skipping RandomSpatialJitter JIT module test due to insufficient"
@@ -161,9 +159,7 @@ class TestRandomSpatialJitter(BaseTest):
         spatialjitter = transforms.RandomSpatialJitter(t_val)
         jit_spatialjitter = torch.jit.script(spatialjitter)
         test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
-        jittered_tensor = jit_spatialjitter(
-            test_input, torch.tensor(translate_vals)
-        )
+        jittered_tensor = jit_spatialjitter(test_input)
         self.assertEqual(list(jittered_tensor.shape), list(test_input.shape))
 
 
@@ -742,7 +738,7 @@ class TestScaleInputRange(BaseTest):
             )
         x = torch.ones(1, 3, 4, 4)
         scale_input = transforms.ScaleInputRange(255)
-        jit_scale_input = torch.jit.script(jit_scale_input)
+        jit_scale_input = torch.jit.script(scale_input)
         output_tensor = jit_scale_input(x)
         self.assertEqual(output_tensor.mean(), 255.0)
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -862,4 +862,3 @@ class TestRandomCrop(BaseTest):
         x_out = jit_crop_transform(x)
 
         self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
-


### PR DESCRIPTION
* Added JIT support to most transforms.

* Added JIT tests for all applicable transforms.

* The `center_crop` function is ignored by JIT via @torch.jit.ignore and thus both it and `CenterCrop` won't benefit from JIT. Though they won't throw an error if someone uses `torch.jit.script` on them. Something similar was done for `NChannelsToRGB` as well.

* The `ToRGB` is rather complex in how it's setup and used, plus JIT doesn't support named dimensions. Still working on a JIT compatible version that doesn't look really messy.