### PR TITLE
Add TransformationRobustness transform

### DIFF
--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -1071,7 +1071,7 @@ class TransformationRobustness(nn.Module):
         else:
             self.jitter_transforms = translate
         self.random_scale = None if scale is None else RandomScale(scale)
-        self.random_rotation = None #if degrees is None else RandomRotation(degrees)
+        self.random_rotation = None  # if degrees is None else RandomRotation(degrees)
         self.final_jitter = (
             None if final_translate is None else RandomSpatialJitter(final_translate)
         )

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -1015,7 +1015,7 @@ class TransformationRobustness(nn.Module):
     inputs.
     """
 
-    __constants__ = ["crop_output"]
+    __constants__ = ["crop_or_pad_output"]
 
     def __init__(
         self,

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -1004,6 +1004,111 @@ class RandomCrop(nn.Module):
         return self._center_crop(x)
 
 
+class TransformationRobustness(nn.Module):
+    """
+    This transform combines the standard transforms together for ease of use.
+
+    Multiple jitter transforms can be used to create roughly gaussian distribution
+    of jitter.
+
+    Outputs can be optionally cropped or padded so that they have the same shape as
+    inputs.
+    """
+
+    __constants__ = ["crop_output"]
+
+    def __init__(
+        self,
+        padding_transform: Optional[nn.Module] = None,
+        translate: Optional[Union[int, List[int]]] = [4] * 10,
+        scale: Optional[NumSeqOrTensorOrProbDistType] = [
+            0.995 ** n for n in range(-5, 80)
+        ]
+        + [0.998 ** n for n in 2 * list(range(20, 40))],
+        degrees: Optional[NumSeqOrTensorOrProbDistType] = list(range(-20, 20))
+        + list(range(-10, 10))
+        + list(range(-5, 5))
+        + 5 * [0],
+        final_translate: Optional[int] = 2,
+        crop_or_pad_output: bool = False,
+    ) -> None:
+        """
+        Args:
+
+            padding_transform (nn.Module, optional): A padding module instance. No
+                padding will be applied before transforms if set to None.
+                Default: None
+            translate (int or list of int, optional): The max horizontal and vertical
+                 translation to use for each jitter transform.
+                 Default: [4] * 10
+            scale (float, sequence, or torch.distribution, optional): Sequence of
+                rescaling values to randomly select from, or a torch.distributions
+                instance. If set to None, no rescaling transform will be used.
+                Default: A set of optimal values.
+            degrees (float, sequence, or torch.distribution, optional): Sequence of
+                degrees to randomly select from, or a torch.distributions
+                instance. If set to None, no rotation transform will be used.
+                Default: A set of optimal values.
+            final_translate (int, optional): The max horizontal and vertical
+                 translation to use for the final jitter transform on fractional
+                 pixels.
+                 Default: 2
+            crop_or_pad_output (bool, optional): Whether or not to crop or pad the
+                transformed output so that it is the same shape as the input.
+                Default: False
+        """
+        super().__init__()
+        self.padding_transform = padding_transform
+        if translate is not None:
+            jitter_transforms = []
+            if hasattr(translate, "__iter__"):
+                jitter_transforms = []
+                for t in translate:
+                    jitter_transforms.append(RandomSpatialJitter(t))
+                self.jitter_transforms = nn.Sequential(*jitter_transforms)
+            else:
+                self.jitter_transforms = RandomSpatialJitter(translate)
+        else:
+            self.jitter_transforms = translate
+        self.random_scale = None if scale is None else RandomScale(scale)
+        self.random_rotation = None #if degrees is None else RandomRotation(degrees)
+        self.final_jitter = (
+            None if final_translate is None else RandomSpatialJitter(final_translate)
+        )
+        self.crop_or_pad_output = crop_or_pad_output
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        assert x.dim() == 4
+        crop_size = x.shape[2:]
+
+        # Apply padding if enabled
+        if self.padding_transform is not None:
+            x = self.padding_transform(x)
+
+        # Jitter real pixels
+        if self.jitter_transforms is not None:
+            x = self.jitter_transforms(x)
+
+        # Apply Random Scaling, turning real pixels into
+        # fractional values of real pixels
+        if self.random_scale is not None:
+            x = self.random_scale(x)
+
+        # Apply Random Rotation
+        if self.random_rotation is not None:
+            x = self.random_rotation(x)
+
+        # Jitter fractional pixels if random_scale is not None
+        if self.final_jitter is not None:
+            x = self.final_jitter(x)
+
+        # Ensure the output is the same shape as the input
+        if self.crop_or_pad_output:
+            x = center_crop(x, size=crop_size)
+            assert x.shape[2:] == crop_size
+        return x
+
+
 __all__ = [
     "BlendAlpha",
     "IgnoreAlpha",
@@ -1018,4 +1123,5 @@ __all__ = [
     "SymmetricPadding",
     "NChannelsToRGB",
     "RandomCrop",
+    "TransformationRobustness",
 ]

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -336,8 +336,8 @@ def center_crop(
         if size[0] > h or size[1] > w:
             # Padding functionality like Torchvision's center crop
             padding = [
-                (size[1] - w) // 2 if size[1] > w else 0,
-                (size[0] - h) // 2 if size[0] > h else 0,
+                math.ceil((size[1] - w) / 2) if size[1] > w else 0,
+                math.ceil((size[0] - h) / 2) if size[0] > h else 0,
                 (size[1] - w + 1) // 2 if size[1] > w else 0,
                 (size[0] - h + 1) // 2 if size[0] > h else 0,
             ]

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -179,7 +179,8 @@ class ToRGB(nn.Module):
 
 class CenterCrop(torch.nn.Module):
     """
