### PR TITLE
Add new StackImage parameterization & JIT support for SharedImage

### DIFF
--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -407,18 +407,44 @@ class LaplacianImage(ImageParameterization):
         return torch.stack(A).refine_names("B", "C", "H", "W")
 
 
+class SimpleTensorParameterization(ImageParameterization):
+    """
+    Parameterize a simple tensor with or without it requiring grad.
+    Compared to PixelImage, this parameterization has no specific shape requirements
+    and does not wrap inputs in nn.Parameter.
+    This parameterization can for example be combined with StackImage for batch
+    dimensions that both require and don't require gradients.
+    This parameterization can also be combined with nn.ModuleList as workaround for
+    TorchScript / JIT not supporting nn.ParameterList. SharedImage uses this module
+    internally for this purpose.
+    """
+
+    def __init__(self, tensor: torch.Tensor = None) -> None:
+        """
+        Args:
+
+            tensor (torch.tensor): The tensor to return everytime this module is called.
+        """
+        super().__init__()
+        assert isinstance(tensor, torch.Tensor)
+        self.tensor = tensor
+
+    def forward(self) -> torch.Tensor:
+        return self.tensor
+
+
 class SharedImage(ImageParameterization):
     """
     Share some image parameters across the batch to increase spatial alignment,
     by using interpolated lower resolution tensors.
     This is sort of like a laplacian pyramid but more general.
-
     Offsets are similar to phase in Fourier transforms, and can be applied to
     any dimension.
-
     Mordvintsev, et al., "Differentiable Image Parameterizations", Distill, 2018.
     https://distill.pub/2018/differentiable-parameterizations/
     """
