### PR TITLE
Interpolation based RandomScale & Other Improvements

### DIFF
--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -292,12 +292,19 @@ def center_crop(
         sw, sh = w // 2 - (w_crop // 2), h // 2 - (h_crop // 2)
         x = input[..., sh : sh + h_crop, sw : sw + w_crop]
     else:
-        h_crop = h - int(math.ceil((h - size[0]) / 2.0))
-        w_crop = w - int(math.ceil((w - size[1]) / 2.0))
+        h_crop = h - int(math.ceil((h - size[0]) / 2.0)) if h > size[0] else size[0]
+        w_crop = w - int(math.ceil((w - size[1]) / 2.0)) if w > size[1] else size[1]
+        
         if h % 2 == 0 and size[0] % 2 != 0 or h % 2 != 0 and size[0] % 2 == 0:
             h_crop = h_crop + 1 if offset_left else h_crop
         if w % 2 == 0 and size[1] % 2 != 0 or w % 2 != 0 and size[1] % 2 == 0:
             w_crop = w_crop + 1 if offset_left else w_crop
+        
+        if size[1] > w or size[0] > h:
+            h_pad = math.ceil(h_crop / 2.0) if size[0] > h else 0
+            w_pad = math.ceil(w_crop / 2.) if size[1] > h else 0
+            padding = [w_pad, h_pad] * 2
+            input = F.pad(input, padding)
         x = input[..., h_crop - size[0] : h_crop, w_crop - size[1] : w_crop]
     return x
 

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -244,6 +244,8 @@ def center_crop(
     size: Union[int, List[int]],
     pixels_from_edges: bool = False,
     offset_left: bool = False,
+    padding_mode: str = "constant",
+    padding_value: float = 0.0,
 ) -> torch.Tensor:
     """
     Center crop a specified amount from a tensor.
@@ -260,6 +262,13 @@ def center_crop(
             equal in size, offset center by +1 to the left and/or top.
             This parameter is only valid when `pixels_from_edges` is False.
             Default: False
+        padding_mode (optional, str): One of "constant", "reflect", "replicate" or
+            "circular". This parameter is only used if the crop size is larger than
+            the image size.
+            Default: "constant"
+        padding_value (float, optional): fill value for "constant" padding. This
+            parameter is only used if the crop size is larger than the image size.
+            Default: 0.0
 
     Returns:
         **tensor**:  A center cropped *tensor*.
@@ -304,7 +313,9 @@ def center_crop(
             h_pad = math.ceil(h_crop / 2.0) if size[0] > h else 0
             w_pad = math.ceil(w_crop / 2.0) if size[1] > w else 0
             padding = [w_pad, h_pad] * 2
-            input = F.pad(input, padding)
+            input = F.pad(
+                input, padding, mode=self.padding_mode, value=self.padding_value
+            )
         x = input[..., h_crop - size[0] : h_crop, w_crop - size[1] : w_crop]
     return x
 

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -334,10 +334,15 @@ def center_crop(
             w_crop = w_crop + 1 if offset_left else w_crop
 
         if size[1] > w or size[0] > h:
-            h_pad = math.ceil(h_crop / 2.0) if size[0] > h else 0
-            w_pad = math.ceil(w_crop / 2.0) if size[1] > w else 0
-            padding = [w_pad, h_pad] * 2
+            # Padding functionality like Torchvision's center crop
+            padding = [
+                (size[1] - w) // 2 if size[1] > w else 0,
+                (size[0] - h) // 2 if size[0] > h else 0,
+                (size[1] - w + 1) // 2 if size[1] > w else 0,
+                (size[0] - h + 1) // 2 if size[0] > h else 0,
+             ]
             input = F.pad(input, padding, mode=padding_mode, value=padding_value)
+
         x = input[..., h_crop - size[0] : h_crop, w_crop - size[1] : w_crop]
     return x
 

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -182,13 +182,21 @@ class CenterCrop(torch.nn.Module):
     Center crop a specified amount from a tensor.
     """
 
-    __constants__ = ["size", "pixels_from_edges", "offset_left"]
+    __constants__ = [
+        "size",
+        "pixels_from_edges",
+        "offset_left",
+        "padding_mode",
+        "padding_value",
+    ]
 
     def __init__(
         self,
         size: IntSeqOrIntType = 0,
         pixels_from_edges: bool = False,
         offset_left: bool = False,
+        padding_mode: str = "constant",
+        padding_value: float = 0.0,
     ) -> None:
         """
         Args:
@@ -205,6 +213,13 @@ class CenterCrop(torch.nn.Module):
                 equal in size, offset center by +1 to the left and/or top.
                 This parameter is only valid when `pixels_from_edges` is False.
                 Default: False
+            padding_mode (optional, str): One of "constant", "reflect", "replicate"
+                or "circular". This parameter is only used if the crop size is larger
+                than the image size.
+                Default: "constant"
+            padding_value (float, optional): fill value for "constant" padding. This
+                parameter is only used if the crop size is larger than the image size.
+                Default: 0.0
         """
         super().__init__()
         if not hasattr(size, "__iter__"):
@@ -222,6 +237,8 @@ class CenterCrop(torch.nn.Module):
         self.size = cast(List[int], size)
         self.pixels_from_edges = pixels_from_edges
         self.offset_left = offset_left
+        self.padding_mode = padding_mode
+        self.padding_value = padding_value
 
     @torch.jit.ignore
     def forward(self, input: torch.Tensor) -> torch.Tensor:
@@ -236,7 +253,14 @@ class CenterCrop(torch.nn.Module):
             **tensor** (torch.Tensor): A center cropped *tensor*.
         """
 
-        return center_crop(input, self.size, self.pixels_from_edges, self.offset_left)
+        return center_crop(
+            input,
+            self.size,
+            self.pixels_from_edges,
+            self.offset_left,
+            self.padding_mode,
+            self.padding_value,
+        )
 
 
 def center_crop(

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -333,7 +333,7 @@ def center_crop(
         if w % 2 == 0 and size[1] % 2 != 0 or w % 2 != 0 and size[1] % 2 == 0:
             w_crop = w_crop + 1 if offset_left else w_crop
 
-        if size[1] > w or size[0] > h:
+        if size[0] > h or size[1] > w:
             # Padding functionality like Torchvision's center crop
             padding = [
                 (size[1] - w) // 2 if size[1] > w else 0,

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -337,9 +337,7 @@ def center_crop(
             h_pad = math.ceil(h_crop / 2.0) if size[0] > h else 0
             w_pad = math.ceil(w_crop / 2.0) if size[1] > w else 0
             padding = [w_pad, h_pad] * 2
-            input = F.pad(
-                input, padding, mode=self.padding_mode, value=self.padding_value
-            )
+            input = F.pad(input, padding, mode=padding_mode, value=padding_value)
         x = input[..., h_crop - size[0] : h_crop, w_crop - size[1] : w_crop]
     return x
 

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -294,12 +294,12 @@ def center_crop(
     else:
         h_crop = h - int(math.ceil((h - size[0]) / 2.0)) if h > size[0] else size[0]
         w_crop = w - int(math.ceil((w - size[1]) / 2.0)) if w > size[1] else size[1]
-        
+
         if h % 2 == 0 and size[0] % 2 != 0 or h % 2 != 0 and size[0] % 2 == 0:
             h_crop = h_crop + 1 if offset_left else h_crop
         if w % 2 == 0 and size[1] % 2 != 0 or w % 2 != 0 and size[1] % 2 == 0:
             w_crop = w_crop + 1 if offset_left else w_crop
-        
+
         if size[1] > w or size[0] > h:
             h_pad = math.ceil(h_crop / 2.0) if size[0] > h else 0
             w_pad = math.ceil(w_crop / 2.0) if size[1] > w else 0
@@ -311,7 +311,156 @@ def center_crop(
 
 class RandomScale(nn.Module):
     """
-    Apply random rescaling on a NCHW tensor using affine transform matrices.
+    Apply random rescaling on a NCHW tensor using the F.interpolate function.
+    """
+
+    __constants__ = [
+        "scale",
+        "mode",
+        "align_corners",
+        "has_align_corners",
+        "recompute_scale_factor",
+        "has_recompute_scale_factor",
+        "is_distribution",
+    ]
+
+    def __init__(
+        self,
+        scale: NumSeqOrTensorType,
+        mode: str = "bilinear",
+        align_corners: Optional[bool] = False,
+        recompute_scale_factor: bool = False,
+    ) -> None:
+        """
+        Args:
+
+            scale (float, sequence, or torch.distribution): Tuple of rescaling values
+                to randomly select from, or a torch.distributions instance.
+            mode (str, optional): Interpolation mode to use. See documentation of
+                F.interpolate for more details. One of; "bilinear", "nearest", "area",
+                or "bicubic".
+                Default: "bilinear"
+            align_corners (bool, optional): Whether or not to align corners. See
+                documentation of F.interpolate for more details.
+                Default: False
+            recompute_scale_factor (bool, optional): Whether or not to recompute the
+                scale factor See documentation of F.interpolate for more details.
+                Default: False
+        """
+        super().__init__()
+        if isinstance(scale, torch.distributions.distribution.Distribution):
+            # Distributions are not supported by TorchScript / JIT yet
+            self.scale_distribution = scale
+            self.is_distribution = True
+            self.scale = []
+        else:
+            assert hasattr(scale, "__iter__")
+            if torch.is_tensor(scale):
+                assert cast(torch.Tensor, scale).dim() == 1
+                scale = scale.tolist()
+            assert len(scale) > 0
+            self.scale = [float(s) for s in scale]
+            self.is_distribution = False
+        self.mode = mode
+        self.align_corners = align_corners if mode not in ["nearest", "area"] else None
+        self.recompute_scale_factor = recompute_scale_factor
+        self.has_align_corners = torch.__version__ >= "1.3.0"
+        self.has_recompute_scale_factor = torch.__version__ >= "1.6.0"
+
+    def _get_scale_mat(
+        self,
+        m: float,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """
+        Create a rotation matrix tensor.
+
+        Args:
+
+            m (float): The scale value to use.
+
+        Returns:
+            **scale_mat** (torch.Tensor): A scale matrix.
+        """
+        scale_mat = torch.tensor(
+            [[m, 0.0, 0.0], [0.0, m, 0.0]], device=device, dtype=dtype
+        )
+        return scale_mat
+
+    def _scale_tensor(self, x: torch.Tensor, scale: float) -> torch.Tensor:
+        """
+        Scale an NCHW image tensor based on a specified scale value.
+
+        Args:
+
+            x (torch.Tensor): The NCHW image tensor to scale.
+            scale (float): The amount to scale the NCHW image by.
+
+        Returns:
+            **x** (torch.Tensor): A scaled NCHW image tensor.
+        """
+        if self.has_align_corners:
+            if self.has_recompute_scale_factor:
+                x = F.interpolate(
+                    x,
+                    scale_factor=scale,
+                    mode=self.mode,
+                    align_corners=self.align_corners,
+                    recompute_scale_factor=self.recompute_scale_factor,
+                )
+            else:
+                x = F.interpolate(
+                    x,
+                    scale_factor=scale,
+                    mode=self.mode,
+                    align_corners=self.align_corners,
+                )
+        else:
+            x = F.interpolate(x, scale_factor=scale, mode=self.mode)
+        return x
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Randomly scale an NCHW image tensor.
+
+        Args:
+
+            x (torch.Tensor): NCHW image tensor to randomly scale.
+
+        Returns:
+            **x** (torch.Tensor): A randomly scaled NCHW image *tensor*.
+        """
+        assert x.dim() == 4
+        if self.is_distribution:
+            scale = self.scale_distribution.sample().item()
+        else:
+            n = int(
+                torch.randint(
+                    low=0,
+                    high=len(self.scale),
+                    size=[1],
+                    dtype=torch.int64,
+                    layout=torch.strided,
+                    device=x.device,
+                ).item()
+            )
+            scale = self.scale[n]
+        return self._scale_tensor(x, scale=scale)
+
+
+class RandomScaleAffine(nn.Module):
+    """
+    Apply random rescaling on a NCHW tensor.
+
+    This random scaling transform utilizes F.affine_grid & F.grid_sample, and as a
+    result has two key differences to the default RandomScale transforms This
+    transform either shrinks an image while adding a background, or center crops image
+    and then resizes it to a larger size. This means that the output image shape is the
+    same shape as the input image.
+
+    In constrast to RandomScaleAffine, the default RandomScale transform simply resizes
+    the input image using F.interpolate.
     """
 
     __constants__ = [
@@ -320,6 +469,7 @@ class RandomScale(nn.Module):
         "padding_mode",
         "align_corners",
         "has_align_corners",
+        "is_distribution",
     ]
 
     def __init__(
@@ -332,7 +482,8 @@ class RandomScale(nn.Module):
         """
         Args:
 
-            scale (float, sequence): Tuple of rescaling values to randomly select from.
+            scale (float, sequence, or torch.distribution): Tuple of rescaling values
+                to randomly select from, or a torch.distributions instance.
             mode (str, optional): Interpolation mode to use. See documentation of
                 F.grid_sample for more details. One of; "bilinear", "nearest", or
                 "bicubic".
@@ -346,12 +497,19 @@ class RandomScale(nn.Module):
                 Default: False
         """
         super().__init__()
-        assert hasattr(scale, "__iter__")
-        if torch.is_tensor(scale):
-            assert cast(torch.Tensor, scale).dim() == 1
-            scale = scale.tolist()
-        assert len(scale) > 0
-        self.scale = [float(s) for s in scale]
+        if isinstance(scale, torch.distributions.distribution.Distribution):
+            # Distributions are not supported by TorchScript / JIT yet
+            self.scale_distribution = scale
+            self.is_distribution = True
+            self.scale = []
+        else:
+            assert hasattr(scale, "__iter__")
+            if torch.is_tensor(scale):
+                assert cast(torch.Tensor, scale).dim() == 1
+                scale = scale.tolist()
+            assert len(scale) > 0
+            self.scale = [float(s) for s in scale]
+            self.is_distribution = False
         self.mode = mode
         self.padding_mode = padding_mode
         self.align_corners = align_corners
@@ -410,31 +568,33 @@ class RandomScale(nn.Module):
             x = F.grid_sample(x, grid, mode=self.mode, padding_mode=self.padding_mode)
         return x
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
-        Randomly scale / zoom in or out of an NCHW image tensor.
+        Randomly scale an NCHW image tensor.
 
         Args:
 
-            input (torch.Tensor): NCHW image tensor to randomly scale.
+            x (torch.Tensor): NCHW image tensor to randomly scale.
 
         Returns:
-            **tensor** (torch.Tensor): A randomly scaled NCHW image *tensor*.
+            **x** (torch.Tensor): A randomly scaled NCHW image *tensor*.
         """
-        assert input.dim() == 4
-
-        n = int(
-            torch.randint(
-                low=0,
-                high=len(self.scale),
-                size=[1],
-                dtype=torch.int64,
-                layout=torch.strided,
-                device=input.device,
-            ).item()
-        )
-        scale = self.scale[n]
-        return self._scale_tensor(input, scale=scale)
+        assert x.dim() == 4
+        if self.is_distribution:
+            scale = self.scale_distribution.sample().item()
+        else:
+            n = int(
+                torch.randint(
+                    low=0,
+                    high=len(self.scale),
+                    size=[1],
+                    dtype=torch.int64,
+                    layout=torch.strided,
+                    device=x.device,
+                ).item()
+            )
+            scale = self.scale[n]
+        return self._scale_tensor(x, scale=scale)
 
 
 class RandomSpatialJitter(torch.nn.Module):

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -302,7 +302,7 @@ def center_crop(
         
         if size[1] > w or size[0] > h:
             h_pad = math.ceil(h_crop / 2.0) if size[0] > h else 0
-            w_pad = math.ceil(w_crop / 2.) if size[1] > h else 0
+            w_pad = math.ceil(w_crop / 2.0) if size[1] > w else 0
             padding = [w_pad, h_pad] * 2
             input = F.pad(input, padding)
         x = input[..., h_crop - size[0] : h_crop, w_crop - size[1] : w_crop]

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -369,8 +369,8 @@ class RandomScale(nn.Module):
         """
         Args:
 
-            scale (float, sequence, or torch.distribution): Tuple of rescaling values
-                to randomly select from, or a torch.distributions instance.
+            scale (float, sequence, or torch.distribution): Sequence of rescaling
+                values to randomly select from, or a torch.distributions instance.
             mode (str, optional): Interpolation mode to use. See documentation of
                 F.interpolate for more details. One of; "bilinear", "nearest", "area",
                 or "bicubic".
@@ -517,8 +517,8 @@ class RandomScaleAffine(nn.Module):
         """
         Args:
 
-            scale (float, sequence, or torch.distribution): Tuple of rescaling values
-                to randomly select from, or a torch.distributions instance.
+            scale (float, sequence, or torch.distribution): Sequence of rescaling
+                values to randomly select from, or a torch.distributions instance.
             mode (str, optional): Interpolation mode to use. See documentation of
                 F.grid_sample for more details. One of; "bilinear", "nearest", or
                 "bicubic".

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -20,30 +20,63 @@ class TestRandomScale(BaseTest):
         scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05])
         self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
 
-    def test_random_scale(self) -> None:
-        scale_module = transforms.RandomScale(scale=[1.0])
-        test_tensor = torch.ones(1, 3, 3, 3)
+    def test_random_scale_scale_distributions(self) -> None:
+        scale = torch.distributions.Uniform(0.95, 1.05)
+        scale_module = transforms.RandomScale(scale=scale)
+        self.assertIsInstance(
+            scale_module.scale_distribution,
+            torch.distributions.distribution.Distribution,
+        )
 
-        # Test rescaling
-        assertTensorAlmostEqual(
-            self,
-            scale_module._scale_tensor(test_tensor, 0.5),
-            torch.ones(3, 1).repeat(3, 1, 3).unsqueeze(0),
-            0,
+    def test_random_scale_downscaling(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5])
+        test_tensor = torch.arange(0, 1 * 1 * 10 * 10).view(1, 1, 10, 10).float()
+
+        scaled_tensor = scale_module._scale_tensor(test_tensor, 0.5)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [5.5000, 7.5000, 9.5000, 11.5000, 13.5000],
+                        [25.5000, 27.5000, 29.5000, 31.5000, 33.5000],
+                        [45.5000, 47.5000, 49.5000, 51.5000, 53.5000],
+                        [65.5000, 67.5000, 69.5000, 71.5000, 73.5000],
+                        [85.5000, 87.5000, 89.5000, 91.5000, 93.5000],
+                    ]
+                ]
+            ]
         )
 
         assertTensorAlmostEqual(
             self,
-            scale_module._scale_tensor(test_tensor, 1.5),
-            torch.tensor(
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_upscaling(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5])
+        test_tensor = torch.arange(0, 1 * 1 * 2 * 2).view(1, 1, 2, 2).float()
+
+        scaled_tensor = scale_module._scale_tensor(test_tensor, 1.5)
+
+        expected_tensor = torch.tensor(
+            [
                 [
-                    [0.2500, 0.5000, 0.2500],
-                    [0.5000, 1.0000, 0.5000],
-                    [0.2500, 0.5000, 0.2500],
+                    [
+                        [0.0000, 0.5000, 1.0000],
+                        [1.0000, 1.5000, 2.0000],
+                        [2.0000, 2.5000, 3.0000],
+                    ]
                 ]
-            )
-            .repeat(3, 1, 1)
-            .unsqueeze(0),
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
             0,
         )
 
@@ -66,6 +99,19 @@ class TestRandomScale(BaseTest):
             0,
         )
 
+    def test_random_scale_forward(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5])
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = scale_module(test_tensor)
+        self.assertEqual(list(output_tensor.shape), [1, 3, 5, 5])
+
+    def test_random_scale_forward_distributions(self) -> None:
+        scale = torch.distributions.Uniform(0.95, 1.05)
+        scale_module = transforms.RandomScale(scale=scale)
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = scale_module(test_tensor)
+        self.assertTrue(torch.is_tensor(output_tensor))
+
     def test_random_scale_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
@@ -73,6 +119,113 @@ class TestRandomScale(BaseTest):
                 + " Torch version."
             )
         scale_module = transforms.RandomScale(scale=[1.5])
+        jit_scale_module = torch.jit.script(scale_module)
+
+        test_tensor = torch.arange(0, 1 * 1 * 2 * 2).view(1, 1, 2, 2).float()
+        scaled_tensor = jit_scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0000, 0.5000, 1.0000],
+                        [1.0000, 1.5000, 2.0000],
+                        [2.0000, 2.5000, 3.0000],
+                    ]
+                ]
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+
+class TestRandomScaleAffine(BaseTest):
+    def test_random_scale_affine_scale(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[1, 0.975, 1.025, 0.95, 1.05])
+        self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
+
+    def test_random_scale_affine_scale_distributions(self) -> None:
+        scale = torch.distributions.Uniform(0.95, 1.05)
+        scale_module = transforms.RandomScaleAffine(scale=scale)
+        self.assertIsInstance(
+            scale_module.scale_distribution,
+            torch.distributions.distribution.Distribution,
+        )
+
+    def test_random_scale_affine_downscaling(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[0.5])
+        test_tensor = torch.ones(1, 3, 3, 3)
+
+        assertTensorAlmostEqual(
+            self,
+            scale_module._scale_tensor(test_tensor, 0.5),
+            torch.ones(3, 1).repeat(3, 1, 3).unsqueeze(0),
+            0,
+        )
+
+    def test_random_scale_affine_upscaling(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[1.5])
+        test_tensor = torch.ones(1, 3, 3, 3)
+
+        assertTensorAlmostEqual(
+            self,
+            scale_module._scale_tensor(test_tensor, 1.5),
+            torch.tensor(
+                [
+                    [0.2500, 0.5000, 0.2500],
+                    [0.5000, 1.0000, 0.5000],
+                    [0.2500, 0.5000, 0.2500],
+                ]
+            )
+            .repeat(3, 1, 1)
+            .unsqueeze(0),
+            0,
+        )
+
+    def test_random_scale_affine_matrix(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[0.5])
+        test_tensor = torch.ones(1, 3, 3, 3)
+        # Test scale matrices
+
+        assertTensorAlmostEqual(
+            self,
+            scale_module._get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
+            torch.tensor([[0.5000, 0.0000, 0.0000], [0.0000, 0.5000, 0.0000]]),
+            0,
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scale_module._get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
+            torch.tensor([[1.2400, 0.0000, 0.0000], [0.0000, 1.2400, 0.0000]]),
+            0,
+        )
+
+    def test_random_scale_affine_forward(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[0.5])
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = scale_module(test_tensor)
+        self.assertEqual(list(output_tensor.shape), list(test_tensor.shape))
+
+    def test_random_scale_affine_forward_distributions(self) -> None:
+        scale = torch.distributions.Uniform(0.95, 1.05)
+        scale_module = transforms.RandomScaleAffine(scale=scale)
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = scale_module(test_tensor)
+        self.assertEqual(list(output_tensor.shape), list(test_tensor.shape))
+
+    def test_random_scale_affine_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RandomScaleAffine JIT module test due to insufficient"
+                + " Torch version."
+            )
+        scale_module = transforms.RandomScaleAffine(scale=[1.5])
         jit_scale_module = torch.jit.script(scale_module)
         test_tensor = torch.ones(1, 3, 3, 3)
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -582,6 +582,24 @@ class TestCenterCropFunction(BaseTest):
         )
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
+    def test_center_crop_padding(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
     def test_center_crop_one_number_exact_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(


### PR DESCRIPTION
* Replace Affine `RandomScale` with Interpolation based variant. Renamed old variant to `RandomScaleAffine`.
* `CenterCrop` / `center_crop` now adds padding if the crop size is larger than the input dimensions.
* Add distributions support to both versions of `RandomScale`.
* Improve transform tests.