### PR TITLE
Improve composable losses

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -110,6 +110,42 @@ class Loss(ABC):
             )
         return CompositeLoss(loss_fn, name=name, target=target)
 
+    def mean(self, dim: Optional = None, keepdim: bool = False) -> "CompositeLoss":
+        """
+        Composable torch.mean reduction operator. See torch.mean for more details:
+        https://pytorch.org/docs/stable/generated/torch.mean.html
+        """
+        if dim is None:
+            # dim is equal to all dimensions unless specified
+            def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
+                return torch.mean(self(module), keepdim=keepdim)
+
+        else:
+
+            def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
+                return torch.mean(self(module), dim=dim, keepdim=keepdim)
+
+        name = "mean(" + self.__name__ + ")"
+        return CompositeLoss(loss_fn, name=name, target=self.target)
+
+    def sum(self, dim: Optional = None, keepdim: bool = False) -> "CompositeLoss":
+        """
+        Composable torch.sum reduction operator. See torch.sum for more details:
+        https://pytorch.org/docs/stable/generated/torch.sum.html
+        """
+        if dim is None:
+            # dim is equal to all dimensions unless specified
+            def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
+                return torch.sum(self(module), keepdim=keepdim)
+
+        else:
+
+            def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
+                return torch.sum(self(module), dim=dim, keepdim=keepdim)
+
+        name = "sum(" + self.__name__ + ")"
+        return CompositeLoss(loss_fn, name=name, target=self.target)
+
 
 def module_op(
     self: Loss, other: Union[None, int, float, Loss], math_op: Callable

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -16,6 +16,7 @@ def _make_arg_str(arg: Any) -> str:
     return arg[:15] + "..." if too_big else arg
 
 
+# Reduction op for loss composability
 REDUCTION_OP: Callable[[torch.Tensor], torch.Tensor] = torch.mean
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -16,7 +16,7 @@ def _make_arg_str(arg: Any) -> str:
     return arg[:15] + "..." if too_big else arg
 
 
-# Reduction op for loss composability size mismatch avoidance
+# Reduction op for CompositeLoss loss composability size mismatch avoidance
 REDUCTION_OP: Callable[[torch.Tensor], torch.Tensor] = torch.mean
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -128,7 +128,7 @@ class Loss(ABC):
         if dim is None:
             # dim is equal to all dimensions unless specified
             def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
-                return torch.mean(self(module), keepdim=keepdim)
+                return torch.mean(self(module))
 
         else:
 
@@ -156,7 +156,7 @@ class Loss(ABC):
         if dim is None:
             # dim is equal to all dimensions unless specified
             def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
-                return torch.sum(self(module), keepdim=keepdim)
+                return torch.sum(self(module))
 
         else:
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -16,7 +16,7 @@ def _make_arg_str(arg: Any) -> str:
     return arg[:15] + "..." if too_big else arg
 
 
-# Reduction op for loss composability
+# Reduction op for loss composability size mismatch avoidance
 REDUCTION_OP: Callable[[torch.Tensor], torch.Tensor] = torch.mean
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -613,6 +613,7 @@ def default_loss_summarize(loss_value: torch.Tensor) -> torch.Tensor:
 
 __all__ = [
     "Loss",
+    "REDUCTION_OP",
     "loss_wrapper",
     "BaseLoss",
     "LayerActivation",

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -114,6 +114,16 @@ class Loss(ABC):
         """
         Composable torch.mean reduction operator. See torch.mean for more details:
         https://pytorch.org/docs/stable/generated/torch.mean.html
+
+        Args:
+            dim (int or tuple of int, optional): The dimension or dimensions to reduce.
+                Default: None for all dimension.
+            keepdim (bool, optional): Whether the output tensor has dim retained or
+                not.
+                Default: False
+
+        Returns:
+            composite_loss (ComposableLoss): A composable loss instance.
         """
         if dim is None:
             # dim is equal to all dimensions unless specified
@@ -132,6 +142,16 @@ class Loss(ABC):
         """
         Composable torch.sum reduction operator. See torch.sum for more details:
         https://pytorch.org/docs/stable/generated/torch.sum.html
+
+        Args:
+            dim (int or tuple of int, optional): The dimension or dimensions to reduce.
+                Default: None for all dimension.
+            keepdim (bool, optional): Whether the output tensor has dim retained or
+                not.
+                Default: False
+
+        Returns:
+            composite_loss (ComposableLoss): A composable loss instance.
         """
         if dim is None:
             # dim is equal to all dimensions unless specified

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -258,13 +258,13 @@ class TestCompositeLoss(BaseTest):
 
     def test_sum(self) -> None:
         model = torch.nn.Identity()
-        loss = opt_loss.LayerActivation(model, 0).sum()
+        loss = opt_loss.LayerActivation(model).sum()
 
         self.assertAlmostEqual(get_loss_value(model, loss), 3.0, places=1)
 
     def mean(self) -> None:
         model = torch.nn.Identity()
-        loss = opt_loss.LayerActivation(model, 0).mean()
+        loss = opt_loss.LayerActivation(model).mean()
 
         self.assertAlmostEqual(get_loss_value(model, loss), 1.0, places=1)
 

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -275,3 +275,8 @@ class TestCompositeLoss(BaseTest):
         self.assertAlmostEqual(
             get_loss_value(model, loss), 1.0, places=1
         )
+
+
+class TestCompositeLossReductionOP(BaseTest):
+    def test_reduction_op(self) -> None:
+        self.assertEqual(opt_loss.REDUCTION_OP, torch.mean)

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -170,7 +170,7 @@ class TestCompositeLoss(BaseTest):
 
     def test_positive(self) -> None:
         model = torch.nn.Identity()
-        loss = -opt.loss.LayerActivation(model, 0)
+        loss = -opt_loss.LayerActivation(model, 0)
         loss = +loss
 
         self.assertAlmostEqual(
@@ -179,7 +179,7 @@ class TestCompositeLoss(BaseTest):
 
     def test_abs(self) -> None:
         model = torch.nn.Identity()
-        loss = abs(opt.loss.LayerActivation(model, 0) * -1)
+        loss = abs(opt_loss.LayerActivation(model, 0) * -1)
 
         self.assertAlmostEqual(
             get_loss_value(model, loss), 1.0, places=1
@@ -262,7 +262,7 @@ class TestCompositeLoss(BaseTest):
 
     def test_sum(self) -> None:
         model = torch.nn.Identity()
-        loss = opt.loss.LayerActivation(model, 0).sum()
+        loss = opt_loss.LayerActivation(model, 0).sum()
 
         self.assertAlmostEqual(
             get_loss_value(model, loss), 3.0, places=1
@@ -270,7 +270,7 @@ class TestCompositeLoss(BaseTest):
 
     def mean(self) -> None:
         model = torch.nn.Identity()
-        loss = opt.loss.LayerActivation(model, 0).mean()
+        loss = opt_loss.LayerActivation(model, 0).mean()
 
         self.assertAlmostEqual(
             get_loss_value(model, loss), 1.0, places=1

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -262,7 +262,7 @@ class TestCompositeLoss(BaseTest):
 
         self.assertAlmostEqual(get_loss_value(model, loss), 3.0, places=1)
 
-    def mean(self) -> None:
+    def test_mean(self) -> None:
         model = torch.nn.Identity()
         loss = opt_loss.LayerActivation(model).mean()
 

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -176,10 +176,11 @@ class TestCompositeLoss(BaseTest):
         self.assertAlmostEqual(get_loss_value(model, loss), 1.0, places=1)
 
     def test_abs(self) -> None:
-        model = torch.nn.Identity()
-        loss = abs(opt_loss.LayerActivation(model, 0) * -1)
-
-        self.assertAlmostEqual(get_loss_value(model, loss), 1.0, places=1)
+        model = BasicModel_ConvNet_Optim()
+        loss = abs(-opt_loss.ChannelActivation(model.layer, 0))
+        self.assertAlmostEqual(
+            get_loss_value(model, loss), CHANNEL_ACTIVATION_0_LOSS, places=6
+        )
 
     def test_addition(self) -> None:
         model = BasicModel_ConvNet_Optim()

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -168,6 +168,23 @@ class TestCompositeLoss(BaseTest):
             get_loss_value(model, loss), -CHANNEL_ACTIVATION_0_LOSS, places=6
         )
 
+    def test_positive(self) -> None:
+        model = torch.nn.Identity()
+        loss = -opt.loss.LayerActivation(model, 0)
+        loss = +loss
+
+        self.assertAlmostEqual(
+            get_loss_value(model, loss), 1.0, places=1
+        )
+
+    def test_abs(self) -> None:
+        model = torch.nn.Identity()
+        loss = abs(opt.loss.LayerActivation(model, 0) * -1)
+
+        self.assertAlmostEqual(
+            get_loss_value(model, loss), 1.0, places=1
+        )
+
     def test_addition(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = (
@@ -242,3 +259,19 @@ class TestCompositeLoss(BaseTest):
     #         opt_loss.ChannelActivation(model.layer, 0) ** opt_loss.ChannelActivation(
     #             model.layer, 1
     #         )
+
+    def test_sum(self) -> None:
+        model = torch.nn.Identity()
+        loss = opt.loss.LayerActivation(model, 0).sum()
+
+        self.assertAlmostEqual(
+            get_loss_value(model, loss), 3.0, places=1
+        )
+
+    def mean(self) -> None:
+        model = torch.nn.Identity()
+        loss = opt.loss.LayerActivation(model, 0).mean()
+
+        self.assertAlmostEqual(
+            get_loss_value(model, loss), 1.0, places=1
+        )

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -173,17 +173,13 @@ class TestCompositeLoss(BaseTest):
         loss = -opt_loss.LayerActivation(model, 0)
         loss = +loss
 
-        self.assertAlmostEqual(
-            get_loss_value(model, loss), 1.0, places=1
-        )
+        self.assertAlmostEqual(get_loss_value(model, loss), 1.0, places=1)
 
     def test_abs(self) -> None:
         model = torch.nn.Identity()
         loss = abs(opt_loss.LayerActivation(model, 0) * -1)
 
-        self.assertAlmostEqual(
-            get_loss_value(model, loss), 1.0, places=1
-        )
+        self.assertAlmostEqual(get_loss_value(model, loss), 1.0, places=1)
 
     def test_addition(self) -> None:
         model = BasicModel_ConvNet_Optim()
@@ -264,17 +260,13 @@ class TestCompositeLoss(BaseTest):
         model = torch.nn.Identity()
         loss = opt_loss.LayerActivation(model, 0).sum()
 
-        self.assertAlmostEqual(
-            get_loss_value(model, loss), 3.0, places=1
-        )
+        self.assertAlmostEqual(get_loss_value(model, loss), 3.0, places=1)
 
     def mean(self) -> None:
         model = torch.nn.Identity()
         loss = opt_loss.LayerActivation(model, 0).mean()
 
-        self.assertAlmostEqual(
-            get_loss_value(model, loss), 1.0, places=1
-        )
+        self.assertAlmostEqual(get_loss_value(model, loss), 1.0, places=1)
 
 
 class TestCompositeLossReductionOP(BaseTest):

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -169,11 +169,11 @@ class TestCompositeLoss(BaseTest):
         )
 
     def test_positive(self) -> None:
-        model = torch.nn.Identity()
-        loss = -opt_loss.LayerActivation(model, 0)
-        loss = +loss
-
-        self.assertAlmostEqual(get_loss_value(model, loss), 1.0, places=1)
+        model = BasicModel_ConvNet_Optim()
+        loss = +opt_loss.ChannelActivation(model.layer, 0)
+        self.assertAlmostEqual(
+            get_loss_value(model, loss), CHANNEL_ACTIVATION_0_LOSS, places=6
+        )
 
     def test_abs(self) -> None:
         model = BasicModel_ConvNet_Optim()

--- a/tests/optim/helpers/numpy_transforms.py
+++ b/tests/optim/helpers/numpy_transforms.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -137,7 +137,7 @@ def center_crop(
     assert input.ndim == 3 or input.ndim == 4
     if isinstance(crop_vals, int):
         crop_vals = [int(crop_vals), int(crop_vals)]
-    elif isinstance(size, (tuple, list)):
+    elif isinstance(crop_vals, (tuple, list)):
         if len(crop_vals) == 1:
             crop_vals = [crop_vals[0], crop_vals[0]]
         elif len(crop_vals) == 2:
@@ -145,7 +145,7 @@ def center_crop(
         else:
             raise ValueError("Crop size length of {} too large".format(len(crop_vals)))
     else:
-        raise ValueError("Unsupported crop size value {}".format(size))
+        raise ValueError("Unsupported crop size value {}".format(crop_vals))
     assert len(crop_vals) == 2
 
     if input.ndim == 4:

--- a/tests/optim/helpers/numpy_transforms.py
+++ b/tests/optim/helpers/numpy_transforms.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union, cast
 
 import numpy as np
 
@@ -114,7 +114,7 @@ class CenterCrop:
 
 def center_crop(
     input: np.ndarray,
-    crop_vals: Union[int, List[int]],
+    crop_vals: IntSeqOrIntType,
     pixels_from_edges: bool = False,
     offset_left: bool = False,
 ) -> np.ndarray:
@@ -135,18 +135,10 @@ def center_crop(
     """
 
     assert input.ndim == 3 or input.ndim == 4
-    if isinstance(crop_vals, int):
-        crop_vals = [int(crop_vals), int(crop_vals)]
-    elif isinstance(crop_vals, (tuple, list)):
-        if len(crop_vals) == 1:
-            crop_vals = [crop_vals[0], crop_vals[0]]
-        elif len(crop_vals) == 2:
-            crop_vals = list(crop_vals)
-        else:
-            raise ValueError("Crop size length of {} too large".format(len(crop_vals)))
-    else:
-        raise ValueError("Unsupported crop size value {}".format(crop_vals))
-    assert len(crop_vals) == 2
+    crop_vals = [crop_vals] if not hasattr(crop_vals, "__iter__") else crop_vals
+    crop_vals = cast(Union[List[int], Tuple[int], Tuple[int, int]], crop_vals)
+    assert len(crop_vals) == 1 or len(crop_vals) == 2
+    crop_vals = crop_vals * 2 if len(crop_vals) == 1 else crop_vals
 
     if input.ndim == 4:
         h, w = input.shape[2], input.shape[3]

--- a/tests/optim/helpers/numpy_transforms.py
+++ b/tests/optim/helpers/numpy_transforms.py
@@ -114,7 +114,7 @@ class CenterCrop:
 
 def center_crop(
     input: np.ndarray,
-    crop_vals: IntSeqOrIntType,
+    crop_vals: Union[int, List[int]],
     pixels_from_edges: bool = False,
     offset_left: bool = False,
 ) -> np.ndarray:
@@ -135,10 +135,18 @@ def center_crop(
     """
 
     assert input.ndim == 3 or input.ndim == 4
-    crop_vals = [crop_vals] if not hasattr(crop_vals, "__iter__") else crop_vals
-    crop_vals = cast(Union[List[int], Tuple[int], Tuple[int, int]], crop_vals)
-    assert len(crop_vals) == 1 or len(crop_vals) == 2
-    crop_vals = crop_vals * 2 if len(crop_vals) == 1 else crop_vals
+    if isinstance(crop_vals, int):
+        crop_vals = [int(crop_vals), int(crop_vals)]
+    elif isinstance(size, (tuple, list)):
+        if len(crop_vals) == 1:
+            crop_vals = [crop_vals[0], crop_vals[0]]
+        elif len(crop_vals) == 2:
+            crop_vals = list(crop_vals)
+        else:
+            raise ValueError("Crop size length of {} too large".format(len(crop_vals)))
+    else:
+        raise ValueError("Unsupported crop size value {}".format(size))
+    assert len(crop_vals) == 2
 
     if input.ndim == 4:
         h, w = input.shape[2], input.shape[3]

--- a/tests/optim/helpers/numpy_transforms.py
+++ b/tests/optim/helpers/numpy_transforms.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union, cast, no_type_check
 
 import numpy as np
 
@@ -112,6 +112,7 @@ class CenterCrop:
         )
 
 
+@no_type_check
 def center_crop(
     input: np.ndarray,
     crop_vals: IntSeqOrIntType,


### PR DESCRIPTION
This PR adds a few simple improvements to the `CompositeLoss` class and it's features.

* Added support for `__pos__` and `__abs__` unary operators to `CompositeLoss`. These appear to be the only other basic operators that make sense to add support for.
* Made `CompositeLoss`'s reduction operation a global variable that can be changed by users. This should improve the generality of the optim module, and it makes it possible to disable this aspect of `CompositeLoss`.
* Added composable `torch.mean` and `torch.sum` reduction operations to `CompositeLoss`. These are common operations, so there are likely use cases that can benefit from them. Example usage: `loss_fn.mean()` & `loss_fn.sum()`.
* Added tests for the changes listed above.

Currently the following objectives do not produce scalar outputs:

```
LayerActivation
ChannelActivation
NeuronActivation
DeepDream
Direction
NeuronDirection
TensorDirection
ActivationWeights
```

I'm also working on ways for users to create their own custom composite loss operations, similar to the `sum_loss_list` function.