### PR TITLE
More tests & new AugmentedImageParameterization base class

### DIFF
--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -762,9 +762,11 @@ __all__ = [
     "ImageTensor",
     "InputParameterization",
     "ImageParameterization",
+    "AugmentedImageParameterization",
     "FFTImage",
     "PixelImage",
     "LaplacianImage",
     "SharedImage",
+    "StackImage",
     "NaturalImage",
 ]

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -133,6 +133,10 @@ class ImageParameterization(InputParameterization):
     pass
 
 
+class AugmentedImageParameterization(InputParameterization):
+    pass
+
+
 class FFTImage(ImageParameterization):
     """
     Parameterize an image using inverse real 2D FFT
@@ -435,7 +439,7 @@ class SimpleTensorParameterization(ImageParameterization):
         return self.tensor
 
 
-class SharedImage(ImageParameterization):
+class SharedImage(AugmentedImageParameterization):
     """
     Share some image parameters across the batch to increase spatial alignment,
     by using interpolated lower resolution tensors.
@@ -606,7 +610,7 @@ class SharedImage(ImageParameterization):
         return output.refine_names("B", "C", "H", "W")
 
 
-class StackImage(ImageParameterization):
+class StackImage(AugmentedImageParameterization):
     """
     Stack multiple NCHW image parameterizations along their batch dimensions.
     """

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -434,6 +434,10 @@ class SimpleTensorParameterization(ImageParameterization):
         self.tensor = tensor
 
     def forward(self) -> torch.Tensor:
+        """
+        Returns:
+            tensor (torch.Tensor): The tensor stored during initialization.
+        """
         return self.tensor
 
 
@@ -587,6 +591,10 @@ class SharedImage(AugmentedImageParameterization):
         return x
 
     def forward(self) -> torch.Tensor:
