### PR TITLE
Add JIT support for SharedImage._interpolate_tensor

### DIFF
--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -612,10 +612,12 @@ class SharedImage(AugmentedImageParameterization):
         if x.size(1) == channels:
             mode = "bilinear"
             size = (height, width)
+            size = torch.jit.annotate(Tuple[int, int], size)
         else:
             mode = "trilinear"
             x = x.unsqueeze(0)
             size = (channels, height, width)
+            size = torch.jit.annotate(Tuple[int, int, int], size)
         x = self._interpolate(x, size=size, mode=mode)
         x = x.squeeze(0) if len(size) == 3 else x
         if x.size(0) != batch:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -574,6 +574,7 @@ class SharedImage(AugmentedImageParameterization):
         """
         assert x.dim() == 4 or x.dim() == 5
         assert mode in ["bilinear", "trilinear"]
+        assert len(size) == 2 if mode == "bilinear" or len(size) == 3 if mode == "trilinear"
         if mode == "bilinear":
             size = torch.jit.annotate(Tuple[int, int], size)
         elif mode == "trilinear":

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -650,10 +650,8 @@ class SharedImage(AugmentedImageParameterization):
         if x.size(0) != batch:
             x = x.permute(1, 0, 2, 3)
             x = self._interpolate_trilinear(
-                x.unsqueeze(0),
                 size=(batch, x.size(2), x.size(3)),
-                mode="trilinear",
-            ).squeeze(0)
+            )
             x = x.permute(1, 0, 2, 3)
         return x
 

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -575,11 +575,10 @@ class SharedImage(AugmentedImageParameterization):
         assert x.dim() == 4 or x.dim() == 5
         assert mode in ["bilinear", "trilinear"]
         if mode == "bilinear":
+            size = size[1:]
             assert len(size) == 2
-            size = torch.jit.annotate(Tuple[int, int], size)
         elif mode == "trilinear":
             assert len(size) == 3
-            size = torch.jit.annotate(Tuple[int, int, int], size)
 
         if self._has_align_corners:
             if self._has_recompute_scale_factor:
@@ -617,7 +616,7 @@ class SharedImage(AugmentedImageParameterization):
 
         if x.size(1) == channels:
             mode = "bilinear"
-            size = (height, width)
+            size = (channels, height, width)
         else:
             mode = "trilinear"
             x = x.unsqueeze(0)

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -454,7 +454,12 @@ class SharedImage(AugmentedImageParameterization):
     https://distill.pub/2018/differentiable-parameterizations/
     """
 