+
+    __constants__ = ["offset", "_supports_is_scripting"]
 
     def __init__(
         self,
@@ -445,10 +471,16 @@ class SharedImage(ImageParameterization):
             assert len(shape) >= 2 and len(shape) <= 4
             shape = ([1] * (4 - len(shape))) + list(shape)
             batch, channels, height, width = shape
-            A.append(torch.nn.Parameter(torch.randn([batch, channels, height, width])))
-        self.shared_init = torch.nn.ParameterList(A)
+            shape_param = torch.nn.Parameter(
+                torch.randn([batch, channels, height, width])
+            )
+            A.append(SimpleTensorParameterization(shape_param))
+        self.shared_init = torch.nn.ModuleList(A)
         self.parameterization = parameterization
         self.offset = self._get_offset(offset, len(A)) if offset is not None else None
+
+        # Check & store whether or not we can use torch.jit.is_scripting()
+        self._supports_is_scripting = torch.__version__ >= "1.6.0"
 
     def _get_offset(self, offset: Union[int, Tuple[int]], n: int) -> List[List[int]]:
         """
@@ -475,6 +507,7 @@ class SharedImage(ImageParameterization):
         assert all([all([type(o) is int for o in v]) for v in offset])
         return offset
 
+    @torch.jit.ignore
     def _apply_offset(self, x_list: List[torch.Tensor]) -> List[torch.Tensor]:
         """
         Apply list of offsets to list of tensors.
@@ -508,6 +541,7 @@ class SharedImage(ImageParameterization):
             A.append(x)
         return A
 
+    @torch.jit.ignore
     def _interpolate_tensor(
         self, x: torch.Tensor, batch: int, channels: int, height: int, width: int
     ) -> torch.Tensor:
@@ -550,7 +584,7 @@ class SharedImage(ImageParameterization):
         image = self.parameterization()
         x = [
             self._interpolate_tensor(
-                shared_tensor,
+                shared_tensor(),
                 image.size(0),
                 image.size(1),
                 image.size(2),
@@ -560,7 +594,77 @@ class SharedImage(ImageParameterization):
         ]
         if self.offset is not None:
             x = self._apply_offset(x)
-        return (image + sum(x)).refine_names("B", "C", "H", "W")
+        output = image + torch.cat(x, 0).sum(0, keepdim=True)
+
+        if self._supports_is_scripting:
+            if torch.jit.is_scripting():
+                return output
+        return output.refine_names("B", "C", "H", "W")
+
+
+class StackImage(ImageParameterization):
+    """
+    Stack multiple NCHW image parameterizations along their batch dimensions.
+    """
+
+    __constants__ = ["_supports_is_scripting", "output_device"]
+
+    def __init__(
+        self,
+        parameterizations: List[Union[ImageParameterization, torch.Tensor]],
+        output_device: Optional[torch.device] = None,
+    ) -> None:
+        """
+        Args:
+            parameterizations (list of ImageParameterization and torch.Tensor): A list
+                 of image parameterizations to stack across their batch dimensions.
+            output_device (torch.device): If the parameterizations are on different
+                devices, then their outputs will be moved to the device specified by
+                this variable. Default is set to None with the expectation that all
+                parameterizations are on the same device.
+                Default: None
+        """
+        super().__init__()
+        assert len(parameterizations) > 0
+        assert isinstance(parameterizations, (list, tuple))
+        assert all(
+            [
+                isinstance(param, (ImageParameterization, torch.Tensor))
+                for param in parameterizations
+            ]
+        )
+        parameterizations = [
+            SimpleTensorParameterization(p) if isinstance(p, torch.Tensor) else p
+            for p in parameterizations
+        ]
+        self.parameterizations = torch.nn.ModuleList(parameterizations)
+        self.output_device = output_device
+
+        # Check & store whether or not we can use torch.jit.is_scripting()
+        self._supports_is_scripting = torch.__version__ >= "1.6.0"
+
+    def forward(self) -> torch.Tensor:
+        """
+        Returns:
+            image (torch.Tensor): A set of NCHW image parameterization outputs stacked
+                along the batch dimension.
+        """
+        P = []
+        for image_param in self.parameterizations:
+            img = image_param()
+            if self.output_device is not None:
+                img = img.to(self.output_device, dtype=img.dtype)
+            P.append(img)
+
+        assert P[0].dim() == 4
+        assert all([im.shape == P[0].shape for im in P])
+        assert all([im.device == P[0].device for im in P])
+
+        image = torch.cat(P, 0)
+        if self._supports_is_scripting:
+            if torch.jit.is_scripting():
+                return image
+        return image.refine_names("B", "C", "H", "W")
 
 
 class NaturalImage(ImageParameterization):

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -412,8 +412,10 @@ class SimpleTensorParameterization(ImageParameterization):
     Parameterize a simple tensor with or without it requiring grad.
     Compared to PixelImage, this parameterization has no specific shape requirements
     and does not wrap inputs in nn.Parameter.
+
     This parameterization can for example be combined with StackImage for batch
     dimensions that both require and don't require gradients.
+
     This parameterization can also be combined with nn.ModuleList as workaround for
     TorchScript / JIT not supporting nn.ParameterList. SharedImage uses this module
     internally for this purpose.
@@ -438,8 +440,10 @@ class SharedImage(ImageParameterization):
     Share some image parameters across the batch to increase spatial alignment,
     by using interpolated lower resolution tensors.
     This is sort of like a laplacian pyramid but more general.
+
     Offsets are similar to phase in Fourier transforms, and can be applied to
     any dimension.
+
     Mordvintsev, et al., "Differentiable Image Parameterizations", Distill, 2018.
     https://distill.pub/2018/differentiable-parameterizations/
     """
@@ -616,6 +620,7 @@ class StackImage(ImageParameterization):
     ) -> None:
         """
         Args:
+
             parameterizations (list of ImageParameterization and torch.Tensor): A list
                  of image parameterizations to stack across their batch dimensions.
             output_device (torch.device): If the parameterizations are on different


### PR DESCRIPTION
* Added `SimpleTensorParameterization` as a workaround for JIT not supporting `nn.ParameterList`. It also helps `StackImage` support tensor inputs.
* Added JIT support for `SharedImage`.
* Added new parameterization called `StackImage`, that stacks multiple parameterizations (that are can be on different devices) along the batch dimension.

Maybe we should try to find a name for the parameterizations that augment the existing parameterizations?