+        """
+        Returns:
+            output (torch.Tensor): An NCHW image parameterization output.
+        """
         image = self.parameterization()
         x = [
             self._interpolate_tensor(

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -693,7 +693,9 @@ class NaturalImage(ImageParameterization):
         channels: int = 3,
         batch: int = 1,
         init: Optional[torch.Tensor] = None,
-        parameterization: ImageParameterization = FFTImage,
+        parameterization: Union[
+            ImageParameterization, AugmentedImageParameterization
+        ] = FFTImage,
         squash_func: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
         decorrelation_module: Optional[nn.Module] = ToRGB(transform="klt"),
         decorrelate_init: bool = True,

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -309,8 +309,6 @@ class PixelImage(ImageParameterization):
             assert init.dim() == 3 or init.dim() == 4
             if init.dim() == 3:
                 init = init.unsqueeze(0)
-            assert init.shape[1] == 3, "PixelImage init should have 3 channels, "
-            f"input has {init.shape[1]} channels."
         self.image = nn.Parameter(init)
 
     def forward(self) -> torch.Tensor:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -133,7 +133,7 @@ class ImageParameterization(InputParameterization):
     pass
 
 
-class AugmentedImageParameterization(InputParameterization):
+class AugmentedImageParameterization(ImageParameterization):
     pass
 
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -108,6 +108,9 @@ class TestAugmentedImageParameterization(BaseTest):
 
 
 class TestFFTImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubClass(images.FFTImage, images.ImageParameterization)
+
     def test_pytorch_fftfreq(self) -> None:
         image = images.FFTImage((1, 1))
         _, _, fftfreq = image.get_fft_funcs()
@@ -238,6 +241,9 @@ class TestFFTImage(BaseTest):
 
 
 class TestPixelImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubClass(images.PixelImage, images.ImageParameterization)
+
     def test_pixelimage_random(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -345,6 +351,11 @@ class TestLaplacianImage(BaseTest):
 
 
 class TestSimpleTensorParameterization(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubClass(
+            images.SimpleTensorParameterization, images.ImageParameterization
+        )
+
     def test_simple_tensor_parameterization_no_grad(self) -> None:
         test_input = torch.randn(1, 3, 4, 4)
         image_param = images.SimpleTensorParameterization(test_input)
@@ -402,6 +413,11 @@ class TestSimpleTensorParameterization(BaseTest):
 
 
 class TestSharedImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubClass(
+            images.SharedImage, images.AugmentedImageParameterization
+        )
+
     def test_sharedimage_get_offset_single_number(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -745,6 +761,11 @@ class TestSharedImage(BaseTest):
 
 
 class TestStackImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubClass(
+            images.StackImage, images.AugmentedImageParameterization
+        )
+
     def test_stackimage_init(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -959,6 +980,9 @@ class TestStackImage(BaseTest):
 
 
 class TestNaturalImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubClass(images.NaturalImage, images.ImageParameterization)
+
     def test_natural_image_0(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -79,7 +79,7 @@ class TestImageTensor(BaseTest):
         self.assertTrue(torch.is_tensor(new_tensor))
         assertTensorAlmostEqual(self, image_tensor, new_tensor)
 
-    def test_natural_image_cuda(self) -> None:
+    def test_image_tensor_cuda(self) -> None:
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
                 "Skipping ImageTensor CUDA test due to not supporting CUDA."
@@ -90,7 +90,8 @@ class TestImageTensor(BaseTest):
 
 class TestInputParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(images.InputParameterization, torch.nn.Module)
+        test = assertIsSubclass(images.InputParameterization, torch.nn.Module)
+        self.assertTrue(test)
 
 
 class TestImageParameterization(BaseTest):

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -370,6 +370,11 @@ class TestSimpleTensorParameterization(BaseTest):
         self.assertFalse(image_param.tensor.requires_grad)
 
     def test_simple_tensor_parameterization_jit_module_no_grad(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping SimpleTensorParameterization JIT module test due to"
+                + "  insufficient Torch version."
+            )
         test_input = torch.randn(1, 3, 4, 4)
         image_param = images.SimpleTensorParameterization(test_input)
         jit_image_param = torch.jit.script(image_param)
@@ -389,6 +394,11 @@ class TestSimpleTensorParameterization(BaseTest):
         self.assertTrue(image_param.tensor.requires_grad)
 
     def test_simple_tensor_parameterization_jit_module_with_grad(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping SimpleTensorParameterization JIT module test due to"
+                + "  insufficient Torch version."
+            )
         test_input = torch.nn.Parameter(torch.randn(1, 3, 4, 4))
         image_param = images.SimpleTensorParameterization(test_input)
         jit_image_param = torch.jit.script(image_param)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -88,6 +88,25 @@ class TestImageTensor(BaseTest):
         self.assertTrue(image_t.is_cuda)
 
 
+class TestInputParameterization(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubClass(images.InputParameterization, torch.nn.Module)
+
+
+class TestImageParameterization(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubClass(
+            images.ImageParameterization, images.InputParameterization
+        )
+
+
+class TestAugmentedImageParameterization(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubClass(
+            images.AugmentedImageParameterization, images.ImageParameterization
+        )
+
+
 class TestFFTImage(BaseTest):
     def test_pytorch_fftfreq(self) -> None:
         image = images.FFTImage((1, 1))

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -95,16 +95,18 @@ class TestInputParameterization(BaseTest):
 
 class TestImageParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(
-            images.ImageParameterization, images.InputParameterization
-        ))
+        self.assertTrue(
+            assertIsSubclass(images.ImageParameterization, images.InputParameterization)
+        )
 
 
 class TestAugmentedImageParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(
-            images.AugmentedImageParameterization, images.ImageParameterization
-        ))
+        self.assertTrue(
+            assertIsSubclass(
+                images.AugmentedImageParameterization, images.ImageParameterization
+            )
+        )
 
 
 class TestFFTImage(BaseTest):
@@ -242,7 +244,9 @@ class TestFFTImage(BaseTest):
 
 class TestPixelImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(images.PixelImage, images.ImageParameterization))
+        self.assertTrue(
+            assertIsSubclass(images.PixelImage, images.ImageParameterization)
+        )
 
     def test_pixelimage_random(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -324,7 +328,9 @@ class TestPixelImage(BaseTest):
 
 class TestLaplacianImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(images.LaplacianImage, images.ImageParameterization))
+        self.assertTrue(
+            assertIsSubclass(images.LaplacianImage, images.ImageParameterization)
+        )
 
     def test_laplacianimage_random_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -355,9 +361,11 @@ class TestLaplacianImage(BaseTest):
 
 class TestSimpleTensorParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(
-            images.SimpleTensorParameterization, images.ImageParameterization
-        ))
+        self.assertTrue(
+            assertIsSubclass(
+                images.SimpleTensorParameterization, images.ImageParameterization
+            )
+        )
 
     def test_simple_tensor_parameterization_no_grad(self) -> None:
         test_input = torch.randn(1, 3, 4, 4)
@@ -427,9 +435,9 @@ class TestSimpleTensorParameterization(BaseTest):
 
 class TestSharedImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(
-            images.SharedImage, images.AugmentedImageParameterization
-        ))
+        self.assertTrue(
+            assertIsSubclass(images.SharedImage, images.AugmentedImageParameterization)
+        )
 
     def test_sharedimage_get_offset_single_number(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -775,9 +783,9 @@ class TestSharedImage(BaseTest):
 
 class TestStackImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(
-            images.StackImage, images.AugmentedImageParameterization
-        ))
+        self.assertTrue(
+            assertIsSubclass(images.StackImage, images.AugmentedImageParameterization)
+        )
 
     def test_stackimage_init(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -994,7 +1002,9 @@ class TestStackImage(BaseTest):
 
 class TestNaturalImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(images.NaturalImage, images.ImageParameterization))
+        self.assertTrue(
+            assertIsSubclass(images.NaturalImage, images.ImageParameterization)
+        )
 
     def test_natural_image_0(self) -> None:
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -278,17 +278,6 @@ class TestPixelImage(BaseTest):
         self.assertEqual(image_param.image.size(3), size[1])
         assertTensorAlmostEqual(self, image_param.image, init_tensor, 0)
 
-    def test_pixelimage_init_error(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping PixelImage init due to insufficient Torch version."
-            )
-        size = (224, 224)
-        channels = 2
-        init_tensor = torch.randn(channels, *size)
-        with self.assertRaises(AssertionError):
-            images.PixelImage(size=size, channels=channels, init=init_tensor)
-
     def test_pixelimage_random_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -90,27 +90,26 @@ class TestImageTensor(BaseTest):
 
 class TestInputParameterization(BaseTest):
     def test_subclass(self) -> None:
-        test = assertIsSubclass(images.InputParameterization, torch.nn.Module)
-        self.assertTrue(test)
+        self.assertTrue(assertIsSubclass(images.InputParameterization, torch.nn.Module))
 
 
 class TestImageParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(
+        self.assertTrue(assertIsSubclass(
             images.ImageParameterization, images.InputParameterization
-        )
+        ))
 
 
 class TestAugmentedImageParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(
+        self.assertTrue(assertIsSubclass(
             images.AugmentedImageParameterization, images.ImageParameterization
-        )
+        ))
 
 
 class TestFFTImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(images.FFTImage, images.ImageParameterization)
+        self.assertTrue(assertIsSubclass(images.FFTImage, images.ImageParameterization))
 
     def test_pytorch_fftfreq(self) -> None:
         image = images.FFTImage((1, 1))
@@ -243,7 +242,7 @@ class TestFFTImage(BaseTest):
 
 class TestPixelImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(images.PixelImage, images.ImageParameterization)
+        self.assertTrue(assertIsSubclass(images.PixelImage, images.ImageParameterization))
 
     def test_pixelimage_random(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -325,7 +324,7 @@ class TestPixelImage(BaseTest):
 
 class TestLaplacianImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(images.LaplacianImage, images.ImageParameterization)
+        self.assertTrue(assertIsSubclass(images.LaplacianImage, images.ImageParameterization))
 
     def test_laplacianimage_random_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -356,9 +355,9 @@ class TestLaplacianImage(BaseTest):
 
 class TestSimpleTensorParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(
+        self.assertTrue(assertIsSubclass(
             images.SimpleTensorParameterization, images.ImageParameterization
-        )
+        ))
 
     def test_simple_tensor_parameterization_no_grad(self) -> None:
         test_input = torch.randn(1, 3, 4, 4)
@@ -428,9 +427,9 @@ class TestSimpleTensorParameterization(BaseTest):
 
 class TestSharedImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(
+        self.assertTrue(assertIsSubclass(
             images.SharedImage, images.AugmentedImageParameterization
-        )
+        ))
 
     def test_sharedimage_get_offset_single_number(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -776,9 +775,9 @@ class TestSharedImage(BaseTest):
 
 class TestStackImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(
+        self.assertTrue(assertIsSubclass(
             images.StackImage, images.AugmentedImageParameterization
-        )
+        ))
 
     def test_stackimage_init(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -995,7 +994,7 @@ class TestStackImage(BaseTest):
 
 class TestNaturalImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubclass(images.NaturalImage, images.ImageParameterization)
+        self.assertTrue(assertIsSubclass(images.NaturalImage, images.ImageParameterization))
 
     def test_natural_image_0(self) -> None:
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -90,20 +90,20 @@ class TestImageTensor(BaseTest):
 
 class TestInputParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(images.InputParameterization, torch.nn.Module))
+        self.assertTrue(issubclass(images.InputParameterization, torch.nn.Module))
 
 
 class TestImageParameterization(BaseTest):
     def test_subclass(self) -> None:
         self.assertTrue(
-            assertIsSubclass(images.ImageParameterization, images.InputParameterization)
+            issubclass(images.ImageParameterization, images.InputParameterization)
         )
 
 
 class TestAugmentedImageParameterization(BaseTest):
     def test_subclass(self) -> None:
         self.assertTrue(
-            assertIsSubclass(
+            issubclass(
                 images.AugmentedImageParameterization, images.ImageParameterization
             )
         )
@@ -111,7 +111,7 @@ class TestAugmentedImageParameterization(BaseTest):
 
 class TestFFTImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(assertIsSubclass(images.FFTImage, images.ImageParameterization))
+        self.assertTrue(issubclass(images.FFTImage, images.ImageParameterization))
 
     def test_pytorch_fftfreq(self) -> None:
         image = images.FFTImage((1, 1))
@@ -244,9 +244,7 @@ class TestFFTImage(BaseTest):
 
 class TestPixelImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(
-            assertIsSubclass(images.PixelImage, images.ImageParameterization)
-        )
+        self.assertTrue(issubclass(images.PixelImage, images.ImageParameterization))
 
     def test_pixelimage_random(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -328,9 +326,7 @@ class TestPixelImage(BaseTest):
 
 class TestLaplacianImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(
-            assertIsSubclass(images.LaplacianImage, images.ImageParameterization)
-        )
+        self.assertTrue(issubclass(images.LaplacianImage, images.ImageParameterization))
 
     def test_laplacianimage_random_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -362,7 +358,7 @@ class TestLaplacianImage(BaseTest):
 class TestSimpleTensorParameterization(BaseTest):
     def test_subclass(self) -> None:
         self.assertTrue(
-            assertIsSubclass(
+            issubclass(
                 images.SimpleTensorParameterization, images.ImageParameterization
             )
         )
@@ -436,7 +432,7 @@ class TestSimpleTensorParameterization(BaseTest):
 class TestSharedImage(BaseTest):
     def test_subclass(self) -> None:
         self.assertTrue(
-            assertIsSubclass(images.SharedImage, images.AugmentedImageParameterization)
+            issubclass(images.SharedImage, images.AugmentedImageParameterization)
         )
 
     def test_sharedimage_get_offset_single_number(self) -> None:
@@ -784,7 +780,7 @@ class TestSharedImage(BaseTest):
 class TestStackImage(BaseTest):
     def test_subclass(self) -> None:
         self.assertTrue(
-            assertIsSubclass(images.StackImage, images.AugmentedImageParameterization)
+            issubclass(images.StackImage, images.AugmentedImageParameterization)
         )
 
     def test_stackimage_init(self) -> None:
@@ -1002,9 +998,7 @@ class TestStackImage(BaseTest):
 
 class TestNaturalImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertTrue(
-            assertIsSubclass(images.NaturalImage, images.ImageParameterization)
-        )
+        self.assertTrue(issubclass(images.NaturalImage, images.ImageParameterization))
 
     def test_natural_image_0(self) -> None:
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -90,26 +90,26 @@ class TestImageTensor(BaseTest):
 
 class TestInputParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubClass(images.InputParameterization, torch.nn.Module)
+        self.assertIsSubclass(images.InputParameterization, torch.nn.Module)
 
 
 class TestImageParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubClass(
+        self.assertIsSubclass(
             images.ImageParameterization, images.InputParameterization
         )
 
 
 class TestAugmentedImageParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubClass(
+        self.assertIsSubclass(
             images.AugmentedImageParameterization, images.ImageParameterization
         )
 
 
 class TestFFTImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubClass(images.FFTImage, images.ImageParameterization)
+        self.assertIsSubclass(images.FFTImage, images.ImageParameterization)
 
     def test_pytorch_fftfreq(self) -> None:
         image = images.FFTImage((1, 1))
@@ -242,7 +242,7 @@ class TestFFTImage(BaseTest):
 
 class TestPixelImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubClass(images.PixelImage, images.ImageParameterization)
+        self.assertIsSubclass(images.PixelImage, images.ImageParameterization)
 
     def test_pixelimage_random(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -323,6 +323,9 @@ class TestPixelImage(BaseTest):
 
 
 class TestLaplacianImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertIsSubclass(images.LaplacianImage, images.ImageParameterization)
+
     def test_laplacianimage_random_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -352,7 +355,7 @@ class TestLaplacianImage(BaseTest):
 
 class TestSimpleTensorParameterization(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubClass(
+        self.assertIsSubclass(
             images.SimpleTensorParameterization, images.ImageParameterization
         )
 
@@ -414,7 +417,7 @@ class TestSimpleTensorParameterization(BaseTest):
 
 class TestSharedImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubClass(
+        self.assertIsSubclass(
             images.SharedImage, images.AugmentedImageParameterization
         )
 
@@ -762,7 +765,7 @@ class TestSharedImage(BaseTest):
 
 class TestStackImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubClass(
+        self.assertIsSubclass(
             images.StackImage, images.AugmentedImageParameterization
         )
 
@@ -981,7 +984,7 @@ class TestStackImage(BaseTest):
 
 class TestNaturalImage(BaseTest):
     def test_subclass(self) -> None:
-        self.assertIsSubClass(images.NaturalImage, images.ImageParameterization)
+        self.assertIsSubclass(images.NaturalImage, images.ImageParameterization)
 
     def test_natural_image_0(self) -> None:
         if torch.__version__ <= "1.2.0":


### PR DESCRIPTION
* Added `AugmentedImageParameterization` class to use a base for `SharedImage` and `StackImage`.
* Removed `PixelImage`'s 3 channel assert.
* Added tests for `InputParameterization`, `ImageParameterization`, & `AugmentedImageParameterization`.