-    __constants__ = ["offset", "_supports_is_scripting", "_has_align_corners", "_has_recompute_scale_factor"]
+    __constants__ = [
+        "offset",
+        "_supports_is_scripting",
+        "_has_align_corners",
+        "_has_recompute_scale_factor",
+    ]
 
     def __init__(
         self,

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -574,10 +574,11 @@ class SharedImage(AugmentedImageParameterization):
         """
         assert x.dim() == 4 or x.dim() == 5
         assert mode in ["bilinear", "trilinear"]
-        assert len(size) == 2 if mode == "bilinear" or len(size) == 3 if mode == "trilinear"
         if mode == "bilinear":
+            assert len(size) == 2
             size = torch.jit.annotate(Tuple[int, int], size)
         elif mode == "trilinear":
+            assert len(size) == 3
             size = torch.jit.annotate(Tuple[int, int, int], size)
 
         if self._has_align_corners:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -570,7 +570,7 @@ class SharedImage(AugmentedImageParameterization):
 
             x (torch.Tensor): The NCHW tensor to resize.
             size (tuple of int): The desired output size to resize the input
-                to.
+                to, with a format of: [height, width].
 
         Returns:
             x (torch.Tensor): A resized NCHW tensor.
@@ -605,7 +605,7 @@ class SharedImage(AugmentedImageParameterization):
 
             x (torch.Tensor): The NCHW tensor to resize.
             size (tuple of int): The desired output size to resize the input
-                to.
+                to, with a format of: [channels, height, width].
 
         Returns:
             x (torch.Tensor): A resized NCHW tensor.

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -556,7 +556,7 @@ class SharedImage(AugmentedImageParameterization):
     def _interpolate(
         self,
         x: torch.Tensor,
-        size: Union[Tuple[int, int], Tuple[int, int, int]],
+        size: Tuple[int, int, int],
         mode: str,
     ) -> torch.Tensor:
         """

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -649,9 +649,7 @@ class SharedImage(AugmentedImageParameterization):
             x = self._interpolate_trilinear(x, size=size)
         if x.size(0) != batch:
             x = x.permute(1, 0, 2, 3)
-            x = self._interpolate_trilinear(
-                size=(batch, x.size(2), x.size(3)),
-            )
+            x = self._interpolate_trilinear(x, size=(batch, x.size(2), x.size(3)))
             x = x.permute(1, 0, 2, 3)
         return x
 

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -572,7 +572,7 @@ class SharedImage(AugmentedImageParameterization):
         Returns:
             x (torch.Tensor): A resized NCHW tensor.
         """
-        assert x.dim() == 4
+        assert x.dim() == 4 or x.dim() == 5
         assert mode in ["bilinear", "trilinear"]
 
         if self._has_align_corners:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -575,24 +575,25 @@ class SharedImage(AugmentedImageParameterization):
         assert x.dim() == 4 or x.dim() == 5
         assert mode in ["bilinear", "trilinear"]
         if mode == "bilinear":
-            size = torch.jit.annotate(Tuple[int, int], size[1:])
+            new_size = torch.jit.annotate(Tuple[int, int], size[1:])
             assert len(size) == 2
         elif mode == "trilinear":
             assert len(size) == 3
+            new_size = size
 
         if self._has_align_corners:
             if self._has_recompute_scale_factor:
                 x = F.interpolate(
                     x,
-                    size=size,
+                    size=new_size,
                     mode=mode,
                     align_corners=False,
                     recompute_scale_factor=False,
                 )
             else:
-                x = F.interpolate(x, size=size, mode=mode, align_corners=False)
+                x = F.interpolate(x, size=new_size, mode=mode, align_corners=False)
         else:
-            x = F.interpolate(x, size=size, mode=mode)
+            x = F.interpolate(x, size=new_size, mode=mode)
         return x
 
     def _interpolate_tensor(

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -577,7 +577,7 @@ class SharedImage(AugmentedImageParameterization):
         if mode == "bilinear":
             new_size = torch.jit.annotate(Tuple[int, int], size[1:])
             assert len(size) == 2
-        elif mode == "trilinear":
+        else:
             assert len(size) == 3
             new_size = size
 

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -575,7 +575,7 @@ class SharedImage(AugmentedImageParameterization):
         assert x.dim() == 4 or x.dim() == 5
         assert mode in ["bilinear", "trilinear"]
         if mode == "bilinear":
-            size = size[1:]
+            size = torch.jit.annotate(size[1:], Tuple[int, int])
             assert len(size) == 2
         elif mode == "trilinear":
             assert len(size) == 3

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -454,7 +454,7 @@ class SharedImage(AugmentedImageParameterization):
     https://distill.pub/2018/differentiable-parameterizations/
     """
 
-    __constants__ = ["offset", "_supports_is_scripting"]
+    __constants__ = ["offset", "_supports_is_scripting", "_has_align_corners", "_has_recompute_scale_factor"]
 
     def __init__(
         self,
@@ -491,6 +491,8 @@ class SharedImage(AugmentedImageParameterization):
 
         # Check & store whether or not we can use torch.jit.is_scripting()
         self._supports_is_scripting = torch.__version__ >= "1.6.0"
+        self._has_align_corners = torch.__version__ >= "1.3.0"
+        self._has_recompute_scale_factor = torch.__version__ >= "1.6.0"
 
     def _get_offset(self, offset: Union[int, Tuple[int]], n: int) -> List[List[int]]:
         """

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -575,7 +575,7 @@ class SharedImage(AugmentedImageParameterization):
         assert x.dim() == 4 or x.dim() == 5
         assert mode in ["bilinear", "trilinear"]
         if mode == "bilinear":
-            size = torch.jit.annotate(size[1:], Tuple[int, int])
+            size = torch.jit.annotate(Tuple[int, int], size[1:])
             assert len(size) == 2
         elif mode == "trilinear":
             assert len(size) == 3

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -574,6 +574,10 @@ class SharedImage(AugmentedImageParameterization):
         """
         assert x.dim() == 4 or x.dim() == 5
         assert mode in ["bilinear", "trilinear"]
+        if mode == "bilinear":
+            size = torch.jit.annotate(Tuple[int, int], size)
+        elif mode == "trilinear":
+            size = torch.jit.annotate(Tuple[int, int, int], size)
 
         if self._has_align_corners:
             if self._has_recompute_scale_factor:
@@ -612,12 +616,10 @@ class SharedImage(AugmentedImageParameterization):
         if x.size(1) == channels:
             mode = "bilinear"
             size = (height, width)
-            size = torch.jit.annotate(Tuple[int, int], size)
         else:
             mode = "trilinear"
             x = x.unsqueeze(0)
             size = (channels, height, width)
-            size = torch.jit.annotate(Tuple[int, int, int], size)
         x = self._interpolate(x, size=size, mode=mode)
         x = x.squeeze(0) if len(size) == 3 else x
         if x.size(0) != batch:

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -352,6 +352,17 @@ class TestSimpleTensorParameterization(BaseTest):
             )
         )
 
