### PR TITLE
New StackImage & JIT support for SharedImage

### DIFF
--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -412,10 +412,10 @@ class SimpleTensorParameterization(ImageParameterization):
     Parameterize a simple tensor with or without it requiring grad.
     Compared to PixelImage, this parameterization has no specific shape requirements
     and does not wrap inputs in nn.Parameter.
-    
+
     This parameterization can for example be combined with StackImage for batch
     dimensions that both require and don't require gradients.
-    
+
     This parameterization can also be combined with nn.ModuleList as workaround for
     TorchScript / JIT not supporting nn.ParameterList. SharedImage uses this module
     internally for this purpose.
@@ -447,6 +447,7 @@ class SharedImage(ImageParameterization):
     Mordvintsev, et al., "Differentiable Image Parameterizations", Distill, 2018.
     https://distill.pub/2018/differentiable-parameterizations/
     """
+
     __constants__ = ["offset", "_supports_is_scripting"]
 
     def __init__(
@@ -474,7 +475,9 @@ class SharedImage(ImageParameterization):
             assert len(shape) >= 2 and len(shape) <= 4
             shape = ([1] * (4 - len(shape))) + list(shape)
             batch, channels, height, width = shape
-            shape_param = torch.nn.Parameter(torch.randn([batch, channels, height, width]))
+            shape_param = torch.nn.Parameter(
+                torch.randn([batch, channels, height, width])
+            )
             A.append(SimpleTensorParameterization(shape_param))
         self.shared_init = torch.nn.ModuleList(A)
         self.parameterization = parameterization
@@ -629,8 +632,16 @@ class StackImage(ImageParameterization):
         super().__init__()
         assert len(parameterizations) > 0
         assert isinstance(parameterizations, (list, tuple))
-        assert all([isinstance(param, (ImageParameterization, torch.Tensor)) for param in parameterizations])
-        parameterizations = [SimpleTensorParameterization(p) if isinstance(p, torch.Tensor) else p for p in parameterizations]
+        assert all(
+            [
+                isinstance(param, (ImageParameterization, torch.Tensor))
+                for param in parameterizations
+            ]
+        )
+        parameterizations = [
+            SimpleTensorParameterization(p) if isinstance(p, torch.Tensor) else p
+            for p in parameterizations
+        ]
         self.parameterizations = torch.nn.ModuleList(parameterizations)
         self.output_device = output_device
 
@@ -652,7 +663,7 @@ class StackImage(ImageParameterization):
 
         assert P[0].dim() == 4
         assert all([im.shape == P[0].shape for im in P])
-        assert all([im.device == P[0].device for im in P])  
+        assert all([im.device == P[0].device for im in P])
 
         image = torch.cat(P, 0)
         if self._supports_is_scripting:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -630,7 +630,7 @@ class StackImage(opt.images.ImageParameterization):
         assert len(parameterizations) > 0
         assert isinstance(parameterizations, (list, tuple))
         assert all([isinstance(param, (opt.images.ImageParameterization, torch.Tensor)) for param in parameterizations])
-        parameterizations = [SimpleTensorParameterization(p) for p in parameterizations if isinstance(p, torch.Tensor) else p]
+        parameterizations = [SimpleTensorParameterization(p) if isinstance(p, torch.Tensor) else p for p in parameterizations]
         self.parameterizations = torch.nn.ModuleList(parameterizations)
         self.output_device = output_device
 

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -603,7 +603,7 @@ class SharedImage(ImageParameterization):
         return output.refine_names("B", "C", "H", "W")
 
 
-class StackImage(opt.images.ImageParameterization):
+class StackImage(ImageParameterization):
     """
     Stack multiple NCHW image parameterizations along their batch dimensions.
     """
@@ -612,7 +612,7 @@ class StackImage(opt.images.ImageParameterization):
 
     def __init__(
         self,
-        parameterizations: List[Union[opt.images.ImageParameterization, torch.Tensor]],
+        parameterizations: List[Union[ImageParameterization, torch.Tensor]],
         output_device: Optional[torch.device] = None,
     ) -> None:
         """
@@ -629,7 +629,7 @@ class StackImage(opt.images.ImageParameterization):
         super().__init__()
         assert len(parameterizations) > 0
         assert isinstance(parameterizations, (list, tuple))
-        assert all([isinstance(param, (opt.images.ImageParameterization, torch.Tensor)) for param in parameterizations])
+        assert all([isinstance(param, (ImageParameterization, torch.Tensor)) for param in parameterizations])
         parameterizations = [SimpleTensorParameterization(p) if isinstance(p, torch.Tensor) else p for p in parameterizations]
         self.parameterizations = torch.nn.ModuleList(parameterizations)
         self.output_device = output_device

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -731,7 +731,7 @@ class TestStackImage(BaseTest):
         fft_param_1 = images.FFTImage(size=size)
         fft_param_2 = images.FFTImage(size=size)
         param_list = [fft_param_1, fft_param_2]