-    Center crop a specified amount from a tensor.
+    Center crop a specified amount from a tensor. If input are smaller than the
+    specified crop size, padding will be applied.
     """
 
     __constants__ = [
@@ -272,7 +273,8 @@ def center_crop(
     padding_value: float = 0.0,
 ) -> torch.Tensor:
     """
-    Center crop a specified amount from a tensor.
+    Center crop a specified amount from a tensor. If input are smaller than the
+    specified crop size, padding will be applied.
 
     Args:
 

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -414,7 +414,7 @@ class RandomScale(nn.Module):
         dtype: torch.dtype,
     ) -> torch.Tensor:
         """
-        Create a rotation matrix tensor.
+        Create a scale matrix tensor.
 
         Args:
 
@@ -562,7 +562,7 @@ class RandomScaleAffine(nn.Module):
         dtype: torch.dtype,
     ) -> torch.Tensor:
         """
-        Create a rotation matrix tensor.
+        Create a scale matrix tensor.
 
         Args:
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -437,6 +437,47 @@ class TestCenterCrop(BaseTest):
         cropped_tensor = crop_mod(px)
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
+    def test_center_crop_padding(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
+        cropped_tensor = center_crop_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_padding_prime_num_pad(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+        
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
+
+        cropped_tensor = center_crop_module(test_tensor)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [2, 1, 2, 1])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_padding_prime_num_pad_offset_left(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=True)
+
+        cropped_tensor = center_crop_module(test_tensor)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [1, 2, 1, 2])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
     def test_center_crop_one_number_exact_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