+    def test_stackimage_torch_version_check(self) -> None:
+        img_param_1 = images.SimpleTensorParameterization(torch.ones(1,3,4,4))
+        img_param_2 = images.SimpleTensorParameterization(torch.ones(1,3,4,4))
+        param_list = [img_param_1, img_param_2]
+        stack_param = images.StackImage(parameterizations=param_list)
+
+        supports_is_scripting = torch.__version__ >= "1.6.0"
+        self.assertEqual(
+            stack_param._supports_is_scripting, supports_is_scripting
+        )
+
     def test_simple_tensor_parameterization_no_grad(self) -> None:
         test_input = torch.randn(1, 3, 4, 4)
         image_param = images.SimpleTensorParameterization(test_input)
@@ -422,6 +433,68 @@ class TestSharedImage(BaseTest):
     def test_subclass(self) -> None:
         self.assertTrue(
             issubclass(images.SharedImage, images.AugmentedImageParameterization)
+        )
+
+    def test_sharedimage_interpolate_bilinear(self) -> None:
+        shared_shapes = (128 // 2, 128 // 2)
+        test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
+        image_param = images.SharedImage(
+            shapes=shared_shapes, parameterization=test_param
+        )
+        
+        size = (224, 128)
+        test_input = torch.randn(1, 3, 128, 128)
+       
+        test_output = images.SharedImage._interpolate_bilinear(test_input.clone(), size=size)    
+        expected_output = F.interpolate(x, size=size, mode="bilinear")
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+        size = (128, 128)
+        test_input = torch.randn(1, 3, 224, 224)
+       
+        test_output = images.SharedImage._interpolate_bilinear(test_input.clone(), size=size)    
+        expected_output = F.interpolate(x, size=size, mode="bilinear")
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+    def test_sharedimage_interpolate_trilinear(self) -> None:
+        shared_shapes = (128 // 2, 128 // 2)
+        test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
+        image_param = images.SharedImage(
+            shapes=shared_shapes, parameterization=test_param
+        )
+        
+        size = (3, 224, 128)
+        test_input = torch.randn(1, 1, 128, 128)
+       
+        test_output = images.SharedImage._interpolate_trilinear(test_input.clone(), size=size)    
+        expected_output = F.interpolate(x.unsqueeze(0), size=size, mode="trilinear").squeeze(0) 
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+        size = (2, 128, 128)
+        test_input = torch.randn(1, 4, 224, 224)
+       
+        test_output = images.SharedImage._interpolate_trilinear(test_input.clone(), size=size)    
+        expected_output = F.interpolate(x.unsqueeze(0), size=size, mode="trilinear").squeeze(0) 
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+    def test_torch_version_check(self) -> None:
+        shared_shapes = (128 // 2, 128 // 2)
+        test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
+        image_param = images.SharedImage(
+            shapes=shared_shapes, parameterization=test_param
+        )
+
+        has_align_corners = torch.__version__ >= "1.3.0"
+        self.assertEqual(image_param._has_align_corners, has_align_corners)
+
+        has_recompute_scale_factor = torch.__version__ >= "1.6.0"
+        self.assertEqual(
+            image_param._has_recompute_scale_factor, has_recompute_scale_factor
+        )
+        
+        supports_is_scripting = torch.__version__ >= "1.6.0"
+        self.assertEqual(
+            image_param._supports_is_scripting, supports_is_scripting
         )
 
     def test_sharedimage_get_offset_single_number(self) -> None:

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -352,15 +352,6 @@ class TestSimpleTensorParameterization(BaseTest):
             )
         )
 
-    def test_stackimage_torch_version_check(self) -> None:
-        img_param_1 = images.SimpleTensorParameterization(torch.ones(1, 3, 4, 4))
-        img_param_2 = images.SimpleTensorParameterization(torch.ones(1, 3, 4, 4))
-        param_list = [img_param_1, img_param_2]
-        stack_param = images.StackImage(parameterizations=param_list)
-
-        supports_is_scripting = torch.__version__ >= "1.6.0"
-        self.assertEqual(stack_param._supports_is_scripting, supports_is_scripting)
-
     def test_simple_tensor_parameterization_no_grad(self) -> None:
         test_input = torch.randn(1, 3, 4, 4)
         image_param = images.SimpleTensorParameterization(test_input)
@@ -848,6 +839,15 @@ class TestStackImage(BaseTest):
         self.assertTrue(
             issubclass(images.StackImage, images.AugmentedImageParameterization)
         )
+
+    def test_stackimage_torch_version_check(self) -> None:
+        img_param_1 = images.SimpleTensorParameterization(torch.ones(1, 3, 4, 4))
+        img_param_2 = images.SimpleTensorParameterization(torch.ones(1, 3, 4, 4))
+        param_list = [img_param_1, img_param_2]
+        stack_param = images.StackImage(parameterizations=param_list)
+
+        supports_is_scripting = torch.__version__ >= "1.6.0"
+        self.assertEqual(stack_param._supports_is_scripting, supports_is_scripting)
 
     def test_stackimage_init(self) -> None:
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -445,14 +445,14 @@ class TestSharedImage(BaseTest):
         size = (224, 128)
         test_input = torch.randn(1, 3, 128, 128)
        
-        test_output = images.SharedImage._interpolate_bilinear(test_input.clone(), size=size)    
+        test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)    
         expected_output = F.interpolate(x, size=size, mode="bilinear")
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
         size = (128, 128)
         test_input = torch.randn(1, 3, 224, 224)
        