-        stack_param = StackImage(parameterizations=param_list)
+        stack_param = images.StackImage(parameterizations=param_list)
         for image_param in stack_param.parameterizations:
             self.assertIsInstance(image_param, images.FFTImage)
             self.assertEqual(list(image_param().shape), [1, 3] + list(size))
@@ -742,7 +742,7 @@ class TestStackImage(BaseTest):
         fft_param_1 = images.FFTImage(size=size)
         fft_param_2 = images.FFTImage(size=size)
         param_list = [fft_param_1, fft_param_2]
-        stack_param = StackImage(parameterizations=param_list)
+        stack_param = images.StackImage(parameterizations=param_list)
         for image_param in stack_param.parameterizations:
             self.assertIsInstance(image_param, images.FFTImage)
             self.assertEqual(list(image_param().shape), [1, 3] + list(size))
@@ -759,7 +759,7 @@ class TestStackImage(BaseTest):
         pixel_param = images.PixelImage(size=size)
         param_list = [fft_param, pixel_param]
 
-        stack_param = StackImage(parameterizations=param_list)
+        stack_param = images.StackImage(parameterizations=param_list)
 
         type_list = [images.FFTImage, images.PixelImage]
         for image_param, expected_type in zip(stack_param.parameterizations, type_list):

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -747,7 +747,7 @@ class TestStackImage(BaseTest):
             self.assertIsInstance(image_param, images.FFTImage)
             self.assertEqual(list(image_param().shape), [1, 3] + list(size))
             self.assertTrue(image_param().requires_grad)
-        
+
         output_tensor = stack_param()
         self.assertEqual(list(output_tensor.shape), [2, 3] + list(size))
         self.assertTrue(output_tensor.requires_grad)
@@ -766,7 +766,7 @@ class TestStackImage(BaseTest):
             self.assertIsInstance(image_param, expected_type)
             self.assertEqual(list(image_param().shape), [1, 3] + list(size))
             self.assertTrue(image_param().requires_grad)
-        
+
         output_tensor = stack_param()
         self.assertEqual(list(output_tensor.shape), [2, 3] + list(size))
         self.assertTrue(output_tensor.requires_grad)
@@ -783,31 +783,37 @@ class TestStackImage(BaseTest):
                 + " GPUs available."
             )
         size = (4, 4)
-        
+
         num_cuda_devices = torch.cuda.device_count()
         param_list, device_list = [], []
- 
+
         fft_param = images.FFTImage(size=size).cpu()
         param_list.append(fft_param)
         device_list.append(torch.device("cpu"))
- 
-        for i in range(num_cuda_devices-1):
+
+        for i in range(num_cuda_devices - 1):
             device = torch.device("cuda:" + str(i))
             device_list.append(device)
             fft_param = images.FFTImage(size=size).to(device)
             param_list.append(fft_param)
 
-        output_device = torch.device("cuda:" + num_cuda_devices-1)
-        stack_param = images.StackImage(parameterizations=param_list, output_device=output_device)
+        output_device = torch.device("cuda:" + num_cuda_devices - 1)
+        stack_param = images.StackImage(
+            parameterizations=param_list, output_device=output_device
+        )
 
-        for image_param, torch_device in zip(stack_param.parameterizations, device_list):
+        for image_param, torch_device in zip(
+            stack_param.parameterizations, device_list
+        ):
             self.assertIsInstance(image_param, images.FFTImage)
             self.assertEqual(list(image_param().shape), [1, 3] + list(size))
             self.assertEqual(image_param().device, torch_device)
             self.assertTrue(image_param().requires_grad)
-        
+
         output_tensor = stack_param()
-        self.assertEqual(list(output_tensor.shape), list(len(param_list)) + [3] + list(size))
+        self.assertEqual(
+            list(output_tensor.shape), list(len(param_list)) + [3] + list(size)
+        )
         self.assertTrue(output_tensor.requires_grad)
         self.assertEqual(stack_param().device, output_device)
 
@@ -818,11 +824,10 @@ class TestStackImage(BaseTest):
             )
         size = (4, 4)
         param_list, device_list = [], []
- 
+
         fft_param = images.FFTImage(size=size).cpu()
         param_list.append(fft_param)
         device_list.append(torch.device("cpu"))
- 
 
         device = torch.device("cuda:0")
         device_list.append(device)
