### PR TITLE
Add asserts & tests for RandomScale transforms

### DIFF
--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -1023,7 +1023,7 @@ class TransformationRobustness(nn.Module):
 
     def __init__(
         self,
-        padding_transform: Optional[nn.Module] = None,
+        padding_transform: Optional[nn.Module] = nn.ConstantPad2d(2, value=0.5),
         translate: Optional[Union[int, List[int]]] = [4] * 10,
         scale: Optional[NumSeqOrTensorOrProbDistType] = [
             0.995 ** n for n in range(-5, 80)
@@ -1041,7 +1041,7 @@ class TransformationRobustness(nn.Module):
 
             padding_transform (nn.Module, optional): A padding module instance. No
                 padding will be applied before transforms if set to None.
-                Default: None
+                Default: nn.ConstantPad2d(2, value=0.5)
             translate (int or list of int, optional): The max horizontal and vertical
                  translation to use for each jitter transform.
                  Default: [4] * 10

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -408,27 +408,6 @@ class RandomScale(nn.Module):
         self._has_align_corners = torch.__version__ >= "1.3.0"
         self._has_recompute_scale_factor = torch.__version__ >= "1.6.0"
 
-    def _get_scale_mat(
-        self,
-        m: float,
-        device: torch.device,
-        dtype: torch.dtype,
-    ) -> torch.Tensor:
-        """
-        Create a scale matrix tensor.
-
-        Args:
-
-            m (float): The scale value to use.
-
-        Returns:
-            **scale_mat** (torch.Tensor): A scale matrix.
-        """
-        scale_mat = torch.tensor(
-            [[m, 0.0, 0.0], [0.0, m, 0.0]], device=device, dtype=dtype
-        )
-        return scale_mat
-
     def _scale_tensor(self, x: torch.Tensor, scale: float) -> torch.Tensor:
         """
         Scale an NCHW image tensor based on a specified scale value.

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -390,6 +390,7 @@ class RandomScale(nn.Module):
         super().__init__()
         if isinstance(scale, torch.distributions.distribution.Distribution):
             # Distributions are not supported by TorchScript / JIT yet
+            assert list(scale.batch_shape) == []
             self.scale_distribution = scale
             self.is_distribution = True
             self.scale = []

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -390,7 +390,7 @@ class RandomScale(nn.Module):
         super().__init__()
         if isinstance(scale, torch.distributions.distribution.Distribution):
             # Distributions are not supported by TorchScript / JIT yet
-            assert list(scale.batch_shape) == []
+            assert scale.batch_shape == torch.Size([])
             self.scale_distribution = scale
             self.is_distribution = True
             self.scale = []
@@ -540,6 +540,7 @@ class RandomScaleAffine(nn.Module):
         super().__init__()
         if isinstance(scale, torch.distributions.distribution.Distribution):
             # Distributions are not supported by TorchScript / JIT yet
+            assert scale.batch_shape == torch.Size([])
             self.scale_distribution = scale
             self.is_distribution = True
             self.scale = []

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1646,7 +1646,7 @@ class TestTransformationRobustness(BaseTest):
 
     def test_transform_robustness_init_transform_values(self) -> None:
         transform_robustness = transforms.TransformationRobustness()
-        self.assertEqual(transform_robustness.padding_transform.padding, 2)
+        self.assertEqual(transform_robustness.padding_transform.padding, (2, 2, 2, 2))
         self.assertEqual(transform_robustness.padding_transform.value, 0.5)
 
         self.assertEqual(len(transform_robustness.jitter_transforms), 10)
@@ -1660,6 +1660,7 @@ class TestTransformationRobustness(BaseTest):
         # expected_degrees = (
         #    list(range(-20, 20)) + list(range(-10, 10)) + list(range(-5, 5)) + 5 * [0]
         # )
+        # expected_degrees = [float(d) for d in expected_degrees]
         # self.assertEqual(
         #    transform_robustness.random_rotation.degrees, test_expected_degrees
         # )

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -997,21 +997,32 @@ class TestIgnoreAlpha(BaseTest):
 
 
 class TestToRGB(BaseTest):
+    def test_to_rgb_init(self) -> None:
+        to_rgb = transforms.ToRGB()
+        self.assertEqual(list(to_rgb.transform.shape), [3, 3])
+        transform = torch.tensor([[ 0.5628,  0.1948,  0.0433], [ 0.5845,  0.0000, -0.1082], [ 0.5845, -0.1948,  0.0649]])
+        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.0)
+
     def test_to_rgb_i1i2i3(self) -> None:
         to_rgb = transforms.ToRGB(transform="i1i2i3")
         to_rgb_np = numpy_transforms.ToRGB(transform="i1i2i3")
         assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
+        transform = torch.tensor([[ 0.3333,  0.3333,  0.3333], [ 0.5000,  0.0000, -0.5000], [-0.2500,  0.5000, -0.2500]])
+        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.0)
 
     def test_to_rgb_klt(self) -> None:
         to_rgb = transforms.ToRGB(transform="klt")
         to_rgb_np = numpy_transforms.ToRGB(transform="klt")
         assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
+        transform = torch.tensor([[ 0.5628,  0.1948,  0.0433], [ 0.5845,  0.0000, -0.1082], [ 0.5845, -0.1948,  0.0649]])
+        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.0)
 
     def test_to_rgb_custom(self) -> None:
         matrix = torch.eye(3, 3)
         to_rgb = transforms.ToRGB(transform=matrix)
         to_rgb_np = numpy_transforms.ToRGB(transform=matrix.numpy())
         assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
+        assertTensorAlmostEqual(self, to_rgb.transform, matrix, 0.0)
 
     def test_to_rgb_klt_forward(self) -> None:
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -503,7 +503,7 @@ class TestCenterCrop(BaseTest):
         self.assertEqual(crop_module.padding_mode, "constant")
         self.assertEqual(crop_module.padding_value, 0.0)
 
-    def test_center_crop_one_number(self) -> None:
+    def test_center_crop_forward_one_number(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
             F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
@@ -524,7 +524,28 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_one_number_list(self) -> None:
+    def test_center_crop_forward_one_number_dim_3(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+        )
+        crop_vals = 3
+
+        crop_tensor = transforms.CenterCrop(crop_vals, True)
+        cropped_tensor = crop_tensor(test_tensor)
+
+        crop_mod_np = numpy_transforms.CenterCrop(crop_vals, True)
+        cropped_array = crop_mod_np.forward(test_tensor.numpy())
+
+        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        expected_tensor = torch.stack(
+            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
+        )
+        self.assertEqual(cropped_tensor.shape, expected_tensor.shape)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_forward_one_number_list(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
             F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
@@ -557,7 +578,7 @@ class TestCenterCrop(BaseTest):
         with self.assertRaises(ValueError):
             crop_tensor = transforms.CenterCrop(crop_vals, True)
 
-    def test_center_crop_two_numbers(self) -> None:
+    def test_center_crop_forward_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
             F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
@@ -578,7 +599,7 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_one_number_exact(self) -> None:
+    def test_center_crop_forward_one_number_exact(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
             F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
@@ -611,7 +632,7 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_two_numbers_exact(self) -> None:
+    def test_center_crop_forward_two_numbers_exact(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
             F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
@@ -634,7 +655,7 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_offset_left_uneven_sides(self) -> None:
+    def test_center_crop_forward_offset_left_uneven_sides(self) -> None:
         crop_mod = transforms.CenterCrop(
             [5, 5], pixels_from_edges=False, offset_left=True
         )
@@ -643,7 +664,7 @@ class TestCenterCrop(BaseTest):
         cropped_tensor = crop_mod(px)
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
-    def test_center_crop_offset_left_even_sides(self) -> None:
+    def test_center_crop_forward_offset_left_even_sides(self) -> None:
         crop_mod = transforms.CenterCrop(
             [5, 5], pixels_from_edges=False, offset_left=True
         )
@@ -652,7 +673,7 @@ class TestCenterCrop(BaseTest):
         cropped_tensor = crop_mod(px)
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
-    def test_center_crop_padding(self) -> None:
+    def test_center_crop_forward_padding(self) -> None:
         test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
         crop_vals = [6, 6]
 
@@ -671,7 +692,7 @@ class TestCenterCrop(BaseTest):
         )
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_padding_prime_num_pad(self) -> None:
+    def test_center_crop_forward_padding_prime_num_pad(self) -> None:
         test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
         crop_vals = [6, 6]
 
@@ -682,7 +703,7 @@ class TestCenterCrop(BaseTest):
         expected_tensor = torch.nn.functional.pad(test_tensor, [2, 1, 2, 1])
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
 
-    def test_center_crop_padding_prime_num_pad_offset_left(self) -> None:
+    def test_center_crop_forward_padding_prime_num_pad_offset_left(self) -> None:
         test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
         crop_vals = [6, 6]
 
@@ -693,7 +714,7 @@ class TestCenterCrop(BaseTest):
         expected_tensor = torch.nn.functional.pad(test_tensor, [1, 2, 1, 2])
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
 
-    def test_center_crop_one_number_exact_jit_module(self) -> None:
+    def test_center_crop_forward_one_number_exact_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
                 "Skipping CenterCrop JIT module test due to insufficient"
@@ -727,7 +748,7 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_padding_jit_module(self) -> None:
+    def test_center_crop_forward_padding_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
                 "Skipping CenterCrop padding JIT module test due to insufficient"
@@ -772,6 +793,26 @@ class TestCenterCropFunction(BaseTest):
         expected_tensor = torch.stack(
             [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
         ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_one_number_dim_3(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+        )
+        crop_vals = 3
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
+        cropped_array = numpy_transforms.center_crop(
+            test_tensor.numpy(), crop_vals, True
+        )
+
+        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        expected_tensor = torch.stack(
+            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
+        )
+        self.assertEqual(cropped_tensor.shape, expected_tensor.shape)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
 
     def test_center_crop_one_number_list(self) -> None:

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -843,7 +843,7 @@ class TestCenterCropFunction(BaseTest):
         crop_vals = [3, 3, 3]
 
         with self.assertRaises(ValueError):
-            cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
+            transforms.center_crop(test_tensor, crop_vals, True)
 
     def test_center_crop_str_value_error(self) -> None:
         pad = (1, 1, 1, 1)
@@ -855,7 +855,7 @@ class TestCenterCropFunction(BaseTest):
         crop_vals = "error"
 
         with self.assertRaises(ValueError):
-            cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
+            transforms.center_crop(test_tensor, crop_vals, True)
 
     def test_center_crop_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1090,6 +1090,29 @@ class TestToRGB(BaseTest):
             self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
         )
 
+    def test_to_rgb_alpha_klt_forward_dim_3(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping ToRGB with Alpha forward dim 3 due to"
+                + " insufficient Torch version."
+            )
+        to_rgb = transforms.ToRGB(transform="klt")
+        test_tensor = torch.ones(4, 4, 4).refine_names("C", "H", "W")
+        rgb_tensor = to_rgb(test_tensor)
+
+        r = torch.ones(4, 4) * 0.8009
+        g = torch.ones(4, 4) * 0.4762
+        b = torch.ones(4, 4) * 0.4546
+        a = torch.ones(4, 4)
+        expected_rgb_tensor = torch.stack([r, g, b, a])
+
+        assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+
+        inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
+        assertTensorAlmostEqual(
+            self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
+        )
+
     def test_to_rgb_i1i2i3_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1156,6 +1156,18 @@ class TestToRGB(BaseTest):
 
 
 class TestGaussianSmoothing(BaseTest):
+    def test_gaussian_smoothing_init_1d(self) -> None:
+        channels = 6
+        kernel_size = 3
+        sigma = 2.0
+        dim = 1
+        smoothening_module = transforms.GaussianSmoothing(
+            channels, kernel_size, sigma, dim
+        )
+        self.assertEqual(smoothening_module.groups, channels)
+        weight = torch.tensor([[0.3192, 0.3617, 0.3192]]).repeat(6, 1, 1)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0)
+
     def test_gaussian_smoothing_init_2d(self) -> None:
         channels = 3
         kernel_size = 3
@@ -1166,6 +1178,28 @@ class TestGaussianSmoothing(BaseTest):
         )
         self.assertEqual(smoothening_module.groups, channels)
         weight = torch.tensor([[[0.1019, 0.1154, 0.1019], [0.1154, 0.1308, 0.1154], [0.1019, 0.1154, 0.1019]]]).repeat(3, 1, 1, 1)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0)
+
+    def test_gaussian_smoothing_init_3d(self) -> None:
+        channels = 4
+        kernel_size = 3
+        sigma = 1.021
+        dim = 3
+        smoothening_module = transforms.GaussianSmoothing(
+            channels, kernel_size, sigma, dim
+        )
+        self.assertEqual(smoothening_module.groups, channels)
+        weight = torch.tensor([[[[0.0212, 0.0342, 0.0212],
+          [0.0342, 0.0552, 0.0342],
+          [0.0212, 0.0342, 0.0212]],
+
+         [[0.0342, 0.0552, 0.0342],
+          [0.0552, 0.0892, 0.0552],
+          [0.0342, 0.0552, 0.0342]],
+
+         [[0.0212, 0.0342, 0.0212],
+          [0.0342, 0.0552, 0.0342],
+          [0.0212, 0.0342, 0.0212]]]]).repeat(4,1,1,1,1)
         assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0)
 
     def test_gaussian_smoothing_1d(self) -> None:

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -27,8 +27,7 @@ class TestRandomScale(BaseTest):
     def test_random_scale_tensor_scale(self) -> None:
         scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])
         scale_module = transforms.RandomScale(scale=scale)
-        expected_scale = torch.tensor([1.0, 0.975, 1.025, 0.95, 1.05]).tolist()
-        self.assertEqual(scale_module.scale, expected_scale)
+        self.assertEqual(scale_module.scale, scale.tolist())
 
     def test_random_scale_int_scale(self) -> None:
         scale = [1, 2, 3, 4, 5]
@@ -251,8 +250,7 @@ class TestRandomScaleAffine(BaseTest):
     def test_random_scale_affine_tensor_scale(self) -> None:
         scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])
         scale_module = transforms.RandomScaleAffine(scale=scale)
-        expected_scale = torch.tensor([1.0, 0.975, 1.025, 0.95, 1.05]).tolist()
-        self.assertEqual(scale_module.scale, expected_scale)
+        self.assertEqual(scale_module.scale, scale.tolist())
 
     def test_random_scale_affine_int_scale(self) -> None:
         scale = [1, 2, 3, 4, 5]

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -927,6 +927,10 @@ class TestCenterCropFunction(BaseTest):
 
 
 class TestBlendAlpha(BaseTest):
+    def test_blend_alpha_init(self) -> None:
+        blend_alpha = transforms.BlendAlpha(background=None)
+        self.assertIsNone(blend_alpha.background)
+
     def test_blend_alpha(self) -> None:
         rgb_tensor = torch.ones(3, 3, 3)
         alpha_tensor = ((torch.eye(3, 3) + torch.eye(3, 3).flip(1)) / 2).repeat(1, 1, 1)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -108,25 +108,6 @@ class TestRandomScale(BaseTest):
             0,
         )
 
-    def test_random_scale_matrix(self) -> None:
-        scale_module = transforms.RandomScale(scale=[0.5])
-        test_tensor = torch.ones(1, 3, 3, 3)
-        # Test scale matrices
-
-        assertTensorAlmostEqual(
-            self,
-            scale_module._get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
-            torch.tensor([[0.5000, 0.0000, 0.0000], [0.0000, 0.5000, 0.0000]]),
-            0,
-        )
-
-        assertTensorAlmostEqual(
-            self,
-            scale_module._get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
-            torch.tensor([[1.2400, 0.0000, 0.0000], [0.0000, 1.2400, 0.0000]]),
-            0,
-        )
-
     def test_random_forward_exact(self) -> None:
         scale_module = transforms.RandomScale(scale=[0.5])
         test_tensor = torch.arange(0, 1 * 1 * 10 * 10).view(1, 1, 10, 10).float()
@@ -292,6 +273,25 @@ class TestRandomScaleAffine(BaseTest):
         _has_align_corners = torch.__version__ >= "1.3.0"
         self.assertEqual(scale_module._has_align_corners, _has_align_corners)
 
+    def test_random_scale_affine_matrix(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[0.5])
+        test_tensor = torch.ones(1, 3, 3, 3)
+        # Test scale matrices
+
+        assertTensorAlmostEqual(
+            self,
+            scale_module._get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
+            torch.tensor([[0.5000, 0.0000, 0.0000], [0.0000, 0.5000, 0.0000]]),
+            0,
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scale_module._get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
+            torch.tensor([[1.2400, 0.0000, 0.0000], [0.0000, 1.2400, 0.0000]]),
+            0,
+        )
+
     def test_random_scale_affine_downscaling(self) -> None:
         scale_module = transforms.RandomScaleAffine(scale=[0.5])
         test_tensor = torch.ones(1, 3, 3, 3)
@@ -319,25 +319,6 @@ class TestRandomScaleAffine(BaseTest):
             )
             .repeat(3, 1, 1)
             .unsqueeze(0),
-            0,
-        )
-
-    def test_random_scale_affine_matrix(self) -> None:
-        scale_module = transforms.RandomScaleAffine(scale=[0.5])
-        test_tensor = torch.ones(1, 3, 3, 3)
-        # Test scale matrices
-
-        assertTensorAlmostEqual(
-            self,
-            scale_module._get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
-            torch.tensor([[0.5000, 0.0000, 0.0000], [0.0000, 0.5000, 0.0000]]),
-            0,
-        )
-
-        assertTensorAlmostEqual(
-            self,
-            scale_module._get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
-            torch.tensor([[1.2400, 0.0000, 0.0000], [0.0000, 1.2400, 0.0000]]),
             0,
         )
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -326,7 +326,7 @@ class TestRandomScaleAffine(BaseTest):
         scale_module = transforms.RandomScaleAffine(scale=[1.5])
         test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
 
-        output_tensor = scale_module(test_tensor)
+        scaled_tensor = scale_module(test_tensor)
 
         expected_tensor = torch.tensor(
             [
@@ -352,7 +352,7 @@ class TestRandomScaleAffine(BaseTest):
         self.assertEqual(scale_module.mode, "nearest")
         test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
 
-        output_tensor = scale_module(test_tensor)
+        scaled_tensor = scale_module(test_tensor)
         expected_tensor = torch.tensor(
             [
                 [

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1324,6 +1324,10 @@ class TestSymmetricPadding(BaseTest):
 
 
 class TestNChannelsToRGB(BaseTest):
+    def test_nchannels_to_rgb_init(self) -> None:
+        nchannels_to_rgb = transforms.NChannelsToRGB()
+        self.assertFalse(nchannels_to_rgb.warp)
+
     def test_nchannels_to_rgb_collapse(self) -> None:
         test_input = torch.randn(1, 6, 224, 224)
         nchannels_to_rgb = transforms.NChannelsToRGB()

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -569,13 +569,13 @@ class TestCenterCrop(BaseTest):
         crop_vals = [3, 3, 3]
 
         with self.assertRaises(ValueError):
-            crop_tensor = transforms.CenterCrop(crop_vals, True)
+            transforms.CenterCrop(crop_vals, True)
 
     def test_center_crop_str_value_error(self) -> None:
         crop_vals = "error"
 
         with self.assertRaises(ValueError):
-            crop_tensor = transforms.CenterCrop(crop_vals, True)
+            transforms.CenterCrop(crop_vals, True)
 
     def test_center_crop_forward_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
@@ -1387,9 +1387,7 @@ class TestGaussianSmoothing(BaseTest):
         sigma = 2.0
         dim = 4
         with self.assertRaises(ValueError):
-            smoothening_module = transforms.GaussianSmoothing(
-                channels, kernel_size, sigma, dim
-            )
+            transforms.GaussianSmoothing(channels, kernel_size, sigma, dim)
 
     def test_gaussian_smoothing_1d(self) -> None:
         channels = 6

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -545,6 +545,12 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
+    def test_center_crop_list_len_3_value_error(self) -> None:
+        crop_vals = [3, 3, 3]
+
+        with self.assertRaises(ValueError):
+            crop_tensor = transforms.CenterCrop(crop_vals, True)
+
     def test_center_crop_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
@@ -781,6 +787,18 @@ class TestCenterCropFunction(BaseTest):
             [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_list_len_3_value_error(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        crop_vals = [3, 3, 3]
+
+        with self.assertRaises(ValueError):
+            cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
 
     def test_center_crop_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
@@ -1084,8 +1102,7 @@ class TestToRGB(BaseTest):
         assertTensorAlmostEqual(self, to_rgb.transform, matrix, 0.0)
 
     def test_to_rgb_init_value_error(self) -> None:
-        with self.assertRaises(ValueError, "transform has to be either 'klt'" +
-             ", 'i1i2i3', or a matrix tensor."):
+        with self.assertRaises(ValueError):
              transforms.ToRGB(transform="error")
 
     def test_to_rgb_klt_forward(self) -> None:

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -524,6 +524,27 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
+    def test_center_crop_one_number_list(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        crop_vals = [3]
+
+        crop_tensor = transforms.CenterCrop(crop_vals, True)
+        cropped_tensor = crop_tensor(test_tensor)
+
+        crop_mod_np = numpy_transforms.CenterCrop(crop_vals, True)
+        cropped_array = crop_mod_np.forward(test_tensor.numpy())
+
+        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        expected_tensor = torch.stack(
+            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
     def test_center_crop_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
@@ -729,6 +750,26 @@ class TestCenterCropFunction(BaseTest):
             .unsqueeze(0)
         )
         crop_vals = 3
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
+        cropped_array = numpy_transforms.center_crop(
+            test_tensor.numpy(), crop_vals, True
+        )
+
+        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        expected_tensor = torch.stack(
+            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_one_number_list(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        crop_vals = [3]
 
         cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
         cropped_array = numpy_transforms.center_crop(

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -413,6 +413,13 @@ class TestRandomScaleAffine(BaseTest):
 
 
 class TestRandomSpatialJitter(BaseTest):
+    def test_random_spatial_jitter_init(self) -> None:
+        translate = 3
+        spatialjitter = transforms.RandomSpatialJitter(translate)
+        
+        self.assertEqual(spatialjitter.pad_range, translate * 2)
+        self.assertIsInstance(spatialjitter.pad, torch.nn.ReflectionPad2d)
+
     def test_random_spatial_jitter_hw(self) -> None:
         translate_vals = [4, 4]
         t_val = 3

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -16,10 +16,13 @@ from tests.optim.helpers import numpy_transforms
 
 
 class TestRandomScale(BaseTest):
-    def test_random_scale_scale(self) -> None:
+    def test_random_scale_init(self) -> None:
         scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05])
         self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
         self.assertFalse(scale_module._is_distribution)
+        self.assertEqual(scale_module.mode, "bilinear")
+        self.assertFalse(scale_module.align_corners)
+        self.assertFalse(scale_module.recompute_scale_factor)
 
     def test_random_scale_tensor_scale(self) -> None:
         scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])
@@ -170,10 +173,13 @@ class TestRandomScale(BaseTest):
 
 
 class TestRandomScaleAffine(BaseTest):
-    def test_random_scale_affine_scale(self) -> None:
+    def test_random_scale_affine_init(self) -> None:
         scale_module = transforms.RandomScaleAffine(scale=[1, 0.975, 1.025, 0.95, 1.05])
         self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
         self.assertFalse(scale_module._is_distribution)
+        self.assertEqual(scale_module.mode, "bilinear")
+        self.assertEqual(scale_module.padding_mode, "zeros")
+        self.assertFalse(scale_module.align_corners)
 
     def test_random_scale_affine_tensor_scale(self) -> None:
         scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -495,6 +495,14 @@ class TestRandomSpatialJitter(BaseTest):
 
 
 class TestCenterCrop(BaseTest):
+    def test_center_crop_init(self) -> None:
+        crop_module = transforms.CenterCrop(3)
+        self.assertEqual(crop_module.size , [[3,3])
+        self.assertFalse(crop_module.pixels_from_edges)
+        self.assertFalse(crop_module.offset_left)
+        self.assertEqual(crop_module.padding_mode, "constant")
+        self.assertEqual(crop_module.padding_value , 0.0)
+
     def test_center_crop_one_number(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -341,6 +341,57 @@ class TestRandomScaleAffine(BaseTest):
             0,
         )
 
+    def test_random_scale_affine_forward_exact(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[1.5])
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+
+        output_tensor = scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0000, 0.1875, 0.5625, 0.1875],
+                        [0.7500, 3.7500, 5.2500, 1.5000],
+                        [2.2500, 9.7500, 11.2500, 3.0000],
+                        [0.7500, 3.1875, 3.5625, 0.9375],
+                    ]
+                ]
+            ]
+        )
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_affine_forward_exact_mode_nearest(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[1.5], mode="nearest")
+        self.assertEqual(scale_module.mode, "nearest")
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+
+        output_tensor = scale_module(test_tensor)
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 0.0, 0.0, 0.0],
+                        [0.0, 5.0, 6.0, 0.0],
+                        [0.0, 9.0, 10.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0],
+                    ]
+                ]
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
     def test_random_scale_affine_forward(self) -> None:
         scale_module = transforms.RandomScaleAffine(scale=[0.5])
         test_tensor = torch.ones(1, 3, 10, 10)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -416,7 +416,7 @@ class TestRandomSpatialJitter(BaseTest):
     def test_random_spatial_jitter_init(self) -> None:
         translate = 3
         spatialjitter = transforms.RandomSpatialJitter(translate)
-        
+
         self.assertEqual(spatialjitter.pad_range, translate * 2)
         self.assertIsInstance(spatialjitter.pad, torch.nn.ReflectionPad2d)
 
@@ -497,11 +497,11 @@ class TestRandomSpatialJitter(BaseTest):
 class TestCenterCrop(BaseTest):
     def test_center_crop_init(self) -> None:
         crop_module = transforms.CenterCrop(3)
-        self.assertEqual(crop_module.size , [[3,3])
+        self.assertEqual(crop_module.size, [3, 3])
         self.assertFalse(crop_module.pixels_from_edges)
         self.assertFalse(crop_module.offset_left)
         self.assertEqual(crop_module.padding_mode, "constant")
-        self.assertEqual(crop_module.padding_value , 0.0)
+        self.assertEqual(crop_module.padding_value, 0.0)
 
     def test_center_crop_one_number(self) -> None:
         pad = (1, 1, 1, 1)
@@ -1000,21 +1000,39 @@ class TestToRGB(BaseTest):
     def test_to_rgb_init(self) -> None:
         to_rgb = transforms.ToRGB()
         self.assertEqual(list(to_rgb.transform.shape), [3, 3])
-        transform = torch.tensor([[ 0.5628,  0.1948,  0.0433], [ 0.5845,  0.0000, -0.1082], [ 0.5845, -0.1948,  0.0649]])
+        transform = torch.tensor(
+            [
+                [0.5628, 0.1948, 0.0433],
+                [0.5845, 0.0000, -0.1082],
+                [0.5845, -0.1948, 0.0649],
+            ]
+        )
         assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.0)
 
     def test_to_rgb_i1i2i3(self) -> None:
         to_rgb = transforms.ToRGB(transform="i1i2i3")
         to_rgb_np = numpy_transforms.ToRGB(transform="i1i2i3")
         assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
-        transform = torch.tensor([[ 0.3333,  0.3333,  0.3333], [ 0.5000,  0.0000, -0.5000], [-0.2500,  0.5000, -0.2500]])
+        transform = torch.tensor(
+            [
+                [0.3333, 0.3333, 0.3333],
+                [0.5000, 0.0000, -0.5000],
+                [-0.2500, 0.5000, -0.2500],
+            ]
+        )
         assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.0)
 
     def test_to_rgb_klt(self) -> None:
         to_rgb = transforms.ToRGB(transform="klt")
         to_rgb_np = numpy_transforms.ToRGB(transform="klt")
         assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
-        transform = torch.tensor([[ 0.5628,  0.1948,  0.0433], [ 0.5845,  0.0000, -0.1082], [ 0.5845, -0.1948,  0.0649]])
+        transform = torch.tensor(
+            [
+                [0.5628, 0.1948, 0.0433],
+                [0.5845, 0.0000, -0.1082],
+                [0.5845, -0.1948, 0.0649],
+            ]
+        )
         assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.0)
 
     def test_to_rgb_custom(self) -> None:
@@ -1177,7 +1195,15 @@ class TestGaussianSmoothing(BaseTest):
             channels, kernel_size, sigma, dim
         )
         self.assertEqual(smoothening_module.groups, channels)
-        weight = torch.tensor([[[0.1019, 0.1154, 0.1019], [0.1154, 0.1308, 0.1154], [0.1019, 0.1154, 0.1019]]]).repeat(3, 1, 1, 1)
+        weight = torch.tensor(
+            [
+                [
+                    [0.1019, 0.1154, 0.1019],
+                    [0.1154, 0.1308, 0.1154],
+                    [0.1019, 0.1154, 0.1019],
+                ]
+            ]
+        ).repeat(3, 1, 1, 1)
         assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0)
 
     def test_gaussian_smoothing_init_3d(self) -> None:
@@ -1189,17 +1215,27 @@ class TestGaussianSmoothing(BaseTest):
             channels, kernel_size, sigma, dim
         )
         self.assertEqual(smoothening_module.groups, channels)
-        weight = torch.tensor([[[[0.0212, 0.0342, 0.0212],
-          [0.0342, 0.0552, 0.0342],
-          [0.0212, 0.0342, 0.0212]],
-
-         [[0.0342, 0.0552, 0.0342],
-          [0.0552, 0.0892, 0.0552],
-          [0.0342, 0.0552, 0.0342]],
-
-         [[0.0212, 0.0342, 0.0212],
-          [0.0342, 0.0552, 0.0342],
-          [0.0212, 0.0342, 0.0212]]]]).repeat(4,1,1,1,1)
+        weight = torch.tensor(
+            [
+                [
+                    [
+                        [0.0212, 0.0342, 0.0212],
+                        [0.0342, 0.0552, 0.0342],
+                        [0.0212, 0.0342, 0.0212],
+                    ],
+                    [
+                        [0.0342, 0.0552, 0.0342],
+                        [0.0552, 0.0892, 0.0552],
+                        [0.0342, 0.0552, 0.0342],
+                    ],
+                    [
+                        [0.0212, 0.0342, 0.0212],
+                        [0.0342, 0.0552, 0.0342],
+                        [0.0212, 0.0342, 0.0212],
+                    ],
+                ]
+            ]
+        ).repeat(4, 1, 1, 1, 1)
         assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0)
 
     def test_gaussian_smoothing_1d(self) -> None:

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -551,6 +551,12 @@ class TestCenterCrop(BaseTest):
         with self.assertRaises(ValueError):
             crop_tensor = transforms.CenterCrop(crop_vals, True)
 
+    def test_center_crop_str_value_error(self) -> None:
+        crop_vals = "error"
+
+        with self.assertRaises(ValueError):
+            crop_tensor = transforms.CenterCrop(crop_vals, True)
+
     def test_center_crop_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
@@ -796,6 +802,18 @@ class TestCenterCropFunction(BaseTest):
             .unsqueeze(0)
         )
         crop_vals = [3, 3, 3]
+
+        with self.assertRaises(ValueError):
+            cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
+
+    def test_center_crop_str_value_error(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        crop_vals = "error"
 
         with self.assertRaises(ValueError):
             cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1007,7 +1007,7 @@ class TestToRGB(BaseTest):
                 [0.5845, -0.1948, 0.0649],
             ]
         )
-        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.0)
+        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.001)
 
     def test_to_rgb_i1i2i3(self) -> None:
         to_rgb = transforms.ToRGB(transform="i1i2i3")

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1227,9 +1227,17 @@ class TestTransformationRobustness(BaseTest):
         test_output = transform_robustness(test_input)
         self.assertTrue(torch.is_tensor(test_output))
 
+    def test_transform_robustness_forward_no_padding(self) -> None:
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=None
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertTrue(torch.is_tensor(test_output))
+
     def test_transform_robustness_forward_crop_output(self) -> None:
         transform_robustness = transforms.TransformationRobustness(
-            crop_or_pad_output=True
+             padding_transform=None, crop_or_pad_output=True
         )
         test_input = torch.ones(1, 3, 224, 224)
         test_output = transform_robustness(test_input)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -27,7 +27,8 @@ class TestRandomScale(BaseTest):
     def test_random_scale_tensor_scale(self) -> None:
         scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])
         scale_module = transforms.RandomScale(scale=scale)
-        self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
+        expected_scale = torch.tensor([1.0, 0.975, 1.025, 0.95, 1.05]).tolist()
+        self.assertEqual(scale_module.scale, expected_scale)
 
     def test_random_scale_int_scale(self) -> None:
         scale = [1, 2, 3, 4, 5]
@@ -250,7 +251,8 @@ class TestRandomScaleAffine(BaseTest):
     def test_random_scale_affine_tensor_scale(self) -> None:
         scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])
         scale_module = transforms.RandomScaleAffine(scale=scale)
-        self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
+        expected_scale = torch.tensor([1.0, 0.975, 1.025, 0.95, 1.05]).tolist()
+        self.assertEqual(scale_module.scale, expected_scale)
 
     def test_random_scale_affine_int_scale(self) -> None:
         scale = [1, 2, 3, 4, 5]

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1141,6 +1141,18 @@ class TestToRGB(BaseTest):
 
 
 class TestGaussianSmoothing(BaseTest):
+    def test_gaussian_smoothing_init_2d(self) -> None:
+        channels = 3
+        kernel_size = 3
+        sigma = 2.0
+        dim = 2
+        smoothening_module = transforms.GaussianSmoothing(
+            channels, kernel_size, sigma, dim
+        )
+        self.assertEqual(smoothening_module.groups, channels)
+        weight = torch.tensor([[[0.1019, 0.1154, 0.1019], [0.1154, 0.1308, 0.1154], [0.1019, 0.1154, 0.1019]]]).repeat(3, 1, 1, 1)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0)
+
     def test_gaussian_smoothing_1d(self) -> None:
         channels = 6
         kernel_size = 3

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1042,6 +1042,11 @@ class TestToRGB(BaseTest):
         assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
         assertTensorAlmostEqual(self, to_rgb.transform, matrix, 0.0)
 
+    def test_to_rgb_init_value_error(self) -> None:
+        with self.assertRaises(ValueError, "transform has to be either 'klt'" +
+             ", 'i1i2i3', or a matrix tensor."):
+             transforms.ToRGB(transform="error")
+
     def test_to_rgb_klt_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -32,8 +32,14 @@ class TestRandomScale(BaseTest):
 
     def test_random_scale_torch_version_check(self) -> None:
         scale_module = transforms.RandomScale([1.0])
-        _has_align_corners = torch.__version__ >= "1.3.0"
-        self.assertEqual(scale_module._has_align_corners, _has_align_corners)
+
+        has_align_corners = torch.__version__ >= "1.3.0"
+        self.assertEqual(scale_module._has_align_corners, has_align_corners)
+
+        has_recompute_scale_factor = torch.__version__ >= "1.6.0"
+        self.assertEqual(
+            scale_module._has_recompute_scale_factor, has_recompute_scale_factor
+        )
 
     def test_random_scale_downscaling(self) -> None:
         scale_module = transforms.RandomScale(scale=[0.5])

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -127,6 +127,91 @@ class TestRandomScale(BaseTest):
             0,
         )
 
+    def test_random_forward_exact(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5])
+        test_tensor = torch.arange(0, 1 * 1 * 10 * 10).view(1, 1, 10, 10).float()
+
+        scaled_tensor = scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [5.5000, 7.5000, 9.5000, 11.5000, 13.5000],
+                        [25.5000, 27.5000, 29.5000, 31.5000, 33.5000],
+                        [45.5000, 47.5000, 49.5000, 51.5000, 53.5000],
+                        [65.5000, 67.5000, 69.5000, 71.5000, 73.5000],
+                        [85.5000, 87.5000, 89.5000, 91.5000, 93.5000],
+                    ]
+                ]
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_forward_exact_nearest(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5], mode="nearest")
+        self.assertIsNone(scale_module.align_corners)
+        self.assertEqual(scale_module.mode, "nearest")
+
+        test_tensor = torch.arange(0, 1 * 1 * 10 * 10).view(1, 1, 10, 10).float()
+
+        scaled_tensor = scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 2.0, 4.0, 6.0, 8.0],
+                        [20.0, 22.0, 24.0, 26.0, 28.0],
+                        [40.0, 42.0, 44.0, 46.0, 48.0],
+                        [60.0, 62.0, 64.0, 66.0, 68.0],
+                        [80.0, 82.0, 84.0, 86.0, 88.0],
+                    ]
+                ]
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_forward_exact_align_corners(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5], align_corners=True)
+        self.assertTrue(scale_module.align_corners)
+
+        test_tensor = torch.arange(0, 1 * 1 * 10 * 10).view(1, 1, 10, 10).float()
+
+        scaled_tensor = scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0000, 2.2500, 4.5000, 6.7500, 9.0000],
+                        [22.5000, 24.7500, 27.0000, 29.2500, 31.5000],
+                        [45.0000, 47.2500, 49.5000, 51.7500, 54.0000],
+                        [67.5000, 69.7500, 72.0000, 74.2500, 76.5000],
+                        [90.0000, 92.2500, 94.5000, 96.7500, 99.0000],
+                    ]
+                ]
+            ]
+        )
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
     def test_random_scale_forward(self) -> None:
         scale_module = transforms.RandomScale(scale=[0.5])
         test_tensor = torch.ones(1, 3, 10, 10)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1403,9 +1403,7 @@ class TestTransformationRobustness(BaseTest):
         self.assertTrue(torch.is_tensor(test_output))
 
     def test_transform_robustness_forward_crop_output(self) -> None:
-        transform_robustness = transforms.TransformationRobustness(
-             padding_transform=None, crop_or_pad_output=True
-        )
+        transform_robustness = transforms.TransformationRobustness(padding_transform=None, crop_or_pad_output=True)
         test_input = torch.ones(1, 3, 224, 224)
         test_output = transform_robustness(test_input)
         self.assertEqual(test_output.shape, test_input.shape)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1189,7 +1189,9 @@ class TestRandomCrop(BaseTest):
 class TestTransformationRobustness(BaseTest):
     def test_transform_robustness_init(self) -> None:
         transform_robustness = transforms.TransformationRobustness()
-        self.assertIsNone(transform_robustness.padding_transform)
+        self.assertIsInstance(
+            transform_robustness.padding_transform, nn.ConstantPad2d
+        )
         self.assertIsInstance(
             transform_robustness.jitter_transforms, torch.nn.Sequential
         )

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1381,12 +1381,12 @@ class TestGaussianSmoothing(BaseTest):
         ).repeat(4, 1, 1, 1, 1)
         assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0.01)
 
-    def test_gaussian_smoothing_init_dim_4_value_error(self) -> None:
+    def test_gaussian_smoothing_init_dim_4_runtime_error(self) -> None:
         channels = 3
         kernel_size = 3
         sigma = 2.0
         dim = 4
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             transforms.GaussianSmoothing(channels, kernel_size, sigma, dim)
 
     def test_gaussian_smoothing_1d(self) -> None:

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1644,6 +1644,28 @@ class TestTransformationRobustness(BaseTest):
         )
         self.assertFalse(transform_robustness.crop_or_pad_output)
 
+    def test_transform_robustness_init_transform_values(self) -> None:
+        transform_robustness = transforms.TransformationRobustness()
+        self.assertEqual(transform_robustness.padding_transform.padding, 2)
+        self.assertEqual(transform_robustness.padding_transform.value, 0.5)
+
+        self.assertEqual(len(transform_robustness.jitter_transforms), 10)
+        for module in transform_robustness.jitter_transforms:
+            self.assertEqual(module.pad_range, 2 * 4)
+
+        expected_scale = [0.995 ** n for n in range(-5, 80)] + [
+            0.998 ** n for n in 2 * list(range(20, 40))
+        ]
+        self.assertEqual(transform_robustness.random_scale.scale, expected_scale)
+        # expected_degrees = (
+        #    list(range(-20, 20)) + list(range(-10, 10)) + list(range(-5, 5)) + 5 * [0]
+        # )
+        # self.assertEqual(
+        #    transform_robustness.random_rotation.degrees, test_expected_degrees
+        # )
+
+        self.assertEqual(transform_robustness.final_jitter.pad_range, 2 * 2)
+
     def test_transform_robustness_init_single_translate(self) -> None:
         transform_robustness = transforms.TransformationRobustness(translate=4)
         self.assertIsInstance(

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1020,7 +1020,7 @@ class TestToRGB(BaseTest):
                 [-0.2500, 0.5000, -0.2500],
             ]
         )
-        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.0)
+        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.001)
 
     def test_to_rgb_klt(self) -> None:
         to_rgb = transforms.ToRGB(transform="klt")
@@ -1033,7 +1033,7 @@ class TestToRGB(BaseTest):
                 [0.5845, -0.1948, 0.0649],
             ]
         )
-        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.0)
+        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.001)
 
     def test_to_rgb_custom(self) -> None:
         matrix = torch.eye(3, 3)
@@ -1184,7 +1184,7 @@ class TestGaussianSmoothing(BaseTest):
         )
         self.assertEqual(smoothening_module.groups, channels)
         weight = torch.tensor([[0.3192, 0.3617, 0.3192]]).repeat(6, 1, 1)
-        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0.001)
 
     def test_gaussian_smoothing_init_2d(self) -> None:
         channels = 3
@@ -1204,7 +1204,7 @@ class TestGaussianSmoothing(BaseTest):
                 ]
             ]
         ).repeat(3, 1, 1, 1)
-        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0.001)
 
     def test_gaussian_smoothing_init_3d(self) -> None:
         channels = 4
@@ -1236,7 +1236,7 @@ class TestGaussianSmoothing(BaseTest):
                 ]
             ]
         ).repeat(4, 1, 1, 1, 1)
-        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight,  0.01)
 
     def test_gaussian_smoothing_1d(self) -> None:
         channels = 6

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1383,6 +1383,16 @@ class TestGaussianSmoothing(BaseTest):
         ).repeat(4, 1, 1, 1, 1)
         assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0.01)
 
+    def test_gaussian_smoothing_init_dim_4_value_error(self) -> None:
+        channels = 3
+        kernel_size = 3
+        sigma = 2.0
+        dim = 4
+        with self.assertRaises(ValueError):
+            smoothening_module = transforms.GaussianSmoothing(
+                channels, kernel_size, sigma, dim
+            )
+
     def test_gaussian_smoothing_1d(self) -> None:
         channels = 6
         kernel_size = 3

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -526,9 +526,8 @@ class TestCenterCrop(BaseTest):
 
     def test_center_crop_forward_one_number_dim_3(self) -> None:
         pad = (1, 1, 1, 1)
-        test_tensor = (
-            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
-            .repeat(3, 1, 1)
+        test_tensor = F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1).repeat(
+            3, 1, 1
         )
         crop_vals = 3
 
@@ -797,9 +796,8 @@ class TestCenterCropFunction(BaseTest):
 
     def test_center_crop_one_number_dim_3(self) -> None:
         pad = (1, 1, 1, 1)
-        test_tensor = (
-            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
-            .repeat(3, 1, 1)
+        test_tensor = F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1).repeat(
+            3, 1, 1
         )
         crop_vals = 3
 
@@ -1162,7 +1160,7 @@ class TestToRGB(BaseTest):
 
     def test_to_rgb_init_value_error(self) -> None:
         with self.assertRaises(ValueError):
-             transforms.ToRGB(transform="error")
+            transforms.ToRGB(transform="error")
 
     def test_to_rgb_klt_forward(self) -> None:
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -19,6 +19,7 @@ class TestRandomScale(BaseTest):
     def test_random_scale_scale(self) -> None:
         scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05])
         self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
+        self.assertFalse(scale_module._is_distribution)
 
     def test_random_scale_scale_distributions(self) -> None:
         scale = torch.distributions.Uniform(0.95, 1.05)
@@ -27,6 +28,12 @@ class TestRandomScale(BaseTest):
             scale_module.scale_distribution,
             torch.distributions.distribution.Distribution,
         )
+        self.assertTrue(scale_module._is_distribution)
+
+    def test_random_scale_torch_version_check(self) -> None:
+        scale_module = transforms.RandomScale([1.0])
+        _has_align_corners = torch.__version__ >= "1.3.0"
+        self.assertEqual(scale_module._has_align_corners, _has_align_corners)
 
     def test_random_scale_downscaling(self) -> None:
         scale_module = transforms.RandomScale(scale=[0.5])
@@ -148,6 +155,7 @@ class TestRandomScaleAffine(BaseTest):
     def test_random_scale_affine_scale(self) -> None:
         scale_module = transforms.RandomScaleAffine(scale=[1, 0.975, 1.025, 0.95, 1.05])
         self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
+        self.assertFalse(scale_module._is_distribution)
 
     def test_random_scale_affine_scale_distributions(self) -> None:
         scale = torch.distributions.Uniform(0.95, 1.05)
@@ -156,6 +164,12 @@ class TestRandomScaleAffine(BaseTest):
             scale_module.scale_distribution,
             torch.distributions.distribution.Distribution,
         )
+        self.assertTrue(scale_module._is_distribution)
+
+    def test_random_scale_affine_torch_version_check(self) -> None:
+        scale_module = transforms.RandomScaleAffine([1.0])
+        _has_align_corners = torch.__version__ >= "1.3.0"
+        self.assertEqual(scale_module._has_align_corners, _has_align_corners)
 
     def test_random_scale_affine_downscaling(self) -> None:
         scale_module = transforms.RandomScaleAffine(scale=[0.5])

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1403,7 +1403,9 @@ class TestTransformationRobustness(BaseTest):
         self.assertTrue(torch.is_tensor(test_output))
 
     def test_transform_robustness_forward_crop_output(self) -> None:
-        transform_robustness = transforms.TransformationRobustness(padding_transform=None, crop_or_pad_output=True)
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=None, crop_or_pad_output=True
+        )
         test_input = torch.ones(1, 3, 224, 224)
         test_output = transform_robustness(test_input)
         self.assertEqual(test_output.shape, test_input.shape)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1231,6 +1231,10 @@ class TestGaussianSmoothing(BaseTest):
 
 
 class TestScaleInputRange(BaseTest):
+    def test_scale_input_range_init(self) -> None:
+        scale_input = transforms.ScaleInputRange(255)
+        self.assertEqual(scale_input.multiplier, 255)
+
     def test_scale_input_range(self) -> None:
         x = torch.ones(1, 3, 4, 4)
         scale_input = transforms.ScaleInputRange(255)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -21,6 +21,18 @@ class TestRandomScale(BaseTest):
         self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
         self.assertFalse(scale_module._is_distribution)
 
+    def test_random_scale_tensor_scale(self) -> None:
+        scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])
+        scale_module = transforms.RandomScale(scale=scale)
+        self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
+
+    def test_random_scale_int_scale(self) -> None:
+        scale = [1, 2, 3, 4, 5]
+        scale_module = transforms.RandomScale(scale=scale)
+        for s in scale_module.scale:
+            self.assertIsInstance(s, float)
+        self.assertEqual(scale_module.scale, [1.0, 2.0, 3.0, 4.0, 5.0])
+
     def test_random_scale_scale_distributions(self) -> None:
         scale = torch.distributions.Uniform(0.95, 1.05)
         scale_module = transforms.RandomScale(scale=scale)
@@ -162,6 +174,18 @@ class TestRandomScaleAffine(BaseTest):
         scale_module = transforms.RandomScaleAffine(scale=[1, 0.975, 1.025, 0.95, 1.05])
         self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
         self.assertFalse(scale_module._is_distribution)
+
+    def test_random_scale_affine_tensor_scale(self) -> None:
+        scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])
+        scale_module = transforms.RandomScaleAffine(scale=scale)
+        self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
+
+    def test_random_scale_affine_int_scale(self) -> None:
+        scale = [1, 2, 3, 4, 5]
+        scale_module = transforms.RandomScaleAffine(scale=scale)
+        for s in scale_module.scale:
+            self.assertIsInstance(s, float)
+        self.assertEqual(scale_module.scale, [1.0, 2.0, 3.0, 4.0, 5.0])
 
     def test_random_scale_affine_scale_distributions(self) -> None:
         scale = torch.distributions.Uniform(0.95, 1.05)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1357,7 +1357,7 @@ class TestTransformationRobustness(BaseTest):
     def test_transform_robustness_init(self) -> None:
         transform_robustness = transforms.TransformationRobustness()
         self.assertIsInstance(
-            transform_robustness.padding_transform, nn.ConstantPad2d
+            transform_robustness.padding_transform, torch.nn.ConstantPad2d
         )
         self.assertIsInstance(
             transform_robustness.jitter_transforms, torch.nn.Sequential

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1236,7 +1236,7 @@ class TestGaussianSmoothing(BaseTest):
                 ]
             ]
         ).repeat(4, 1, 1, 1, 1)
-        assertTensorAlmostEqual(self, smoothening_module.weight, weight,  0.01)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0.01)
 
     def test_gaussian_smoothing_1d(self) -> None:
         channels = 6


### PR DESCRIPTION
* Added `torch.distribution` assert check and more extensive testing for both RandomScale transforms.
* Removed unused code from the main `RandomScale` transform.
* Added more comprehensive testing to applicable transforms. Test coverage reported by pytest should now be 100% minus the version specific tests.