-        test_output = images.SharedImage._interpolate_bilinear(test_input.clone(), size=size)    
+        test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)    
         expected_output = F.interpolate(x, size=size, mode="bilinear")
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
@@ -466,14 +466,14 @@ class TestSharedImage(BaseTest):
         size = (3, 224, 128)
         test_input = torch.randn(1, 1, 128, 128)
        
-        test_output = images.SharedImage._interpolate_trilinear(test_input.clone(), size=size)    
+        test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)    
         expected_output = F.interpolate(x.unsqueeze(0), size=size, mode="trilinear").squeeze(0) 
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
         size = (2, 128, 128)
         test_input = torch.randn(1, 4, 224, 224)
        
-        test_output = images.SharedImage._interpolate_trilinear(test_input.clone(), size=size)    
+        test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)    
         expected_output = F.interpolate(x.unsqueeze(0), size=size, mode="trilinear").squeeze(0) 
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -444,14 +444,14 @@ class TestSharedImage(BaseTest):
         test_input = torch.randn(1, 3, 128, 128)
 
         test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)
-        expected_output = F.interpolate(x, size=size, mode="bilinear")
+        expected_output = torch.nn.functional.interpolate(test_input.clone(), size=size, mode="bilinear")
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
         size = (128, 128)
         test_input = torch.randn(1, 3, 224, 224)
 
         test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)
-        expected_output = F.interpolate(x, size=size, mode="bilinear")
+        expected_output = torch.nn.functional.interpolate(test_input.clone(), size=size, mode="bilinear")
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
     def test_sharedimage_interpolate_trilinear(self) -> None:
@@ -465,8 +465,8 @@ class TestSharedImage(BaseTest):
         test_input = torch.randn(1, 1, 128, 128)
 
         test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)
-        expected_output = F.interpolate(
-            x.unsqueeze(0), size=size, mode="trilinear"
+        expected_output = torch.nn.functional.interpolate(
+            test_input.clone().unsqueeze(0), size=size, mode="trilinear"
         ).squeeze(0)
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
@@ -474,8 +474,8 @@ class TestSharedImage(BaseTest):
         test_input = torch.randn(1, 4, 224, 224)
 
         test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)
