### PR TITLE
Miscellaneous Changes

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -448,14 +448,14 @@ class Direction(BaseLoss):
         batch_index: Optional[int] = None,
     ) -> None:
         BaseLoss.__init__(self, target, batch_index)
-        self.direction = vec.reshape((1, -1, 1, 1))
+        self.vec = vec.reshape((1, -1, 1, 1))
         self.cossim_pow = cossim_pow
 
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
         activations = targets_to_values[self.target]
         assert activations.size(1) == self.direction.size(1)
         activations = activations[self.batch_index[0] : self.batch_index[1]]
-        return _dot_cossim(self.direction, activations, cossim_pow=self.cossim_pow)
+        return _dot_cossim(self.vec, activations, cossim_pow=self.cossim_pow)
 
 
 @loss_wrapper
@@ -477,7 +477,7 @@ class NeuronDirection(BaseLoss):
         batch_index: Optional[int] = None,
     ) -> None:
         BaseLoss.__init__(self, target, batch_index)
-        self.direction = vec.reshape((1, -1, 1, 1))
+        self.vec = vec.reshape((1, -1, 1, 1))
         self.x = x
         self.y = y
         self.channel_index = channel_index
@@ -496,7 +496,7 @@ class NeuronDirection(BaseLoss):
         ]
         if self.channel_index is not None:
             activations = activations[:, self.channel_index, ...][:, None, ...]
-        return _dot_cossim(self.direction, activations, cossim_pow=self.cossim_pow)
+        return _dot_cossim(self.vec, activations, cossim_pow=self.cossim_pow)
 
 
 @loss_wrapper
@@ -515,7 +515,8 @@ class TensorDirection(BaseLoss):
         batch_index: Optional[int] = None,
     ) -> None:
         BaseLoss.__init__(self, target, batch_index)
-        self.direction = vec
+        assert vec.dim() == 4
+        self.vec = vec
         self.cossim_pow = cossim_pow
 
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
@@ -523,8 +524,8 @@ class TensorDirection(BaseLoss):
 
         assert activations.dim() == 4
 
-        H_direction, W_direction = self.direction.size(2), self.direction.size(3)
-        H_activ, W_activ = activations.size(2), activations.size(3)
+        H_direction, W_direction = self.vec.shape[2:]
+        H_activ, W_activ = activations.shape[2:]
 
         H = (H_activ - H_direction) // 2
         W = (W_activ - W_direction) // 2
@@ -535,7 +536,7 @@ class TensorDirection(BaseLoss):
             H : H + H_direction,
             W : W + W_direction,
         ]
-        return _dot_cossim(self.direction, activations, cossim_pow=self.cossim_pow)
+        return _dot_cossim(self.vec, activations, cossim_pow=self.cossim_pow)
 
 
 @loss_wrapper

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -89,9 +89,12 @@ class ToRGB(nn.Module):
             **transform** (torch.Tensor): A Karhunen-Loève transform (KLT) measured on
                 the ImageNet dataset.
         """
+        # Handle older versions of PyTorch
+        torch_norm = torch.linalg.norm if torch.__version__ >= "1.9.0" else torch.norm
+
         KLT = [[0.26, 0.09, 0.02], [0.27, 0.00, -0.05], [0.27, -0.09, 0.03]]
         transform = torch.Tensor(KLT).float()
-        transform = transform / torch.max(torch.norm(transform, dim=0))
+        transform = transform / torch.max(torch_norm(transform, dim=0))
         return transform
 
     @staticmethod

--- a/captum/optim/_utils/image/common.py
+++ b/captum/optim/_utils/image/common.py
@@ -115,6 +115,7 @@ def nchannels_to_rgb(x: torch.Tensor, warp: bool = True) -> torch.Tensor:
     Convert an NCHW image with n channels into a 3 channel RGB image.
 
     Args:
+
         x (torch.Tensor):  NCHW image tensor to transform into RGB image.
         warp (bool, optional):  Whether or not to make colors more distinguishable.
             Default: True

--- a/captum/optim/_utils/image/common.py
+++ b/captum/optim/_utils/image/common.py
@@ -115,14 +115,18 @@ def nchannels_to_rgb(x: torch.Tensor, warp: bool = True) -> torch.Tensor:
     Convert an NCHW image with n channels into a 3 channel RGB image.
 
     Args:
-        x (torch.Tensor):  Image tensor to transform into RGB image.
+        x (torch.Tensor):  NCHW image tensor to transform into RGB image.
         warp (bool, optional):  Whether or not to make colors more distinguishable.
             Default: True
+
     Returns:
-        *tensor* RGB image
+        tensor (torch.Tensor): An NCHW RGB image tensor.
     """
 