@@ -830,16 +835,22 @@ class TestStackImage(BaseTest):
         param_list.append(fft_param)
 
         output_device = torch.device("cuda:0")
-        stack_param = images.StackImage(parameterizations=param_list, output_device=output_device)
+        stack_param = images.StackImage(
+            parameterizations=param_list, output_device=output_device
+        )
 
-        for image_param, torch_device in zip(stack_param.parameterizations, device_list):
+        for image_param, torch_device in zip(
+            stack_param.parameterizations, device_list
+        ):
             self.assertIsInstance(image_param, images.FFTImage)
             self.assertEqual(list(image_param().shape), [1, 3] + list(size))
             self.assertEqual(image_param().device, torch_device)
-            self.assertTrue(image_param().requires_grad)       
-        
+            self.assertTrue(image_param().requires_grad)
+
         output_tensor = stack_param()
-        self.assertEqual(list(output_tensor.shape), list(len(param_list)) + [3] + list(size))
+        self.assertEqual(
+            list(output_tensor.shape), list(len(param_list)) + [3] + list(size)
+        )
         self.assertTrue(output_tensor.requires_grad)
         self.assertEqual(stack_param().device, output_device)
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -341,7 +341,7 @@ class TestSimpleTensorParameterization(BaseTest):
         image_param = images.SimpleTensorParameterization(test_input)
         jit_image_param = torch.jit.script(image_param)
 
-        test_output = image_param()
+        test_output = jit_image_param()
         assertTensorAlmostEqual(self, test_output, test_input, 0.0)
         self.assertFalse(image_param.tensor.requires_grad)
 
@@ -360,7 +360,7 @@ class TestSimpleTensorParameterization(BaseTest):
         image_param = images.SimpleTensorParameterization(test_input)
         jit_image_param = torch.jit.script(image_param)
 
-        test_output = image_param()
+        test_output = jit_image_param()
         assertTensorAlmostEqual(self, test_output, test_input, 0.0)
         self.assertTrue(image_param.tensor.requires_grad)
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -863,7 +863,7 @@ class TestStackImage(BaseTest):
 
         output_tensor = stack_param()
         self.assertEqual(
-            list(output_tensor.shape), list(len(param_list)) + [3] + list(size)
+            list(output_tensor.shape), [len(param_list)] + [3] + list(size)
         )
         self.assertTrue(output_tensor.requires_grad)
         self.assertEqual(stack_param().device, output_device)
@@ -900,7 +900,7 @@ class TestStackImage(BaseTest):
 
         output_tensor = stack_param()
         self.assertEqual(
-            list(output_tensor.shape), list(len(param_list)) + [3] + list(size)
+            list(output_tensor.shape), [len(param_list)] + [3] + list(size)
         )
         self.assertTrue(output_tensor.requires_grad)
         self.assertEqual(stack_param().device, output_device)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -781,7 +781,11 @@ class TestStackImage(BaseTest):
 
         stack_param = images.StackImage(parameterizations=param_list)
 
-        type_list = [images.FFTImage, images.PixelImage, images.SimpleTensorParameterization]
+        type_list = [
+            images.FFTImage,
+            images.PixelImage,
+            images.SimpleTensorParameterization,
+        ]
         for image_param, expected_type in zip(stack_param.parameterizations, type_list):
             self.assertIsInstance(image_param, expected_type)
             self.assertEqual(list(image_param().shape), [1, 3] + list(size))
@@ -801,7 +805,11 @@ class TestStackImage(BaseTest):
 
         stack_param = images.StackImage(parameterizations=param_list)
 
-        type_list = [images.FFTImage, images.PixelImage, images.SimpleTensorParameterization]
+        type_list = [
+            images.FFTImage,
+            images.PixelImage,
+            images.SimpleTensorParameterization,
+        ]
         for image_param, expected_type in zip(stack_param.parameterizations, type_list):
             self.assertIsInstance(image_param, expected_type)
             self.assertEqual(list(image_param().shape), [1, 3] + list(size))

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -797,7 +797,7 @@ class TestStackImage(BaseTest):
             fft_param = images.FFTImage(size=size).to(device)
             param_list.append(fft_param)
 
-        output_device = torch.device("cuda:" + num_cuda_devices - 1)
+        output_device = torch.device("cuda:" + str(num_cuda_devices - 1))
         stack_param = images.StackImage(
             parameterizations=param_list, output_device=output_device
         )


### PR DESCRIPTION
* Added `SimpleTensorParameterization` as a workaround for JIT not supporting `nn.ParameterList`. It also helps `StackImage` support tensor inputs.
* Added JIT support for `SharedImage`.
* Added new parameterization called `StackImage`, that stacks multiple parameterizations (that are can be on different devices) along the batch dimension.