### PR TITLE
Improve ModuleOutputsHook, testing coverage, & fix bug

### DIFF
--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -142,7 +142,7 @@ def _remove_all_forward_hooks(
     This function removes all forward hooks in the specified module, without requiring
     any hook handles. This lets us clean up & remove any hooks that weren't property
     deleted.
-    
+
     Warning: Various PyTorch modules and systems make use of hooks, and thus extreme
     caution should be exercised when removing all hooks. Users are recommended to give
     their hook function a unique name that can be used to safely identify and only
@@ -156,14 +156,38 @@ def _remove_all_forward_hooks(
             Default: None
     """
 
-    # Remove hooks from target submodules
-    for name, child in module._modules.items():
-        if child is not None:
-            if hasattr(child, "_forward_hooks"):
-                if child._forward_hooks != OrderedDict():
+    if hook_name is None or hook_name == "":
+        warn("Removing all active hooks can break some PyTorch modules & systems.")
+
+    def _remove_forward_hooks(
+        module: torch.nn.Module, hook_name: Optional[str] = None
+    ) -> None:
+
+        # Remove hooks from target submodules
+        for name, child in module._modules.items():
+            if child is not None:
+                if hasattr(child, "_forward_hooks"):
+                    if child._forward_hooks != OrderedDict():
+                        if hook_name is not None:
+                            dict_items = list(child._forward_hooks.items())
+                            child._forward_hooks = OrderedDict(
+                                [
+                                    (i, fn)
+                                    for i, fn in dict_items
+                                    if fn.__name__ != hook_name
+                                ]
+                            )
+                        else:
+                            child._forward_hooks: Dict[int, Callable] = OrderedDict()
+                _remove_forward_hooks(child, hook_name)
+
+        # Remove hooks from the target module
+        if hasattr(module, "_forward_hooks"):
+            if module._forward_hooks != OrderedDict():
+                if module._forward_hooks != OrderedDict():
                     if hook_name is not None:
-                        dict_items = list(child._forward_hooks.items())
-                        child._forward_hooks = OrderedDict(
+                        dict_items = list(module._forward_hooks.items())
+                        module._forward_hooks = OrderedDict(
                             [
                                 (i, fn)
                                 for i, fn in dict_items
@@ -171,17 +195,6 @@ def _remove_all_forward_hooks(
                             ]
                         )
                     else:
-                        child._forward_hooks: Dict[int, Callable] = OrderedDict()
-            _remove_all_forward_hooks(child, hook_name)
+                        module._forward_hooks: Dict[int, Callable] = OrderedDict()
 
-    # Remove hooks from the target module
-    if hasattr(module, "_forward_hooks"):
-        if module._forward_hooks != OrderedDict():
-            if module._forward_hooks != OrderedDict():
-                if hook_name is not None:
-                    dict_items = list(module._forward_hooks.items())
-                    module._forward_hooks = OrderedDict(
-                        [(i, fn) for i, fn in dict_items if fn.__name__ != hook_name]
-                    )
-                else:
-                    module._forward_hooks: Dict[int, Callable] = OrderedDict()
+    _remove_forward_hooks(module, name)

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -139,9 +139,14 @@ def _remove_all_forward_hooks(
     module: torch.nn.Module, hook_name: Optional[str] = None
 ) -> None:
     """
-    This function removes all forward hooks in the specified model, without requiring
+    This function removes all forward hooks in the specified module, without requiring
     any hook handles. This lets us clean up & remove any hooks that weren't property
     deleted.
+    
+    Warning: Various PyTorch modules and systems make use of hooks, and thus extreme
+    caution should be exercised when removing all hooks. Users are recommended to give
+    their hook function a unique name that can be used to safetly identify and remove
+    the hook.
 
     Args:
 

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -142,7 +142,7 @@ def _remove_all_forward_hooks(
     This function removes all forward hooks in the specified model, without requiring
     any hook handles. This lets us clean up & remove any hooks that weren't property
     deleted.
-    
+
     Args:
 
         module (nn.Module): The module instance to remove forward hooks from.
@@ -151,9 +151,11 @@ def _remove_all_forward_hooks(
             Default: None
     """
     if hook_name is None or hook_name == "":
-        warn("Warning modules like weight_norm will be broken by removing all hooks."
+        warn(
+            "Warning modules like weight_norm will be broken by removing all hooks."
             + " Please specify the full & unique function name of the target hook to"
-            + " avoid errors")
+            + " avoid errors"
+        )
 
     # Remove hooks from target submodules
     for name, child in module._modules.items():

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -151,6 +151,11 @@ def _remove_all_forward_hooks(
             their function's __name__ attribute.
             Default: None
     """
+    if hook_name is None or hook_name == "":
+        warn("Warning modules like weight_norm will be broken by removing all hooks."
+            + " Please specify the full & unique function name of the target hook to"
+            + " avoid errors")
+
     for name, child in model._modules.items():
         if child is not None:
             if hasattr(child, "_forward_hooks"):

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -155,12 +155,6 @@ def _remove_all_forward_hooks(
             their function's __name__ attribute.
             Default: None
     """
-    if hook_name is None or hook_name == "":
-        warn(
-            "Warning modules like weight_norm will be broken by removing all hooks."
-            + " Please specify the full & unique function name of the target hook to"
-            + " avoid errors"
-        )
 
     # Remove hooks from target submodules
     for name, child in module._modules.items():

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -17,6 +17,7 @@ class ModuleOutputsHook:
             target_modules (Iterable of nn.Module): A list of nn.Module targets.
         """
         for module in target_modules:
+            # Clean up any old hooks that weren't properly deleted
             _remove_all_forward_hooks(module, "module_outputs_forward_hook")
         self.outputs: ModuleOutputMapping = dict.fromkeys(target_modules, None)
         self.hooks = [

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -157,11 +157,11 @@ def _remove_all_forward_hooks(
         warn("Removing all active hooks can break some PyTorch modules & systems.")
 
     def _remove_forward_hooks(
-        module: torch.nn.Module, hook_name: Optional[str] = None
+        target_module: torch.nn.Module, hook_name: Optional[str] = None
     ) -> None:
 
         # Remove hooks from target submodules
-        for name, child in module._modules.items():
+        for name, child in target_module._modules.items():
             if child is not None:
                 if hasattr(child, "_forward_hooks"):
                     if child._forward_hooks != OrderedDict():
@@ -179,12 +179,12 @@ def _remove_all_forward_hooks(
                 _remove_forward_hooks(child, hook_name)
 
         # Remove hooks from the target module
-        if hasattr(module, "_forward_hooks"):
-            if module._forward_hooks != OrderedDict():
-                if module._forward_hooks != OrderedDict():
+        if hasattr(target_module, "_forward_hooks"):
+            if target_module._forward_hooks != OrderedDict():
+                if target_module._forward_hooks != OrderedDict():
                     if hook_name is not None:
-                        dict_items = list(module._forward_hooks.items())
-                        module._forward_hooks = OrderedDict(
+                        dict_items = list(target_module._forward_hooks.items())
+                        target_module._forward_hooks = OrderedDict(
                             [
                                 (i, fn)
                                 for i, fn in dict_items
@@ -192,6 +192,6 @@ def _remove_all_forward_hooks(
                             ]
                         )
                     else:
-                        module._forward_hooks: Dict[int, Callable] = OrderedDict()
+                        target_module._forward_hooks: Dict[int, Callable] = OrderedDict()
 
     _remove_forward_hooks(module, hook_fn_name)

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -36,10 +36,10 @@ class ModuleOutputsHook:
 
     def _forward_hook(self) -> Callable:
         """
-        Return the forward_hook function.
+        Return the module_outputs_forward_hook forward hook function.
 
         Returns:
-            forward_hook (Callable): The forward_hook function.
+            forward_hook (Callable): The module_outputs_forward_hook function.
         """
 
         def module_outputs_forward_hook(

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -172,7 +172,7 @@ def _remove_all_forward_hooks(
                         m._forward_hooks: Dict[int, Callable] = OrderedDict()
 
     def _remove_child_hooks(
-        target_module: torch.nn.Module, hook_name: Optional[str] = None:
+        target_module: torch.nn.Module, hook_name: Optional[str] = None
     ) -> None:
         for name, child in target_module._modules.items():
             if child is not None:

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -157,7 +157,7 @@ def _remove_all_forward_hooks(
             Default: None
     """
 
-    if hook_fn_name is None or hook_fn_name == "":
+    if hook_fn_name is None:
         warn("Removing all active hooks can break some PyTorch modules & systems.")
 
     def _remove_hooks(m: torch.nn.Module, name: Optional[str] = None) -> None:

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -142,11 +142,14 @@ def _remove_all_forward_hooks(
     This function removes all forward hooks in the specified module, without requiring
     any hook handles. This lets us clean up & remove any hooks that weren't property
     deleted.
+
     Warning: Various PyTorch modules and systems make use of hooks, and thus extreme
     caution should be exercised when removing all hooks. Users are recommended to give
     their hook function a unique name that can be used to safely identify and only
     remove the target forward hooks.
+
     Args:
+
         module (nn.Module): The module instance to remove forward hooks from.
         hook_fn_name (str, optional): Optionally only remove specific forward hooks
             based on their function's __name__ attribute.
@@ -160,7 +163,6 @@ def _remove_all_forward_hooks(
         target_module: torch.nn.Module, hook_name: Optional[str] = None
     ) -> None:
 
-        # Remove hooks from target submodules
         for name, child in target_module._modules.items():
             if child is not None:
                 if hasattr(child, "_forward_hooks"):
@@ -178,20 +180,17 @@ def _remove_all_forward_hooks(
                             child._forward_hooks: Dict[int, Callable] = OrderedDict()
                 _remove_forward_hooks(child, hook_name)
 
-        # Remove hooks from the target module
-        if hasattr(target_module, "_forward_hooks"):
-            if target_module._forward_hooks != OrderedDict():
-                if target_module._forward_hooks != OrderedDict():
-                    if hook_name is not None:
-                        dict_items = list(target_module._forward_hooks.items())
-                        target_module._forward_hooks = OrderedDict(
-                            [
-                                (i, fn)
-                                for i, fn in dict_items
-                                if fn.__name__ != hook_name
-                            ]
-                        )
-                    else:
-                        target_module._forward_hooks: Dict[int, Callable] = OrderedDict()
-
+    # Remove hooks from target submodules
     _remove_forward_hooks(module, hook_fn_name)
+
+    # Remove hooks from the target module
+    if hasattr(module, "_forward_hooks"):
+        if module._forward_hooks != OrderedDict():
+            if module._forward_hooks != OrderedDict():
+                if hook_fn_name is not None:
+                    dict_items = list(module._forward_hooks.items())
+                    module._forward_hooks = OrderedDict(
+                        [(i, fn) for i, fn in dict_items if fn.__name__ != hook_fn_name]
+                    )
+                else:
+                    module._forward_hooks: Dict[int, Callable] = OrderedDict()

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -197,4 +197,4 @@ def _remove_all_forward_hooks(
                     else:
                         module._forward_hooks: Dict[int, Callable] = OrderedDict()
 
-    _remove_forward_hooks(module, name)
+    _remove_forward_hooks(module, hook_name)

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -183,4 +183,4 @@ def _remove_all_forward_hooks(
     _remove_child_hooks(module, hook_fn_name)
 
     # Remove hooks from the target module
-    _remove_hooks(model, hook_fn_name)
+    _remove_hooks(module, hook_fn_name)

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -136,27 +136,24 @@ class ActivationFetcher:
 
 
 def _remove_all_forward_hooks(
-    module: torch.nn.Module, hook_name: Optional[str] = None
+    module: torch.nn.Module, hook_fn_name: Optional[str] = None
 ) -> None:
     """
     This function removes all forward hooks in the specified module, without requiring
     any hook handles. This lets us clean up & remove any hooks that weren't property
     deleted.
-
     Warning: Various PyTorch modules and systems make use of hooks, and thus extreme
     caution should be exercised when removing all hooks. Users are recommended to give
     their hook function a unique name that can be used to safely identify and only
     remove the target forward hooks.
-
     Args:
-
         module (nn.Module): The module instance to remove forward hooks from.
-        name (str, optional): Optionally only remove specific forward hooks based on
-            their function's __name__ attribute.
+        hook_fn_name (str, optional): Optionally only remove specific forward hooks
+            based on their function's __name__ attribute.
             Default: None
     """
 
-    if hook_name is None or hook_name == "":
+    if hook_fn_name is None or hook_fn_name == "":
         warn("Removing all active hooks can break some PyTorch modules & systems.")
 
     def _remove_forward_hooks(
@@ -197,4 +194,4 @@ def _remove_all_forward_hooks(
                     else:
                         module._forward_hooks: Dict[int, Callable] = OrderedDict()
 
-    _remove_forward_hooks(module, hook_name)
+    _remove_forward_hooks(module, hook_fn_name)

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -174,7 +174,6 @@ def _remove_all_forward_hooks(
     def _remove_child_hooks(
         target_module: torch.nn.Module, hook_name: Optional[str] = None
     ) -> None:
-
         for name, child in target_module._modules.items():
             if child is not None:
                 _remove_hooks(child, hook_name)

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -1,6 +1,6 @@
 import warnings
 from collections import OrderedDict
-from typing import Callable, Dict, Iterable, Tuple
+from typing import Callable, Dict, Iterable, Optional, Tuple
 from warnings import warn
 
 import torch

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -145,8 +145,8 @@ def _remove_all_forward_hooks(
     
     Warning: Various PyTorch modules and systems make use of hooks, and thus extreme
     caution should be exercised when removing all hooks. Users are recommended to give
-    their hook function a unique name that can be used to safetly identify and remove
-    the hook.
+    their hook function a unique name that can be used to safely identify and only
+    remove the target forward hooks.
 
     Args:
 

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -159,7 +159,7 @@ def _remove_all_forward_hooks(
     if hook_fn_name is None or hook_fn_name == "":
         warn("Removing all active hooks can break some PyTorch modules & systems.")
 
-    def _remove_hooks(m: nn.Module, name: Optional[str] = None) -> None 
+    def _remove_hooks(m: nn.Module, name: Optional[str] = None) -> None:
         if hasattr(module, "_forward_hooks"):
             if m._forward_hooks != OrderedDict():
                 if m._forward_hooks != OrderedDict():
@@ -172,7 +172,7 @@ def _remove_all_forward_hooks(
                         m._forward_hooks: Dict[int, Callable] = OrderedDict()
 
     def _remove_child_hooks(
-        target_module: torch.nn.Module, hook_name: Optional[str] = None
+        target_module: torch.nn.Module, hook_name: Optional[str] = None:
     ) -> None:
         for name, child in target_module._modules.items():
             if child is not None:

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -134,28 +134,7 @@ class ActivationFetcher:
             self.layers.remove_hooks()
         return activations_dict
 
-
-def _remove_all_forward_hooks(
-    model: torch.nn.Module, hook_name: Optional[str] = None
-) -> None:
-    """
-    This function removes all forward hooks in the specified model, without requiring
-    any hook handles. This lets us clean up & remove any hooks that weren't property
-    deleted.
-    
-    Args:
-
-        model (nn.Module): The model instance or target module instance to remove
-            forward hooks from.
-        name (str, optional): Optionally only remove specific forward hooks based on
-            their function's __name__ attribute.
-            Default: None
-    """
-    if hook_name is None or hook_name == "":
-        warn("Warning modules like weight_norm will be broken by removing all hooks."
-            + " Please specify the full & unique function name of the target hook to"
-            + " avoid errors")
-
+    # Remove hooks from target submodules
     for name, child in model._modules.items():
         if child is not None:
             if hasattr(child, "_forward_hooks"):
@@ -172,6 +151,7 @@ def _remove_all_forward_hooks(
                     else:
                         child._forward_hooks: Dict[int, Callable] = OrderedDict()
             _remove_all_forward_hooks(child, hook_name)
+    # Remove hooks from the target
     if hasattr(model, "_forward_hooks"):
         if model._forward_hooks != OrderedDict():
             if model._forward_hooks != OrderedDict():

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -158,7 +158,7 @@ def _remove_all_forward_hooks(
     """
 
     if hook_fn_name is None:
-        warn("Removing all active hooks can break some PyTorch modules & systems.")
+        warn("Removing all active hooks will break some PyTorch modules & systems.")
 
     def _remove_hooks(m: torch.nn.Module, name: Optional[str] = None) -> None:
         if hasattr(module, "_forward_hooks"):

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -145,8 +145,8 @@ def _remove_all_forward_hooks(
 
     Warning: Various PyTorch modules and systems make use of hooks, and thus extreme
     caution should be exercised when removing all hooks. Users are recommended to give
-    their hook function a unique name that can be used to safely identify and only
-    remove the target forward hooks.
+    their hook function a unique name that can be used to safely identify and remove
+    the target forward hooks.
 
     Args:
 

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -162,14 +162,13 @@ def _remove_all_forward_hooks(
     def _remove_hooks(m: torch.nn.Module, name: Optional[str] = None) -> None:
         if hasattr(module, "_forward_hooks"):
             if m._forward_hooks != OrderedDict():
-                if m._forward_hooks != OrderedDict():
-                    if name is not None:
-                        dict_items = list(m._forward_hooks.items())
-                        m._forward_hooks = OrderedDict(
-                            [(i, fn) for i, fn in dict_items if fn.__name__ != name]
-                        )
-                    else:
-                        m._forward_hooks: Dict[int, Callable] = OrderedDict()
+                if name is not None:
+                    dict_items = list(m._forward_hooks.items())
+                    m._forward_hooks = OrderedDict(
+                        [(i, fn) for i, fn in dict_items if fn.__name__ != name]
+                    )
+                else:
+                    m._forward_hooks: Dict[int, Callable] = OrderedDict()
 
     def _remove_child_hooks(
         target_module: torch.nn.Module, hook_name: Optional[str] = None

--- a/captum/optim/_core/output_hook.py
+++ b/captum/optim/_core/output_hook.py
@@ -159,7 +159,7 @@ def _remove_all_forward_hooks(
     if hook_fn_name is None or hook_fn_name == "":
         warn("Removing all active hooks can break some PyTorch modules & systems.")
 
-    def _remove_hooks(m: nn.Module, name: Optional[str] = None) -> None:
+    def _remove_hooks(m: torch.nn.Module, name: Optional[str] = None) -> None:
         if hasattr(module, "_forward_hooks"):
             if m._forward_hooks != OrderedDict():
                 if m._forward_hooks != OrderedDict():

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import unittest
 from collections import OrderedDict
-from typing import Optional, cast
+from typing import Optional, Tuple, cast
 
 import torch
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -166,6 +166,25 @@ class TestModuleOutputsHook(BaseTest):
         expected_outputs = dict.fromkeys(target_modules, None)
         self.assertEqual(hook_module.outputs, expected_outputs)
 
+    def test_consume_outputs_warning(self) -> None:
+        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        target_modules = [model[0], model[1]]
+        test_input = torch.randn(1, 3, 4, 4)
+
+        hook_module = output_hook.ModuleOutputsHook(target_modules)
+        self.assertFalse(hook_module.is_ready)
+
+        _ = model(test_input)
+
+        self.assertTrue(hook_module.is_ready)
+
+        hook_module._reset_outputs()
+
+        self.assertFalse(hook_module.is_ready)
+
+        with self.assertWarns(Warning):
+            _ = hook_module.consume_outputs()
+
 
 class TestActivationFetcher(BaseTest):
     def test_activation_fetcher_simple_model(self) -> None:

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -137,12 +137,9 @@ class TestModuleOutputsHook(BaseTest):
 
         test_output = hook_module.consume_outputs()
 
-        for target, activations, i in zip(test_output.items(), list(range(len(target_modules))):
-            self.assertEqual(target, target_modules[i])
-            self.assertIsNone(target_activations)
-
-        outputs = dict.fromkeys(target_modules, None)
-        self.assertEqual(outputs, hook_module.outputs)
+        expected_outputs = dict.fromkeys(target_modules, None)
+        self.assertEqual(test_output, expected_outputs)
+        self.assertEqual(test_output, hook_module.outputs)
 
         self.assertTrue(hook_module.is_ready)
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -242,6 +242,8 @@ class TestRemoveAllForwardHooks(BaseTest):
             self, input: Tuple[torch.Tensor], output: torch.Tensor
         ) -> None:
             pass
+        
+        fn_name = forward_hook_unique_fn.__name__
 
         layer1 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         layer2 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
@@ -251,10 +253,10 @@ class TestRemoveAllForwardHooks(BaseTest):
         model[1].register_forward_hook(forward_hook_unique_fn)
         model[0][1].register_forward_hook(forward_hook_unique_fn)
 
-        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn")
+        n_hooks = _count_forward_hooks(model, fn_name)
         self.assertEqual(n_hooks, 3)
 
-        output_hook._remove_all_forward_hooks(model, "forward_hook_unique_fn")
+        output_hook._remove_all_forward_hooks(model, fn_name)
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 0)
 
@@ -264,6 +266,8 @@ class TestRemoveAllForwardHooks(BaseTest):
         ) -> None:
             pass
 
+        fn_name = forward_hook_unique_fn.__name__
+
         layer1 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         layer2 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         model = torch.nn.Sequential(layer1, layer2)
@@ -271,20 +275,20 @@ class TestRemoveAllForwardHooks(BaseTest):
         model[1].register_forward_hook(forward_hook_unique_fn)
         model[0][1].register_forward_hook(forward_hook_unique_fn)
 
-        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn")
+        n_hooks = _count_forward_hooks(model, fn_name)
         self.assertEqual(n_hooks, 2)
 
-        output_hook._remove_all_forward_hooks(model, "forward_hook_unique_fn")
+        output_hook._remove_all_forward_hooks(model, fn_name)
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 0)
 
         model[1].register_forward_hook(forward_hook_unique_fn)
         model[1][1].register_forward_hook(forward_hook_unique_fn)
 
-        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn")
+        n_hooks = _count_forward_hooks(model, fn_name)
         self.assertEqual(n_hooks, 2)
 
-        output_hook._remove_all_forward_hooks(model, "forward_hook_unique_fn")
+        output_hook._remove_all_forward_hooks(model, fn_name)
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 0)
 
@@ -299,6 +303,9 @@ class TestRemoveAllForwardHooks(BaseTest):
         ) -> None:
             pass
 
+        fn_name_1 = forward_hook_unique_fn_1.__name__
+        fn_name_2 = forward_hook_unique_fn_2.__name__
+
         layer1 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         layer2 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         model = torch.nn.Sequential(layer1, layer2)
@@ -310,19 +317,19 @@ class TestRemoveAllForwardHooks(BaseTest):
         model.register_forward_hook(forward_hook_unique_fn_2)
         model[1][0].register_forward_hook(forward_hook_unique_fn_2)
 
-        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn_1")
+        n_hooks = _count_forward_hooks(model, fn_name_1)
         self.assertEqual(n_hooks, 3)
-        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn_2")
+        n_hooks = _count_forward_hooks(model, fn_name_2)
         self.assertEqual(n_hooks, 2)
 
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 5)
 
-        output_hook._remove_all_forward_hooks(model, "forward_hook_unique_fn_1")
+        output_hook._remove_all_forward_hooks(model, fn_name_1)
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 2)
 
-        output_hook._remove_all_forward_hooks(model, "forward_hook_unique_fn_2")
+        output_hook._remove_all_forward_hooks(model, fn_name_2)
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 0)
 
@@ -332,12 +339,14 @@ class TestRemoveAllForwardHooks(BaseTest):
         ) -> None:
             pass
 
+        fn_name = forward_hook_unique_fn.__name__
+
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
 
         model[0].register_forward_hook(forward_hook_unique_fn)
         model[1].register_forward_hook(forward_hook_unique_fn)
 
-        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn")
+        n_hooks = _count_forward_hooks(model, fn_name)
         self.assertEqual(n_hooks, 2)
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 2)
@@ -345,7 +354,7 @@ class TestRemoveAllForwardHooks(BaseTest):
         with self.assertWarns(Warning):
             output_hook._remove_all_forward_hooks(model)
 
-        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn")
+        n_hooks = _count_forward_hooks(model, fn_name)
         self.assertEqual(n_hooks, 0)
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 0)

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -10,13 +10,13 @@ from captum.optim.models import googlenet
 from tests.helpers.basic import BaseTest
 
 
-def _count_forward_hooks(model: torch.nn.Module, hook_name: Optional[str] = None) -> int:
+def _count_forward_hooks(module: torch.nn.Module, hook_name: Optional[str] = None) -> int:
     """
     Count the number of active forward hooks on the specified model or module.
 
     Args:
 
-        model (nn.Module): The model instance or target module instance to count
+        module (nn.Module): The model instance or target module instance to count
             the number of forward hooks on.
         name (str, optional): Optionally only count specific forward hooks based on
             their function's __name__ attribute.
@@ -27,7 +27,7 @@ def _count_forward_hooks(model: torch.nn.Module, hook_name: Optional[str] = None
     """
 
     num_hooks = 0
-    for name, child in model._modules.items():
+    for name, child in module._modules.items():
         if child is not None:
             if hasattr(child, "_forward_hooks"):
                 if child._forward_hooks != OrderedDict():
@@ -38,9 +38,9 @@ def _count_forward_hooks(model: torch.nn.Module, hook_name: Optional[str] = None
                 elif hook_name is not None:
                     num_hooks +=1
             _count_forward_hooks(child, hook_name)
-    if hasattr(model, "_forward_hooks"):
-        if model._forward_hooks != OrderedDict():
-            if model._forward_hooks != OrderedDict():
+    if hasattr(module, "_forward_hooks"):
+        if module._forward_hooks != OrderedDict():
+            if module._forward_hooks != OrderedDict():
                 dict_items = list(model._forward_hooks.items())
                 for i, fn in dict_items:
                     if hook_name is None or fn.__name__ == hook_name:            

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -139,7 +139,7 @@ class TestModuleOutputsHook(BaseTest):
 
         expected_outputs = dict.fromkeys(target_modules, None)
         self.assertEqual(test_output, expected_outputs)
-        self.assertEqual(test_output, hook_module.outputs)
+        self.assertEqual(hook_module.outputs, expected_outputs)
 
         self.assertTrue(hook_module.is_ready)
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -15,15 +15,12 @@ def _count_forward_hooks(
 ) -> int:
     """
     Count the number of active forward hooks on the specified module instance.
-
     Args:
-
         module (nn.Module): The model module instance to count the number of
             forward hooks on.
         name (str, optional): Optionally only count specific forward hooks based on
             their function's __name__ attribute.
             Default: None
-
     Returns:
         num_hooks (int): The number of active hooks in the specified module.
     """
@@ -48,7 +45,7 @@ def _count_forward_hooks(
                 _count_hooks(child, hook_name)
                 _count_child_hooks(child, hook_name)
 
-    _count_num_forward_hooks(module, hook_fn_name)
+    _count_child_hooks(module, hook_fn_name)
     _count_hooks(module, hook_fn_name)
     return num_hooks[0]
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -272,3 +272,27 @@ class TestRemoveAllForwardHooks(BaseTest):
         output_hook._remove_all_forward_hooks(model, "forward_hook_unique_fn_2")
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 0)
+
+    def test_forward_hook_removal_no_hook_fn_name(self) -> None:
+        def forward_hook_unique_fn(
+            self, input: Tuple[torch.Tensor], output: torch.Tensor
+        ) -> None:
+            pass
+
+        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+
+        model[0].register_forward_hook(forward_hook_unique_fn)
+        model[1].register_forward_hook(forward_hook_unique_fn)
+
+        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn")
+        self.assertEqual(n_hooks, 2)
+        n_hooks = _count_forward_hooks(model)
+        self.assertEqual(n_hooks, 2)
+
+        with self.assertWarns(Warning):
+            output_hook._remove_all_forward_hooks(model)
+
+        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn")
+        self.assertEqual(n_hooks, 0)
+        n_hooks = _count_forward_hooks(model)
+        self.assertEqual(n_hooks, 0)

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -37,7 +37,7 @@ def _count_forward_hooks(
                     for i, fn in dict_items:
                         if hook_name is None or fn.__name__ == hook_name:
                             num_hooks += 1
-                elif hook_name is not None:
+                elif hook_name is None:
                     num_hooks += 1
             _count_forward_hooks(child, hook_name)
     if hasattr(module, "_forward_hooks"):
@@ -47,7 +47,7 @@ def _count_forward_hooks(
                 for i, fn in dict_items:
                     if hook_name is None or fn.__name__ == hook_name:
                         num_hooks += 1
-            elif hook_name is not None:
+            elif hook_name is None:
                 num_hooks += 1
     return num_hooks
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -168,6 +168,18 @@ class TestModuleOutputsHook(BaseTest):
 
 
 class TestActivationFetcher(BaseTest):
+    def test_activation_fetcher_simple_model(self) -> None:
+        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+
+        catch_activ = output_hook.ActivationFetcher(model, targets=[model[0]])
+        test_input = torch.randn(1, 3, 224, 224)
+        activ_out = catch_activ(test_input)
+
+        self.assertIsInstance(activ_out, dict)
+        self.assertEqual(len(activ_out), 1)
+        activ = activ_out[model[0]]
+        assertTensorAlmostEqual(self, activ, test_input)
+
     def test_activation_fetcher_single_target(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -221,7 +221,9 @@ class TestActivationFetcher(BaseTest):
             )
         model = googlenet(pretrained=True)
 
-        catch_activ = output_hook.ActivationFetcher(model, targets=[model.mixed4d, model.mixed5b])
+        catch_activ = output_hook.ActivationFetcher(
+            model, targets=[model.mixed4d, model.mixed5b]
+        )
         activ_out = catch_activ(torch.zeros(1, 3, 224, 224))
 
         self.assertIsInstance(activ_out, dict)

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -136,7 +136,7 @@ class TestModuleOutputsHook(BaseTest):
         for target, activations in outputs_dict.items():
             self.assertEqual(target, target_modules[i])
             assertTensorAlmostEqual(self, activations, test_input)
-            i+=1
+            i += 1
 
         hook_module._reset_outputs()
 
@@ -165,7 +165,7 @@ class TestModuleOutputsHook(BaseTest):
         for target, activations in test_outputs_dict.items():
             self.assertEqual(target, target_modules[i])
             assertTensorAlmostEqual(self, activations, test_input)
-            i+=1
+            i += 1
 
         test_output = hook_module.consume_outputs()
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -66,6 +66,7 @@ class TestModuleOutputsHook(BaseTest):
 
         outputs = dict.fromkeys(target_modules, None)
         self.assertEqual(outputs, hook_module.outputs)
+        self.assertEqual(list(hook_module.targets), target_modules)
 
     def test_init_multiple_targets(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
@@ -79,6 +80,7 @@ class TestModuleOutputsHook(BaseTest):
 
         outputs = dict.fromkeys(target_modules, None)
         self.assertEqual(outputs, hook_module.outputs)
+        self.assertEqual(list(hook_module.targets), target_modules)
 
     def test_init_hook_duplication_fix(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
@@ -86,6 +88,34 @@ class TestModuleOutputsHook(BaseTest):
             _ = output_hook.ModuleOutputsHook([model[1]])
         n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
         self.assertEqual(n_hooks, 1)
+
+    def test_init_multiple_targets_remove_hooks(self) -> None:
+        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        target_modules = [model[0], model[1]]
+        
+        hook_module = output_hook.ModuleOutputsHook(target_modules)
+
+        n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
+        self.assertEqual(n_hooks, len(target_modules))
+
+        hook_module.remove_hooks()
+
+        n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
+        self.assertEqual(n_hooks, 0)
+
+    def test_init_multiple_targets_del(self) -> None:
+        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        target_modules = [model[0], model[1]]
+        
+        hook_module = output_hook.ModuleOutputsHook(target_modules)
+
+        n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
+        self.assertEqual(n_hooks, len(target_modules))
+
+        del hook_module
+
+        n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
+        self.assertEqual(n_hooks, 0)
 
     def test_consume_outputs_multiple_targets(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -54,6 +54,32 @@ def _count_forward_hooks(
 
 
 class TestModuleOutputsHook(BaseTest):
+    def test_init_single_target(self) -> None:
+        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        target_modules = [model[0]]
+        
+        hook_module = output_hook.ModuleOutputsHook(target_modules)
+        self.assertEqual(len(hook_module.hooks), len(target_modules))
+
+        n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
+        self.assertEqual(n_hooks, len(target_modules))
+
+        outputs = dict.fromkeys(target_modules, None)
+        self.assertEqual(outputs, hook_module.outputs)
+
+    def test_init_multiple_targets(self) -> None:
+        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        target_modules = [model[0], model[1]]
+        
+        hook_module = output_hook.ModuleOutputsHook(target_modules)
+        self.assertEqual(len(hook_module.hooks), len(target_modules))
+
+        n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
+        self.assertEqual(n_hooks, len(target_modules))
+
+        outputs = dict.fromkeys(target_modules, None)
+        self.assertEqual(outputs, hook_module.outputs)
+
     def test_init_hook_duplication_fix(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         for i in range(5):

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -132,11 +132,11 @@ class TestModuleOutputsHook(BaseTest):
         self.assertFalse(hook_module.is_ready)
 
         outputs_dict = hook_module.outputs
-        for target, activations, i in zip(
-            outputs_dict.items(), list(range(len(target_modules)))
-        ):
+        i = 0
+        for target, activations in outputs_dict.items():
             self.assertEqual(target, target_modules[i])
             assertTensorAlmostEqual(self, activations, test_input)
+            i+=1
 
         hook_module._reset_outputs()
 
@@ -161,11 +161,11 @@ class TestModuleOutputsHook(BaseTest):
         self.assertIsInstance(test_outputs_dict, dict)
         self.assertEqual(len(test_outputs_dict), len(target_modules))
 
-        for target, activations, i in zip(
-            test_outputs_dict.items(), list(range(len(target_modules)))
-        ):
+        i = 0
+        for target, activations in test_outputs_dict.items():
             self.assertEqual(target, target_modules[i])
             assertTensorAlmostEqual(self, activations, test_input)
+            i+=1
 
         test_output = hook_module.consume_outputs()
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -47,7 +47,7 @@ def _count_forward_hooks(
                 _count_hooks(child, hook_name)
                 _count_child_hooks(child, hook_name)
 
-    _count_num_forward_hooks(module, hook_fn_name)
+    _count_child_hooks(module, hook_fn_name)
     _count_hooks(module, hook_fn_name)
     return num_hooks[0]
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -29,27 +29,32 @@ def _count_forward_hooks(
     """
 
     num_hooks: List[int] = [0]
-
-    def _count_hooks(m: torch.nn.Module, name: Optional[str] = None) -> None:
-        if hasattr(m, "_forward_hooks"):
-            if m._forward_hooks != OrderedDict():
-                dict_items = list(m._forward_hooks.items())
-                for i, fn in dict_items:
-                    if hook_fn_name is None or fn.__name__ == name:
-                        num_hooks[0] += 1
-
-    def _count_child_hooks(
+    def _count_num_forward_hooks(
         target_module: torch.nn.Module,
         hook_name: Optional[str] = None,
     ) -> None:
+
         for name, child in target_module._modules.items():
             if child is not None:
-                _count_hooks(child, hook_name)
-                _count_child_hooks(child, hook_name)
+                if hasattr(child, "_forward_hooks"):
+                    if child._forward_hooks != OrderedDict():
+                        dict_items = list(child._forward_hooks.items())
+                        for i, fn in dict_items:
+                            if hook_name is None or fn.__name__ == hook_name:
+                                num_hooks[0] += 1
+                _count_num_forward_hooks(child, hook_name)
 
-    _count_child_hooks(module, hook_fn_name)
-    _count_hooks(module, hook_fn_name)
-    return num_hooks[0]
+    _count_num_forward_hooks(module, hook_fn_name)
+    num_hooks = num_hooks[0]
+
+    if hasattr(module, "_forward_hooks"):
+        if module._forward_hooks != OrderedDict():
+            if module._forward_hooks != OrderedDict():
+                dict_items = list(module._forward_hooks.items())
+                for i, fn in dict_items:
+                    if hook_fn_name is None or fn.__name__ == hook_fn_name:
+                        num_hooks += 1
+    return num_hooks
 
 
 class TestModuleOutputsHook(BaseTest):

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -171,8 +171,13 @@ class TestModuleOutputsHook(BaseTest):
 
         self.assertFalse(hook_module.is_ready)
 
+        i = 0
+        for target, activations in test_output.items():
+            self.assertEqual(target, target_modules[i])
+            assertTensorAlmostEqual(self, activations, test_input)
+            i += 1
+
         expected_outputs = dict.fromkeys(target_modules, None)
-        self.assertEqual(test_output, expected_outputs)
         self.assertEqual(hook_module.outputs, expected_outputs)
 
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -105,20 +105,6 @@ class TestModuleOutputsHook(BaseTest):
         n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
         self.assertEqual(n_hooks, 0)
 
-    def test_init_multiple_targets_del(self) -> None:
-        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
-        target_modules = [model[0], model[1]]
-
-        hook_module = output_hook.ModuleOutputsHook(target_modules)
-
-        n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
-        self.assertEqual(n_hooks, len(target_modules))
-
-        del hook_module
-
-        n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
-        self.assertEqual(n_hooks, 0)
-
     def test_reset_outputs_multiple_targets(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         target_modules = [model[0], model[1]]

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -242,7 +242,7 @@ class TestRemoveAllForwardHooks(BaseTest):
             self, input: Tuple[torch.Tensor], output: torch.Tensor
         ) -> None:
             pass
-        
+
         fn_name = forward_hook_unique_fn.__name__
 
         layer1 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -205,6 +205,36 @@ class TestRemoveAllForwardHooks(BaseTest):
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 0)
 
+    def test_forward_hook_removal_empty_hook_dicts(self) -> None:
+        def forward_hook_unique_fn(
+            self, input: Tuple[torch.Tensor], output: torch.Tensor
+        ) -> None:
+            pass
+
+        layer1 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        layer2 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        model = torch.nn.Sequential(layer1, layer2)
+
+        model[1].register_forward_hook(forward_hook_unique_fn)
+        model[0][1].register_forward_hook(forward_hook_unique_fn)
+
+        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn")
+        self.assertEqual(n_hooks, 2)
+
+        output_hook._remove_all_forward_hooks(model, "forward_hook_unique_fn")
+        n_hooks = _count_forward_hooks(model)
+        self.assertEqual(n_hooks, 0)
+
+        model[1].register_forward_hook(forward_hook_unique_fn)
+        model[1][1].register_forward_hook(forward_hook_unique_fn)
+
+        n_hooks = _count_forward_hooks(model, "forward_hook_unique_fn")
+        self.assertEqual(n_hooks, 2)
+
+        output_hook._remove_all_forward_hooks(model, "forward_hook_unique_fn")
+        n_hooks = _count_forward_hooks(model)
+        self.assertEqual(n_hooks, 0)
+
     def test_forward_hook_removal_unique_fn(self) -> None:
         def forward_hook_unique_fn_1(
             self, input: Tuple[torch.Tensor], output: torch.Tensor

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -14,22 +14,25 @@ def _count_forward_hooks(
     module: torch.nn.Module, hook_fn_name: Optional[str] = None
 ) -> int:
     """
-    Count the number of active forward hooks on the specified model or module.
+    Count the number of active forward hooks on the specified module instance.
+
     Args:
+
         module (nn.Module): The model module instance to count the number of
             forward hooks on.
         name (str, optional): Optionally only count specific forward hooks based on
             their function's __name__ attribute.
             Default: None
+
     Returns:
         num_hooks (int): The number of active hooks in the specified module.
     """
 
+    num_hooks: List[int] = [0]
     def _count_num_forward_hooks(
         target_module: torch.nn.Module,
         hook_name: Optional[str] = None,
-        num_hooks: int = 0,
-    ) -> int:
+    ) -> None:
 
         for name, child in target_module._modules.items():
             if child is not None:
@@ -38,19 +41,20 @@ def _count_forward_hooks(
                         dict_items = list(child._forward_hooks.items())
                         for i, fn in dict_items:
                             if hook_name is None or fn.__name__ == hook_name:
-                                num_hooks += 1
-                _count_num_forward_hooks(child, hook_name, num_hooks)
+                                num_hooks[0] += 1
+                _count_num_forward_hooks(child, hook_name)
 
-        if hasattr(target_module, "_forward_hooks"):
-            if target_module._forward_hooks != OrderedDict():
-                if target_module._forward_hooks != OrderedDict():
-                    dict_items = list(target_module._forward_hooks.items())
-                    for i, fn in dict_items:
-                        if hook_name is None or fn.__name__ == hook_name:
-                            num_hooks += 1
-        return num_hooks
+    _count_num_forward_hooks(module, hook_fn_name)
+    num_hooks = num_hooks[0]
 
-    return _count_num_forward_hooks(module, hook_fn_name)
+    if hasattr(module, "_forward_hooks"):
+        if module._forward_hooks != OrderedDict():
+            if module._forward_hooks != OrderedDict():
+                dict_items = list(module._forward_hooks.items())
+                for i, fn in dict_items:
+                    if hook_fn_name is None or fn.__name__ == hook_fn_name:
+                        num_hooks += 1
+    return num_hooks
 
 
 class TestModuleOutputsHook(BaseTest):

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -7,7 +7,7 @@ import torch
 
 import captum.optim._core.output_hook as output_hook
 from captum.optim.models import googlenet
-from tests.helpers.basic import BaseTest
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 
 
 def _count_forward_hooks(

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -10,7 +10,9 @@ from captum.optim.models import googlenet
 from tests.helpers.basic import BaseTest
 
 
-def _count_forward_hooks(module: torch.nn.Module, hook_name: Optional[str] = None) -> int:
+def _count_forward_hooks(
+    module: torch.nn.Module, hook_name: Optional[str] = None
+) -> int:
     """
     Count the number of active forward hooks on the specified model or module.
 
@@ -33,20 +35,20 @@ def _count_forward_hooks(module: torch.nn.Module, hook_name: Optional[str] = Non
                 if child._forward_hooks != OrderedDict():
                     dict_items = list(child._forward_hooks.items())
                     for i, fn in dict_items:
-                        if hook_name is None or fn.__name__ == hook_name:            
-                            num_hooks +=1
+                        if hook_name is None or fn.__name__ == hook_name:
+                            num_hooks += 1
                 elif hook_name is not None:
-                    num_hooks +=1
+                    num_hooks += 1
             _count_forward_hooks(child, hook_name)
     if hasattr(module, "_forward_hooks"):
         if module._forward_hooks != OrderedDict():
             if module._forward_hooks != OrderedDict():
                 dict_items = list(module._forward_hooks.items())
                 for i, fn in dict_items:
-                    if hook_name is None or fn.__name__ == hook_name:            
-                        num_hooks +=1
+                    if hook_name is None or fn.__name__ == hook_name:
+                        num_hooks += 1
             elif hook_name is not None:
-                num_hooks +=1
+                num_hooks += 1
     return num_hooks
 
 
@@ -77,10 +79,13 @@ class TestActivationFetcher(BaseTest):
 
 class TestRemoveAllForwardHooks(BaseTest):
     def test_forward_hook_removal(self) -> None:
-        def forward_hook_unique_fn(self, input: Tuple[torch.Tensor], output: torch.Tensor) -> None:
+        def forward_hook_unique_fn(
+            self, input: Tuple[torch.Tensor], output: torch.Tensor
+        ) -> None:
             pass
+
         layer = torch.nn.Sequential(*[torch.nn.Identity()] * 2)
-        model = torch.nn.Sequential(*[layer]*2)
+        model = torch.nn.Sequential(*[layer] * 2)
 
         model.register_forward_hook(forward_hook_unique_fn)
         model[1].register_forward_hook(forward_hook_unique_fn)
@@ -94,18 +99,23 @@ class TestRemoveAllForwardHooks(BaseTest):
         self.assertEqual(n_hooks, 0)
 
     def test_forward_hook_removal_unique_fn(self) -> None:
-        def forward_hook_unique_fn_1(self, input: Tuple[torch.Tensor], output: torch.Tensor) -> None:
+        def forward_hook_unique_fn_1(
+            self, input: Tuple[torch.Tensor], output: torch.Tensor
+        ) -> None:
             pass
-        def forward_hook_unique_fn_2(self, input: Tuple[torch.Tensor], output: torch.Tensor) -> None:
+
+        def forward_hook_unique_fn_2(
+            self, input: Tuple[torch.Tensor], output: torch.Tensor
+        ) -> None:
             pass
 
         layer = torch.nn.Sequential(*[torch.nn.Identity()] * 2)
-        model = torch.nn.Sequential(*[layer]*2)
+        model = torch.nn.Sequential(*[layer] * 2)
 
         model.register_forward_hook(forward_hook_unique_fn_1)
         model[1].register_forward_hook(forward_hook_unique_fn_1)
         model[0][1].register_forward_hook(forward_hook_unique_fn_1)
-        
+
         model.register_forward_hook(forward_hook_unique_fn_2)
         model[1][0].register_forward_hook(forward_hook_unique_fn_2)
 
@@ -124,4 +134,3 @@ class TestRemoveAllForwardHooks(BaseTest):
         output_hook._remove_all_forward_hooks(model, "forward_hook_unique_fn_2")
         n_hooks = _count_forward_hooks(model)
         self.assertEqual(n_hooks, 0)
-

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -16,8 +16,8 @@ def _count_forward_hooks(module: torch.nn.Module, hook_name: Optional[str] = Non
 
     Args:
 
-        module (nn.Module): The model instance or target module instance to count
-            the number of forward hooks on.
+        module (nn.Module): The model module instance to count the number of
+            forward hooks on.
         name (str, optional): Optionally only count specific forward hooks based on
             their function's __name__ attribute.
             Default: None
@@ -41,7 +41,7 @@ def _count_forward_hooks(module: torch.nn.Module, hook_name: Optional[str] = Non
     if hasattr(module, "_forward_hooks"):
         if module._forward_hooks != OrderedDict():
             if module._forward_hooks != OrderedDict():
-                dict_items = list(model._forward_hooks.items())
+                dict_items = list(module._forward_hooks.items())
                 for i, fn in dict_items:
                     if hook_name is None or fn.__name__ == hook_name:            
                         num_hooks +=1

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -87,6 +87,31 @@ class TestModuleOutputsHook(BaseTest):
         n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
         self.assertEqual(n_hooks, 1)
 
+    def test_consume_outputs_multiple_targets(self) -> None:
+        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        target_modules = [model[0], model[1]]
+        test_input = torch.randn(1, 3, 4, 4)
+        
+        hook_module = output_hook.ModuleOutputsHook(target_modules)
+        _ = model(test_input)
+        
+        test_outputs = hook_module.outputs
+        self.assertIsInstance(test_outputs, dict)
+        self.assertEqual(len(test_outputs), len(target_modules))
+
+        for target, activations, i in zip(test_outputs.items(), list(range(len(target_modules))):
+            self.assertEqual(target, target_modules[i])
+            assertTensorAlmostEqual(self, target_activations, test_input)
+
+        self.assertFalse(hook_module.is_ready)
+
+        outputs_dict = hook_module.consume_outputs()
+        
+        outputs = dict.fromkeys(target_modules, None)
+        self.assertEqual(outputs, hook_module.outputs)
+
+        self.assertTrue(hook_module.is_ready)
+
 
 class TestActivationFetcher(BaseTest):
     def test_activation_fetcher(self) -> None:

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -15,12 +15,15 @@ def _count_forward_hooks(
 ) -> int:
     """
     Count the number of active forward hooks on the specified module instance.
+
     Args:
+
         module (nn.Module): The model module instance to count the number of
             forward hooks on.
         name (str, optional): Optionally only count specific forward hooks based on
             their function's __name__ attribute.
             Default: None
+
     Returns:
         num_hooks (int): The number of active hooks in the specified module.
     """

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -29,32 +29,28 @@ def _count_forward_hooks(
     """
 
     num_hooks: List[int] = [0]
-    def _count_num_forward_hooks(
+
+    def _count_hooks(m: torch.nn.Module, name: Optional[str] = None) -> None:
+        if hasattr(m, "_forward_hooks"):
+            if m._forward_hooks != OrderedDict():
+                dict_items = list(m._forward_hooks.items())
+                for i, fn in dict_items:
+                    if hook_fn_name is None or fn.__name__ == name:
+                        num_hooks[0] += 1
+
+    def _count_child_hooks(
         target_module: torch.nn.Module,
         hook_name: Optional[str] = None,
     ) -> None:
 
         for name, child in target_module._modules.items():
             if child is not None:
-                if hasattr(child, "_forward_hooks"):
-                    if child._forward_hooks != OrderedDict():
-                        dict_items = list(child._forward_hooks.items())
-                        for i, fn in dict_items:
-                            if hook_name is None or fn.__name__ == hook_name:
-                                num_hooks[0] += 1
-                _count_num_forward_hooks(child, hook_name)
+                _count_hooks(child, hook_name)
+                _count_child_hooks(child, hook_name)
 
     _count_num_forward_hooks(module, hook_fn_name)
-    num_hooks = num_hooks[0]
-
-    if hasattr(module, "_forward_hooks"):
-        if module._forward_hooks != OrderedDict():
-            if module._forward_hooks != OrderedDict():
-                dict_items = list(module._forward_hooks.items())
-                for i, fn in dict_items:
-                    if hook_fn_name is None or fn.__name__ == hook_fn_name:
-                        num_hooks += 1
-    return num_hooks
+    _count_hooks(module, hook_fn_name)
+    return num_hooks[0]
 
 
 class TestModuleOutputsHook(BaseTest):

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -37,8 +37,6 @@ def _count_forward_hooks(
                     for i, fn in dict_items:
                         if hook_name is None or fn.__name__ == hook_name:
                             num_hooks += 1
-                elif hook_name is None:
-                    num_hooks += 1
             _count_forward_hooks(child, hook_name)
     if hasattr(module, "_forward_hooks"):
         if module._forward_hooks != OrderedDict():
@@ -47,8 +45,6 @@ def _count_forward_hooks(
                 for i, fn in dict_items:
                     if hook_name is None or fn.__name__ == hook_name:
                         num_hooks += 1
-            elif hook_name is None:
-                num_hooks += 1
     return num_hooks
 
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -55,7 +55,7 @@ def _count_forward_hooks(
 
 class TestModuleOutputsHook(BaseTest):
     def test_init_hook_duplication_fix(self) -> None:
-        model = torch.nn.Sequential(*[torch.nn.Identity()] * 2)
+        model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         for i in range(5):
             _ = output_hook.ModuleOutputsHook([model[1]])
         n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
@@ -85,8 +85,9 @@ class TestRemoveAllForwardHooks(BaseTest):
         ) -> None:
             pass
 
-        layer = torch.nn.Sequential(*[torch.nn.Identity()] * 2)
-        model = torch.nn.Sequential(*[layer] * 2)
+        layer1 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        layer2 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        model = torch.nn.Sequential(layer1, layer2)
 
         model.register_forward_hook(forward_hook_unique_fn)
         model[1].register_forward_hook(forward_hook_unique_fn)
@@ -110,8 +111,9 @@ class TestRemoveAllForwardHooks(BaseTest):
         ) -> None:
             pass
 
-        layer = torch.nn.Sequential(*[torch.nn.Identity()] * 2)
-        model = torch.nn.Sequential(*[layer] * 2)
+        layer1 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        layer2 = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
+        model = torch.nn.Sequential(layer1, layer2)
 
         model.register_forward_hook(forward_hook_unique_fn_1)
         model[1].register_forward_hook(forward_hook_unique_fn_1)

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -125,18 +125,22 @@ class TestModuleOutputsHook(BaseTest):
         hook_module = output_hook.ModuleOutputsHook(target_modules)
         _ = model(test_input)
         
-        test_outputs = hook_module.outputs
-        self.assertIsInstance(test_outputs, dict)
-        self.assertEqual(len(test_outputs), len(target_modules))
+        test_outputs_dict = hook_module.outputs
+        self.assertIsInstance(test_outputs_dict, dict)
+        self.assertEqual(len(test_outputs_dict), len(target_modules))
 
-        for target, activations, i in zip(test_outputs.items(), list(range(len(target_modules))):
+        for target, activations, i in zip(test_outputs_dict.items(), list(range(len(target_modules))):
             self.assertEqual(target, target_modules[i])
             assertTensorAlmostEqual(self, target_activations, test_input)
 
         self.assertFalse(hook_module.is_ready)
 
-        outputs_dict = hook_module.consume_outputs()
-        
+        test_output = hook_module.consume_outputs()
+
+        for target, activations, i in zip(test_output.items(), list(range(len(target_modules))):
+            self.assertEqual(target, target_modules[i])
+            self.assertIsNone(target_activations)
+
         outputs = dict.fromkeys(target_modules, None)
         self.assertEqual(outputs, hook_module.outputs)
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -57,7 +57,7 @@ class TestModuleOutputsHook(BaseTest):
     def test_init_single_target(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         target_modules = [model[0]]
-        
+
         hook_module = output_hook.ModuleOutputsHook(target_modules)
         self.assertEqual(len(hook_module.hooks), len(target_modules))
 
@@ -72,7 +72,7 @@ class TestModuleOutputsHook(BaseTest):
     def test_init_multiple_targets(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         target_modules = [model[0], model[1]]
-        
+
         hook_module = output_hook.ModuleOutputsHook(target_modules)
         self.assertEqual(len(hook_module.hooks), len(target_modules))
 
@@ -94,7 +94,7 @@ class TestModuleOutputsHook(BaseTest):
     def test_init_multiple_targets_remove_hooks(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         target_modules = [model[0], model[1]]
-        
+
         hook_module = output_hook.ModuleOutputsHook(target_modules)
 
         n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
@@ -108,7 +108,7 @@ class TestModuleOutputsHook(BaseTest):
     def test_init_multiple_targets_del(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         target_modules = [model[0], model[1]]
-        
+
         hook_module = output_hook.ModuleOutputsHook(target_modules)
 
         n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
@@ -123,7 +123,7 @@ class TestModuleOutputsHook(BaseTest):
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         target_modules = [model[0], model[1]]
         test_input = torch.randn(1, 3, 4, 4)
-        
+
         hook_module = output_hook.ModuleOutputsHook(target_modules)
         self.assertTrue(hook_module.is_ready)
 
@@ -132,9 +132,11 @@ class TestModuleOutputsHook(BaseTest):
         self.assertFalse(hook_module.is_ready)
 
         outputs_dict = hook_module.outputs
-        for target, activations, i in zip(outputs_dict.items(), list(range(len(target_modules))):
+        for target, activations, i in zip(
+            outputs_dict.items(), list(range(len(target_modules)))
+        ):
             self.assertEqual(target, target_modules[i])
-            assertTensorAlmostEqual(self, target_activations, test_input)
+            assertTensorAlmostEqual(self, activations, test_input)
 
         hook_module._reset_outputs()
 
@@ -147,21 +149,23 @@ class TestModuleOutputsHook(BaseTest):
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
         target_modules = [model[0], model[1]]
         test_input = torch.randn(1, 3, 4, 4)
-        
+
         hook_module = output_hook.ModuleOutputsHook(target_modules)
         self.assertTrue(hook_module.is_ready)
 
         _ = model(test_input)
-        
+
         self.assertFalse(hook_module.is_ready)
-        
+
         test_outputs_dict = hook_module.outputs
         self.assertIsInstance(test_outputs_dict, dict)
         self.assertEqual(len(test_outputs_dict), len(target_modules))
 
-        for target, activations, i in zip(test_outputs_dict.items(), list(range(len(target_modules))):
+        for target, activations, i in zip(
+            test_outputs_dict.items(), list(range(len(target_modules)))
+        ):
             self.assertEqual(target, target_modules[i])
-            assertTensorAlmostEqual(self, target_activations, test_input)
+            assertTensorAlmostEqual(self, activations, test_input)
 
         test_output = hook_module.consume_outputs()
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -67,7 +67,7 @@ class TestModuleOutputsHook(BaseTest):
         outputs = dict.fromkeys(target_modules, None)
         self.assertEqual(outputs, hook_module.outputs)
         self.assertEqual(list(hook_module.targets), target_modules)
-        self.assertTrue(hook_module.is_ready)
+        self.assertFalse(hook_module.is_ready)
 
     def test_init_multiple_targets(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
@@ -82,7 +82,7 @@ class TestModuleOutputsHook(BaseTest):
         outputs = dict.fromkeys(target_modules, None)
         self.assertEqual(outputs, hook_module.outputs)
         self.assertEqual(list(hook_module.targets), target_modules)
-        self.assertTrue(hook_module.is_ready)
+        self.assertFalse(hook_module.is_ready)
 
     def test_init_hook_duplication_fix(self) -> None:
         model = torch.nn.Sequential(torch.nn.Identity(), torch.nn.Identity())
@@ -125,11 +125,11 @@ class TestModuleOutputsHook(BaseTest):
         test_input = torch.randn(1, 3, 4, 4)
 
         hook_module = output_hook.ModuleOutputsHook(target_modules)
-        self.assertTrue(hook_module.is_ready)
+        self.assertFalse(hook_module.is_ready)
 
         _ = model(test_input)
 
-        self.assertFalse(hook_module.is_ready)
+        self.assertTrue(hook_module.is_ready)
 
         outputs_dict = hook_module.outputs
         i = 0
@@ -140,7 +140,7 @@ class TestModuleOutputsHook(BaseTest):
 
         hook_module._reset_outputs()
 
-        self.assertTrue(hook_module.is_ready)
+        self.assertFalse(hook_module.is_ready)
 
         expected_outputs = dict.fromkeys(target_modules, None)
         self.assertEqual(hook_module.outputs, expected_outputs)
@@ -151,11 +151,11 @@ class TestModuleOutputsHook(BaseTest):
         test_input = torch.randn(1, 3, 4, 4)
 
         hook_module = output_hook.ModuleOutputsHook(target_modules)
-        self.assertTrue(hook_module.is_ready)
+        self.assertFalse(hook_module.is_ready)
 
         _ = model(test_input)
 
-        self.assertFalse(hook_module.is_ready)
+        self.assertTrue(hook_module.is_ready)
 
         test_outputs_dict = hook_module.outputs
         self.assertIsInstance(test_outputs_dict, dict)
@@ -169,7 +169,7 @@ class TestModuleOutputsHook(BaseTest):
 
         test_output = hook_module.consume_outputs()
 
-        self.assertTrue(hook_module.is_ready)
+        self.assertFalse(hook_module.is_ready)
 
         expected_outputs = dict.fromkeys(target_modules, None)
         self.assertEqual(test_output, expected_outputs)

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import unittest
 from collections import OrderedDict
-from typing import Optional, Tuple, cast
+from typing import List, Optional, Tuple, cast
 
 import torch
 
@@ -29,32 +29,27 @@ def _count_forward_hooks(
     """
 
     num_hooks: List[int] = [0]
-    def _count_num_forward_hooks(
+
+    def _count_hooks(m: torch.nn.Module, name: Optional[str] = None) -> None:
+        if hasattr(m, "_forward_hooks"):
+            if m._forward_hooks != OrderedDict():
+                dict_items = list(m._forward_hooks.items())
+                for i, fn in dict_items:
+                    if hook_fn_name is None or fn.__name__ == name:
+                        num_hooks[0] += 1
+
+    def _count_child_hooks(
         target_module: torch.nn.Module,
         hook_name: Optional[str] = None,
     ) -> None:
-
         for name, child in target_module._modules.items():
             if child is not None:
-                if hasattr(child, "_forward_hooks"):
-                    if child._forward_hooks != OrderedDict():
-                        dict_items = list(child._forward_hooks.items())
-                        for i, fn in dict_items:
-                            if hook_name is None or fn.__name__ == hook_name:
-                                num_hooks[0] += 1
-                _count_num_forward_hooks(child, hook_name)
+                _count_hooks(child, hook_name)
+                _count_child_hooks(child, hook_name)
 
     _count_num_forward_hooks(module, hook_fn_name)
-    num_hooks = num_hooks[0]
-
-    if hasattr(module, "_forward_hooks"):
-        if module._forward_hooks != OrderedDict():
-            if module._forward_hooks != OrderedDict():
-                dict_items = list(module._forward_hooks.items())
-                for i, fn in dict_items:
-                    if hook_fn_name is None or fn.__name__ == hook_fn_name:
-                        num_hooks += 1
-    return num_hooks
+    _count_hooks(module, hook_fn_name)
+    return num_hooks[0]
 
 
 class TestModuleOutputsHook(BaseTest):

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -13,10 +13,6 @@ from tests.helpers.basic import BaseTest
 def _count_forward_hooks(model: torch.nn.Module, hook_name: Optional[str] = None) -> int:
     """
     Count the number of active forward hooks on the specified model or module.
-    By default nn.Module instance do not have a "_forward_hooks" attribute, and
-    we can only remove the hooks without their handles by setting them to their
-    default of 'OrderedDict()'. So just because a module has the right attribute,
-    doesn't mean that we need to count it.
 
     Args:
 

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -53,7 +53,7 @@ class TestModuleOutputsHook(BaseTest):
         model = torch.nn.Sequential(*[torch.nn.Identity()] * 2)
         for i in range(5):
             _ = output_hook.ModuleOutputsHook([model[1]])
-        n_hooks = _count_forward_hooks(model)
+        n_hooks = _count_forward_hooks(model, "module_outputs_forward_hook")
         self.assertEqual(n_hooks, 1)
 
 


### PR DESCRIPTION
Currently there a sort of 'bug' where unused forward hooks aren't removed. Every time an instance of `InputOptimization` is created, global hooks are created in `ModuleOutputsHook()`'s initialization function for the target modules. These hooks remain until `InputOptimization.optimze` has finished running or `InputOptimization.cleanup()` has been run. This means that there is the potential for unused 'ghost' hooks to remain that can interfere with things like TorchScript / JIT as these unused hooks technically still exist.

To resolve this issue, my fix checks for the presence of forward hooks and then removes them (without requiring hook handles), so that every time an instance of `InputOptimization` is created, and by extension `ModuleOutputsHook` is run, old hooks are removed.

* Added the `_remove_all_forward_hooks` function for easy cleanup and removal of hooks without requiring their handles.

* Changed `ModuleOutputHook`'s forward hook function name from `forward_hook` to `module_outputs_forward_hook` to allow for easy removal of only hooks using that hook function.

* `ModuleOutputHook`'s initialization function now runs the `_remove_all_forward_hooks` function on targets, and only removes the hooks created by `ModuleOutputHook` to avoid breaking PyTorch.

* Added the `_count_forward_hooks` function for easy testing of hook creation & removal functionality.

* Added tests for verifying that the 'ghost hook' bug has been fixed, and that the new function is working correctly.

* Added tests for `ModuleOutputsHook`. Previously we had no tests for this module.