-    def hue_to_rgb(angle: float) -> torch.Tensor:
+    # Handle older versions of PyTorch
+    torch_norm = torch.linalg.norm if torch.__version__ >= "1.9.0" else torch.norm
+
+    def hue_to_rgb(angle: float, device: torch.device) -> torch.Tensor:
         """
         Create an RGB unit vector based on a hue of the input angle.
         """
@@ -136,7 +140,8 @@ def nchannels_to_rgb(x: torch.Tensor, warp: bool = True) -> torch.Tensor:
                 [0.0, 0.7071, 0.7071],
                 [0.0, 0.0, 1.0],
                 [0.7071, 0.0, 0.7071],
-            ]
+            ],
+            device=device,
         )
 
         idx = math.floor(angle / 60)
@@ -150,7 +155,7 @@ def nchannels_to_rgb(x: torch.Tensor, warp: bool = True) -> torch.Tensor:
             d = adj(d) if idx % 2 == 0 else 1 - adj(1 - d)
 
         vec = (1 - d) * colors[idx] + d * colors[(idx + 1) % 6]
-        return vec / torch.norm(vec)
+        return vec / torch_norm(vec)
 
     assert x.dim() == 4
 
@@ -161,12 +166,12 @@ def nchannels_to_rgb(x: torch.Tensor, warp: bool = True) -> torch.Tensor:
     nc = x.size(1)
     for i in range(nc):
         rgb = rgb + x[:, i][:, None, :, :]
-        rgb = rgb * hue_to_rgb(360 * i / nc).to(device=x.device)[None, :, None, None]
+        rgb = rgb * hue_to_rgb(360 * i / nc, device=x.device)[None, :, None, None]
 