@@ -469,6 +510,26 @@ class TestCenterCrop(BaseTest):
             ]
             * 3
         ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_padding_jit_module(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
+        jit_center_crop = torch.jit.script(center_crop_module)
+        cropped_tensor = jit_center_crop(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1232,7 +1232,7 @@ class TestTransformationRobustness(BaseTest):
 
     def test_transform_robustness_forward_all_disabled(self) -> None:
         transform_robustness = transforms.TransformationRobustness(
-            padding_transform=False,
+            padding_transform=None,
             translate=None,
             scale=None,
             degrees=None,

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1216,9 +1216,9 @@ class TestTransformationRobustness(BaseTest):
         self.assertTrue(torch.is_tensor(test_output))
 
     def test_transform_robustness_forward_crop_output(self) -> None:
-        transform_robustness = transforms.TransformationRobustness()
+        transform_robustness = transforms.TransformationRobustness(crop_or_pad_output=True)
         test_input = torch.ones(1, 3, 224, 224)
-        test_output = transform_robustness(test_input, crop_or_pad_output=True)
+        test_output = transform_robustness(test_input)
         self.assertEqual(test_output.shape, test_input.shape)
 
     def test_transform_robustness_forward_padding_crop_output(self) -> None:

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -459,7 +459,7 @@ class TestCenterCrop(BaseTest):
     def test_center_crop_padding_prime_num_pad(self) -> None:
         test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
         crop_vals = [6, 6]
-        
+
         center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
 
         cropped_tensor = center_crop_module(test_tensor)
@@ -674,7 +674,9 @@ class TestCenterCropFunction(BaseTest):
         test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
         crop_vals = [6, 6]
 
-        cropped_tensor = transforms.center_crop(test_tensor, crop_vals, offset_left=True)
+        cropped_tensor = transforms.center_crop(
+            test_tensor, crop_vals, offset_left=True
+        )
 
         expected_tensor = torch.nn.functional.pad(test_tensor, [1, 2, 1, 2])
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
@@ -1184,9 +1186,9 @@ class TestTransformationRobustness(BaseTest):
         for module in transform_robustness.jitter_transforms:
             self.assertIsInstance(module, transforms.RandomSpatialJitter)
         self.assertIsInstance(transform_robustness.random_scale, transforms.RandomScale)
-        #self.assertIsInstance(
+        # self.assertIsInstance(
         #    transform_robustness.random_rotation, transforms.RandomRotation
-        #)
+        # )
         self.assertIsInstance(
             transform_robustness.final_jitter, transforms.RandomSpatialJitter
         )

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -600,6 +600,24 @@ class TestCenterCropFunction(BaseTest):
         )
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
+    def test_center_crop_padding_prime_num_pad(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [2, 1, 2, 1])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_padding_prime_num_pad_offset_left(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals, offset_left=True)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [1, 2, 1, 2])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
     def test_center_crop_one_number_exact_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
@@ -632,6 +650,25 @@ class TestCenterCropFunction(BaseTest):
             * 3
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_padding_jit_module(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        jit_center_crop = torch.jit.script(transforms.center_crop)
+        cropped_tensor = jit_center_crop(test_tensor, crop_vals)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
 
 class TestBlendAlpha(BaseTest):

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1216,7 +1216,9 @@ class TestTransformationRobustness(BaseTest):
         self.assertTrue(torch.is_tensor(test_output))
 
     def test_transform_robustness_forward_crop_output(self) -> None:
-        transform_robustness = transforms.TransformationRobustness(crop_or_pad_output=True)
+        transform_robustness = transforms.TransformationRobustness(
+            crop_or_pad_output=True
+        )
         test_input = torch.ones(1, 3, 224, 224)
         test_output = transform_robustness(test_input)
         self.assertEqual(test_output.shape, test_input.shape)


### PR DESCRIPTION
Similar to Lucid's `standard_transforms`, the `TransformationRobustness()` is a convenient helper for apply to standard set of transforms in the correct order. The default values have also been tuned to optimal values.

Link to Lucid's version: https://github.com/tensorflow/lucid/blob/master/lucid/optvis/transform.py#L164
Ludwig's original PR had the same transform planned: https://github.com/ludwigschubert/captum/blob/f1fd0729dece59564a7c10b7b397617d8a09a247/captum/optim/param/transform.py#L88

* Add `TransformationRobustness()` transform.
* Fixed bug with `center_crop` padding code, and added related tests to `center_crop` & `CenterCrop`.