-        expected_output = F.interpolate(
-            x.unsqueeze(0), size=size, mode="trilinear"
+        expected_output = torch.nn.functional.interpolate(
+            test_input.clone().unsqueeze(0), size=size, mode="trilinear"
         ).squeeze(0)
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -353,15 +353,13 @@ class TestSimpleTensorParameterization(BaseTest):
         )
 
     def test_stackimage_torch_version_check(self) -> None:
-        img_param_1 = images.SimpleTensorParameterization(torch.ones(1,3,4,4))
-        img_param_2 = images.SimpleTensorParameterization(torch.ones(1,3,4,4))
+        img_param_1 = images.SimpleTensorParameterization(torch.ones(1, 3, 4, 4))
+        img_param_2 = images.SimpleTensorParameterization(torch.ones(1, 3, 4, 4))
         param_list = [img_param_1, img_param_2]
         stack_param = images.StackImage(parameterizations=param_list)
 
         supports_is_scripting = torch.__version__ >= "1.6.0"
-        self.assertEqual(
-            stack_param._supports_is_scripting, supports_is_scripting
-        )
+        self.assertEqual(stack_param._supports_is_scripting, supports_is_scripting)
 
     def test_simple_tensor_parameterization_no_grad(self) -> None:
         test_input = torch.randn(1, 3, 4, 4)
@@ -441,18 +439,18 @@ class TestSharedImage(BaseTest):
         image_param = images.SharedImage(
             shapes=shared_shapes, parameterization=test_param
         )
-        
+
         size = (224, 128)
         test_input = torch.randn(1, 3, 128, 128)
-       
-        test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)    
+
+        test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)
         expected_output = F.interpolate(x, size=size, mode="bilinear")
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
         size = (128, 128)
         test_input = torch.randn(1, 3, 224, 224)
-       
-        test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)    
+
+        test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)
         expected_output = F.interpolate(x, size=size, mode="bilinear")
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
@@ -462,19 +460,23 @@ class TestSharedImage(BaseTest):
         image_param = images.SharedImage(
             shapes=shared_shapes, parameterization=test_param
         )
-        
+
         size = (3, 224, 128)
         test_input = torch.randn(1, 1, 128, 128)
-       
-        test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)    
-        expected_output = F.interpolate(x.unsqueeze(0), size=size, mode="trilinear").squeeze(0) 
+
+        test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)
+        expected_output = F.interpolate(
+            x.unsqueeze(0), size=size, mode="trilinear"
+        ).squeeze(0)
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
         size = (2, 128, 128)
         test_input = torch.randn(1, 4, 224, 224)
-       
-        test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)    
-        expected_output = F.interpolate(x.unsqueeze(0), size=size, mode="trilinear").squeeze(0) 
+
+        test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)
+        expected_output = F.interpolate(
+            x.unsqueeze(0), size=size, mode="trilinear"
+        ).squeeze(0)
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
     def test_torch_version_check(self) -> None:
@@ -491,11 +493,9 @@ class TestSharedImage(BaseTest):
         self.assertEqual(
             image_param._has_recompute_scale_factor, has_recompute_scale_factor
         )
-        
+
         supports_is_scripting = torch.__version__ >= "1.6.0"
-        self.assertEqual(
-            image_param._supports_is_scripting, supports_is_scripting
-        )
+        self.assertEqual(image_param._supports_is_scripting, supports_is_scripting)
 
     def test_sharedimage_get_offset_single_number(self) -> None:
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -444,14 +444,18 @@ class TestSharedImage(BaseTest):
         test_input = torch.randn(1, 3, 128, 128)
 
         test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)
-        expected_output = torch.nn.functional.interpolate(test_input.clone(), size=size, mode="bilinear")
+        expected_output = torch.nn.functional.interpolate(
+            test_input.clone(), size=size, mode="bilinear"
+        )
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
         size = (128, 128)
         test_input = torch.randn(1, 3, 224, 224)
 
         test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)
-        expected_output = torch.nn.functional.interpolate(test_input.clone(), size=size, mode="bilinear")
+        expected_output = torch.nn.functional.interpolate(
+            test_input.clone(), size=size, mode="bilinear"
+        )
         assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
 
     def test_sharedimage_interpolate_trilinear(self) -> None:


### PR DESCRIPTION
* Added JIT support for SharedImage's interpolation operations.
* Unfortunately, JIT support required me to separate SharedImage's bilinear and trilinear resizing into separate functions as Union's of tuples are currently broken. Union support was also a newer addition, so now SharedImage can support older PyTorch versions as well.