-    rgb = rgb + torch.ones(x.size(2), x.size(3))[None, None, :, :] * (
+    rgb = rgb + torch.ones(x.size(2), x.size(3), device=x.device)[None, None, :, :] * (
         torch.sum(x, 1)[:, None] - torch.max(x, 1)[0][:, None]
     )
-    return (rgb / (1e-4 + torch.norm(rgb, dim=1, keepdim=True))) * torch.norm(
+    return (rgb / (1e-4 + torch_norm(rgb, dim=1, keepdim=True))) * torch_norm(
         x, dim=1, keepdim=True
     )
 

--- a/captum/optim/_utils/image/dataset.py
+++ b/captum/optim/_utils/image/dataset.py
@@ -1,38 +1,71 @@
+from typing import cast
+
 import torch
 
+try:
+    from tqdm.auto import tqdm
+except (ImportError, AssertionError):
+    print(
+        "The tqdm package is required to use captum.optim's"
+        + " image dataset functions with progress bar"
+    )
 
-def image_cov(tensor: torch.Tensor) -> torch.Tensor:
+
+def image_cov(x: torch.Tensor) -> torch.Tensor:
     """
     Calculate a tensor's RGB covariance matrix.
 
     Args:
+
         tensor (tensor):  An NCHW image tensor.
+
     Returns:
         *tensor*:  An RGB covariance matrix for the specified tensor.
     """
 
-    tensor = tensor.reshape(-1, 3)
-    tensor = tensor - tensor.mean(0, keepdim=True)
-    return 1 / (tensor.size(0) - 1) * tensor.T @ tensor
+    assert x.dim() > 1
+    x = x.reshape(-1, x.size(1)).T
+    x = x - torch.mean(x, dim=-1).unsqueeze(-1)
+    return 1 / (x.shape[-1] - 1) * x @ x.transpose(-1, -2)
 
 
-def dataset_cov_matrix(loader: torch.utils.data.DataLoader) -> torch.Tensor:
+def dataset_cov_matrix(
+    loader: torch.utils.data.DataLoader,
+    show_progress: bool = False,
+    device: torch.device = torch.device("cpu"),
+) -> torch.Tensor:
     """
     Calculate the covariance matrix for an image dataset.
 
     Args:
+
         loader (torch.utils.data.DataLoader):  The reference to a PyTorch
             dataloader instance.
+        show_progress (bool, optional): Whether or not to display a tqdm progress bar.
+            Default: False
+        device (torch.device, optional): The PyTorch device to use for for calculating
+            the cov matrix.
+            Default: torch.device("cpu")
+
     Returns:
         *tensor*:  A covariance matrix for the specified dataset.
     """
 
-    cov_mtx = torch.zeros(3, 3)
+    if show_progress:
+        pbar = tqdm(total=len(loader.dataset), unit=" images")  # type: ignore
+
+    cov_mtx = cast(torch.Tensor, 0.0)
     for images, _ in loader:
-        assert images.dim() == 4
-        for b in range(images.size(0)):
-            cov_mtx = cov_mtx + image_cov(images[b].permute(1, 2, 0))
-    cov_mtx = cov_mtx / len(loader.dataset)  # type: ignore
+        assert images.dim() > 1
+        images = images.to(device)
+        cov_mtx = cov_mtx + image_cov(images)
+        if show_progress:
+            pbar.update(images.size(0))
+
+    if show_progress:
+        pbar.close()
+
+    cov_mtx = cov_mtx / cast(int, len(loader.dataset))
     return cov_mtx
 
 
@@ -43,22 +76,31 @@ def cov_matrix_to_klt(
     Convert a cov matrix to a klt matrix.
 
     Args:
+
         cov_mtx (tensor):  A 3 by 3 covariance matrix generated from a dataset.
         normalize (bool):  Whether or not to normalize the resulting KLT matrix.
+            Default: False
         epsilon (float):
+
     Returns:
         *tensor*:  A KLT matrix for the specified covariance matrix.
     """
 
+    # Handle older versions of PyTorch
+    torch_norm = torch.linalg.norm if torch.__version__ >= "1.9.0" else torch.norm
+
     U, S, V = torch.svd(cov_mtx)
     svd_sqrt = U @ torch.diag(torch.sqrt(S + epsilon))
     if normalize:
-        svd_sqrt / torch.max(torch.norm(svd_sqrt, dim=0))
+        svd_sqrt / torch.max(torch_norm(svd_sqrt, dim=0))
     return svd_sqrt
 
 
 def dataset_klt_matrix(
-    loader: torch.utils.data.DataLoader, normalize: bool = False
+    loader: torch.utils.data.DataLoader,
+    normalize: bool = False,
+    show_progress: bool = False,
+    device: torch.device = torch.device("cpu"),
 ) -> torch.Tensor:
     """
     Calculate the color correlation matrix, also known as
@@ -67,12 +109,20 @@ def dataset_klt_matrix(
     transforms for models trained on the dataset.
 
     Args:
+
         loader (torch.utils.data.DataLoader):  The reference to a PyTorch
             dataloader instance.
         normalize (bool):  Whether or not to normalize the resulting KLT matrix.
+            Default: False
+        show_progress (bool, optional): Whether or not to display a tqdm progress bar.
+            Default: False
+        device (torch.device, optional): The PyTorch device to use for for calculating
+            the cov matrix.
+            Default: torch.device("cpu")
+
     Returns:
         *tensor*:  A KLT matrix for the specified dataset.
     """
 
-    cov_mtx = dataset_cov_matrix(loader)
+    cov_mtx = dataset_cov_matrix(loader, show_progress=show_progress, device=device)
     return cov_matrix_to_klt(cov_mtx, normalize)

--- a/tests/optim/helpers/numpy_transforms.py
+++ b/tests/optim/helpers/numpy_transforms.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union, cast, no_type_check
 
 import numpy as np
 
@@ -112,6 +112,7 @@ class CenterCrop:
         )
 
 
+@no_type_check
 def center_crop(
     input: np.ndarray,
     crop_vals: IntSeqOrIntType,

--- a/tests/optim/utils/image/common.py
+++ b/tests/optim/utils/image/common.py
@@ -40,13 +40,100 @@ class TestGetNeuronPos(unittest.TestCase):
 
 class TestNChannelsToRGB(BaseTest):
     def test_nchannels_to_rgb_collapse(self) -> None:
-        test_input = torch.randn(1, 6, 224, 224)
-        test_output = common.nchannels_to_rgb(test_input)
-        self.assertEqual(list(test_output.size()), [1, 3, 224, 224])
+        test_input = torch.arange(0, 1 * 4 * 4 * 4).view(1, 4, 4, 4).float()
+        test_output = common.nchannels_to_rgb(test_input, warp=True)
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [31.6934, 32.6204, 33.5554, 34.4981],
+                        [35.4482, 36.4053, 37.3690, 38.3390],
+                        [39.3149, 40.2964, 41.2832, 42.2750],
+                        [43.2715, 44.2725, 45.2776, 46.2866],
+                    ],
+                    [
+                        [20.6687, 21.5674, 22.4618, 23.3529],
+                        [24.2417, 25.1290, 26.0154, 26.9013],
+                        [27.7870, 28.6729, 29.5592, 30.4460],
+                        [31.3335, 32.2217, 33.1109, 34.0009],
+                    ],
+                    [
+                        [46.3932, 47.4421, 48.5129, 49.6036],
+                        [50.7125, 51.8380, 52.9788, 54.1335],
+                        [55.3011, 56.4806, 57.6710, 58.8715],
+                        [60.0815, 61.3001, 62.5268, 63.7611],
+                    ],
+                ]
+            ]
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, delta=0)
+
+    def test_nchannels_to_rgb_collapse_warp_false(self) -> None:
+        test_input = torch.arange(0, 1 * 4 * 4 * 4).view(1, 4, 4, 4).float()
+        test_output = common.nchannels_to_rgb(test_input, warp=False)
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [28.4279, 29.3496, 30.2753, 31.2053],
+                        [32.1396, 33.0782, 34.0210, 34.9679],
+                        [35.9188, 36.8736, 37.8322, 38.7943],
+                        [39.7598, 40.7286, 41.7006, 42.6756],
+                    ],
+                    [
+                        [20.5599, 21.4595, 22.3544, 23.2459],
+                        [24.1351, 25.0225, 25.9088, 26.7946],
+                        [27.6801, 28.5657, 29.4515, 30.3378],
+                        [31.2247, 32.1124, 33.0008, 33.8900],
+                    ],
+                    [
+                        [48.5092, 49.5791, 50.6723, 51.7866],
+                        [52.9201, 54.0713, 55.2386, 56.4206],
+                        [57.6164, 58.8246, 60.0444, 61.2749],
+                        [62.5153, 63.7649, 65.0231, 66.2892],
+                    ],
+                ]
+            ]
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, delta=0.001)
 
     def test_nchannels_to_rgb_increase(self) -> None:
-        test_input = torch.randn(1, 2, 224, 224)
+        test_input = torch.arange(0, 1 * 2 * 4 * 4).view(1, 2, 4, 4).float()
+        test_output = common.nchannels_to_rgb(test_input, warp=True)
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [0.0000, 0.9234, 1.7311, 2.4623],
+                        [3.1419, 3.7855, 4.4036, 5.0033],
+                        [5.5894, 6.1654, 6.7337, 7.2961],
+                        [7.8540, 8.4083, 8.9597, 9.5089],
+                    ],
+                    [
+                        [11.3136, 12.0238, 12.7476, 13.4895],
+                        [14.2500, 15.0278, 15.8210, 16.6277],
+                        [17.4464, 18.2754, 19.1135, 19.9595],
+                        [20.8124, 21.6714, 22.5357, 23.4049],
+                    ],
+                    [
+                        [11.3136, 12.0238, 12.7476, 13.4895],
+                        [14.2500, 15.0278, 15.8210, 16.6277],
+                        [17.4464, 18.2754, 19.1135, 19.9595],
+                        [20.8124, 21.6714, 22.5357, 23.4049],
+                    ],
+                ]
+            ]
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, delta=0.001)
+
+    def test_nchannels_to_rgb_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping nchannels_to_rgb CUDA test due to not supporting CUDA."
+            )
+        test_input = torch.randn(1, 6, 224, 224).cuda()
         test_output = common.nchannels_to_rgb(test_input)
+        self.assertTrue(test_output.is_cuda)
         self.assertEqual(list(test_output.size()), [1, 3, 224, 224])
 
 


### PR DESCRIPTION
This PR is mostly just the miscellaneous changes from the old atlas PRs.

* Handle depreciations in favor of the new linalg module. Changes made in `ToRGB.klt_transform` and `nchannels_to_rgb`.
* Fix device issue with `nchannels_to_rgb` function. Previously it wouldn't work on the GPU. Also added new and improved tests.
* Change direction vector variable name to `vec` in `Direction`, `NeuronDirection`, & `TensorDirection`. This should improve readability.
* Speed up dataset cov color matrix calculations.
* Support cov color matrix creation with fewer or more than 3 color channels. While this change isn't needed it Captum at the moment, it will hopefully help make it easier for researchers to deal with non RGB models.