### PR TITLE
Add ImageParameterization Instance support for NaturalImage & JIT support for SharedImage

### DIFF
--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -620,7 +620,7 @@ class NaturalImage(ImageParameterization):
                 nn.Parameter tensor, or stacking init images.
                 Default: 1
             parameterization (ImageParameterization, optional): An image
-                parameterization class.
+                parameterization class, or instance of an image parameterization class.
                 Default: FFTImage
             squash_func (Callable[[torch.Tensor], torch.Tensor]], optional): The squash
                 function to use after color recorrelation. A funtion or lambda function.
@@ -632,6 +632,10 @@ class NaturalImage(ImageParameterization):
                 Default: True
         """
         super().__init__()
+        if not isinstance(parameterization, ImageParameterization)
+            assert issubclass(parameterization, ImageParameterization)
+        else:
+            assert isinstance(parameterization, ImageParameterization)
         self.decorrelate = decorrelation_module
         if init is not None:
             assert init.dim() == 3 or init.dim() == 4
@@ -647,9 +651,11 @@ class NaturalImage(ImageParameterization):
                 squash_func = self._clamp_image
 
         self.squash_func = torch.sigmoid if squash_func is None else squash_func
-        self.parameterization = parameterization(
-            size=size, channels=channels, batch=batch, init=init
-        )
+        if not isinstance(parameterization, ImageParameterization):
+            parameterization = parameterization(
+                size=size, channels=channels, batch=batch, init=init
+            )
+        self.parameterization = parameterization
 
     @torch.jit.export
     def _clamp_image(self, x: torch.Tensor) -> torch.Tensor:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -603,7 +603,7 @@ class SharedImage(ImageParameterization):
         image = self.parameterization()
         x = [
             self._interpolate_tensor(
-                shared_tensor,
+                shared_tensor(),
                 image.size(0),
                 image.size(1),
                 image.size(2),

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -632,7 +632,7 @@ class NaturalImage(ImageParameterization):
                 Default: True
         """
         super().__init__()
-        if not isinstance(parameterization, ImageParameterization)
+        if not isinstance(parameterization, ImageParameterization):
             # Verify uninitialized class is correct type
             assert issubclass(parameterization, ImageParameterization)
         else:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -633,11 +633,13 @@ class NaturalImage(ImageParameterization):
         """
         super().__init__()
         if not isinstance(parameterization, ImageParameterization)
+            # Verify unitialized class is correct type
             assert issubclass(parameterization, ImageParameterization)
         else:
             assert isinstance(parameterization, ImageParameterization)
+
         self.decorrelate = decorrelation_module
-        if init is not None:
+        if init is not None and not isinstance(parameterization, ImageParameterization):
             assert init.dim() == 3 or init.dim() == 4
             if decorrelate_init and self.decorrelate is not None:
                 init = (

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -497,6 +497,7 @@ class SharedImage(ImageParameterization):
         assert all([all([type(o) is int for o in v]) for v in offset])
         return offset
 
+    @torch.jit.ignore
     def _apply_offset(self, x_list: List[torch.Tensor]) -> List[torch.Tensor]:
         """
         Apply list of offsets to list of tensors.
@@ -530,6 +531,7 @@ class SharedImage(ImageParameterization):
             A.append(x)
         return A
 
+    @torch.jit.ignore
     def _interpolate_tensor(
         self, x: torch.Tensor, batch: int, channels: int, height: int, width: int
     ) -> torch.Tensor:
@@ -582,7 +584,7 @@ class SharedImage(ImageParameterization):
         ]
         if self.offset is not None:
             x = self._apply_offset(x)
-        output = image + sum(x)
+        output = image + torch.cat(x, 0).sum(0, keepdim=True)
 
         if self._supports_is_scripting:
             if torch.jit.is_scripting():

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -319,8 +319,6 @@ class PixelImage(ImageParameterization):
             assert init.dim() == 3 or init.dim() == 4
             if init.dim() == 3:
                 init = init.unsqueeze(0)
-            assert init.shape[1] == 3, "PixelImage init should have 3 channels, "
-            f"input has {init.shape[1]} channels."
         self.image = nn.Parameter(init)
 
         # Check & store whether or not we can use torch.jit.is_scripting()

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -633,7 +633,7 @@ class NaturalImage(ImageParameterization):
         """
         super().__init__()
         if not isinstance(parameterization, ImageParameterization)
-            # Verify unitialized class is correct type
+            # Verify uninitialized class is correct type
             assert issubclass(parameterization, ImageParameterization)
         else:
             assert isinstance(parameterization, ImageParameterization)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -843,7 +843,8 @@ class TestSharedImage(BaseTest):
     def test_sharedimage_multiple_shapes_diff_len_forward_jit_module(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
-                "Skipping SharedImage JIT module test due to insufficient Torch version."
+                "Skipping SharedImage JIT module test due to insufficient Torch"
+                + " version."
             )
 
         shared_shapes = (

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -473,6 +473,27 @@ class TestLaplacianImage(BaseTest):
         assertArraysAlmostEqual(np.ones_like(test_np) * 0.5, test_np)
 
 
+class TestSimpleTensorParameterization(BaseTest):
+    def test_simple_tensor_parameterization_no_grad(self) -> None:
+        test_input = torch.randn(1, 3, 4, 4)
+        image_param = images.SimpleTensorParameterization(test_input)
+        assertTensorAlmostEqual(self, image_param.tensor, test_input, 0.0)
+        self.assertFalse(image_param.tensor.requires_grad)
+
+        test_output = image_param()
+        assertTensorAlmostEqual(self, test_output, test_input, 0.0)
+        self.assertFalse(image_param.tensor.requires_grad)
+
+    def test_simple_tensor_parameterization_jit_module_no_grad(self) -> None:
+        test_input = torch.randn(1, 3, 4, 4)
+        image_param = images.SimpleTensorParameterization(test_input)
+        jit_image_param = torch.jit.script(image_param)
+
+        test_output = image_param()
+        assertTensorAlmostEqual(self, test_output, test_input, 0.0)
+        self.assertFalse(image_param.tensor.requires_grad)
+
+
 class TestSharedImage(BaseTest):
     def test_sharedimage_get_offset_single_number(self) -> None:
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -813,7 +813,7 @@ class TestNaturalImage(BaseTest):
                 "Skipping NaturalImage FFTImage init func FFTImage instance test due"
                 + " to insufficient Torch version."
             )
-            
+
         fft_param = images.FFTImage(size=(4, 4))
         image_param = images.NaturalImage(parameterization=fft_param)
         self.assertIsInstance(image_param.parameterization, images.FFTImage)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -796,7 +796,7 @@ class TestNaturalImage(BaseTest):
         self.assertIsInstance(image_param.decorrelate, ToRGB)
         self.assertEqual(image_param.squash_func, torch.sigmoid)
 
-    def test_natural_image_init_func_fft_image(self) -> None:
+    def test_natural_image_init_func_fftimage(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
                 "Skipping NaturalImage FFTImage init func test due to insufficient"
@@ -807,7 +807,20 @@ class TestNaturalImage(BaseTest):
         self.assertIsInstance(image_param.decorrelate, ToRGB)
         self.assertEqual(image_param.squash_func, torch.sigmoid)
 
-    def test_natural_image_init_func_pixel_image(self) -> None:
+    def test_natural_image_init_func_fftimage_instance(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage FFTImage init func FFTImage instance test due"
+                + " to insufficient Torch version."
+            )
+            
+        fft_param = images.FFTImage(size=(4, 4))
+        image_param = images.NaturalImage(parameterization=fft_param)
+        self.assertIsInstance(image_param.parameterization, images.FFTImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+
+    def test_natural_image_init_func_pixelimage(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
                 "Skipping NaturalImage PixelImage init func test due to insufficient"
@@ -831,7 +844,7 @@ class TestNaturalImage(BaseTest):
         self.assertIsInstance(image_param.decorrelate, ToRGB)
         self.assertEqual(image_param.squash_func, image_param._clamp_image)
 
-    def test_natural_image_init_tensor_pixel_image_sf_sigmoid(self) -> None:
+    def test_natural_image_init_tensor_pixelimage_sf_sigmoid(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
                 "Skipping NaturalImage PixelImage init tensor with sigmoid"
@@ -897,7 +910,7 @@ class TestNaturalImage(BaseTest):
         output_tensor = jit_image_param()
         assertTensorAlmostEqual(self, output_tensor, torch.ones_like(output_tensor))
 
-    def test_natural_image_jit_module_init_tensor_pixel_image(self) -> None:
+    def test_natural_image_jit_module_init_tensor_pixelimage(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
                 "Skipping NaturalImage PixelImage init tensor JIT module"


### PR DESCRIPTION
* Added `ImageParameterization` instance support for `NaturalImage`.
* Added asserts verify parameterization inputs are instances or types of `ImageParameterization`.
These changes should make it easier to use parameterization enhancements like `SharedImage`, and will be helpful for custom parameterizations that don't use the standard input variable set (`size`, `channels`, `batch`, & `init`).