### PR TITLE
Add dim variable to StackImage

### DIFF
--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -708,7 +708,7 @@ class StackImage(AugmentedImageParameterization):
             output_device (torch.device, optional): If the parameterizations are on
                 different devices, then their outputs will be moved to the device
                 specified by this variable. Default is set to None with the expectation
-                 that all parameterizations are on the same device.
+                that all parameterizations are on the same device.
                 Default: None
         """
         super().__init__()

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -689,11 +689,12 @@ class StackImage(AugmentedImageParameterization):
     Stack multiple NCHW image parameterizations along their batch dimensions.
     """
 
-    __constants__ = ["_supports_is_scripting", "output_device"]
+    __constants__ = ["_supports_is_scripting", "dim", "output_device"]
 
     def __init__(
         self,
         parameterizations: List[Union[ImageParameterization, torch.Tensor]],
+        dim: int = 0,
         output_device: Optional[torch.device] = None,
     ) -> None:
         """
@@ -701,10 +702,13 @@ class StackImage(AugmentedImageParameterization):
 
             parameterizations (list of ImageParameterization and torch.Tensor): A list
                  of image parameterizations to stack across their batch dimensions.
-            output_device (torch.device): If the parameterizations are on different
-                devices, then their outputs will be moved to the device specified by
-                this variable. Default is set to None with the expectation that all
-                parameterizations are on the same device.
+            dim (int, optional): Optionally specify the dim to concatinate
+                 parameterization outputs on. Default is set to the batch dimension.
+                 Default: 0
+            output_device (torch.device, optional): If the parameterizations are on
+                different devices, then their outputs will be moved to the device
+                specified by this variable. Default is set to None with the expectation
+                 that all parameterizations are on the same device.
                 Default: None
         """
         super().__init__()
@@ -721,6 +725,7 @@ class StackImage(AugmentedImageParameterization):
             for p in parameterizations
         ]
         self.parameterizations = torch.nn.ModuleList(parameterizations)
+        self.dim = dim
         self.output_device = output_device
 
         # Check & store whether or not we can use torch.jit.is_scripting()
@@ -743,7 +748,7 @@ class StackImage(AugmentedImageParameterization):
         assert all([im.shape == P[0].shape for im in P])
         assert all([im.device == P[0].device for im in P])
 
-        image = torch.cat(P, 0)
+        image = torch.cat(P, dim=self.dim)
         if self._supports_is_scripting:
             if torch.jit.is_scripting():
                 return image

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -882,7 +882,8 @@ class TestStackImage(BaseTest):
         param_list = [fft_param_1, fft_param_2]
         stack_param = images.StackImage(parameterizations=param_list)
 
-        self.assertIsInstance(stack_param.parameterization, torch.nn.ModuleList)
+        self.assertIsInstance(stack_param.parameterizations, torch.nn.ModuleList)
+        self.assertEqual(len(stack_param.parameterizations), 2)
         self.assertEqual(stack_param.dim, 0)
 
         for image_param in stack_param.parameterizations:

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -434,14 +434,16 @@ class TestSharedImage(BaseTest):
         shared_param = images.SharedImage(
             shapes=shared_shapes, parameterization=test_param
         )
-        
+
         self.assertIsInstance(shared_param.shared_init, torch.nn.ModuleList)
         self.assertEqual(len(shared_param.shared_init), len(shared_shapes))
         for shared_init, shape in zip(shared_param.shared_init, shared_shapes):
             self.assertIsInstance(shared_init, images.SimpleTensorParameterization)
             self.assertEqual(list(shared_init().shape), list(shape))
-        
-        self.assertIsInstance(shared_param.parameterization, images.SimpleTensorParameterization)
+
+        self.assertIsInstance(
+            shared_param.parameterization, images.SimpleTensorParameterization
+        )
         self.assertIsNone(shared_param.offset)
 
     def test_sharedimage_interpolate_bilinear(self) -> None:
@@ -894,9 +896,9 @@ class TestStackImage(BaseTest):
         img_param_b = images.SimpleTensorParameterization(torch.ones(1, 1, 4, 4))
         param_list = [img_param_r, img_param_g, img_param_b]
         stack_param = images.StackImage(parameterizations=param_list, dim=1)
-        
+
         self.assertEqual(stack_param.dim, 1)
-        
+
         test_output = stack_param()
         self.assertEqual(list(test_output.shape), [1, 3, 4, 4])
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -424,6 +424,26 @@ class TestSharedImage(BaseTest):
             issubclass(images.SharedImage, images.AugmentedImageParameterization)
         )
 
+    def test_sharedimage_init(self) -> None:
+        shared_shapes = (
+            (1, 3, 128 // 2, 128 // 2),
+            (1, 3, 128 // 4, 128 // 4),
+            (1, 3, 128 // 8, 128 // 8),
+        )
+        test_param = images.SimpleTensorParameterization(torch.ones(4, 3, 4, 4))
+        shared_param = images.SharedImage(
+            shapes=shared_shapes, parameterization=test_param
+        )
+        
+        self.assertIsInstance(shared_param.shared_init, torch.nn.ModuleList)
+        self.assertEqual(len(shared_param.shared_init), len(shared_shapes))
+        for shared_init, shape in zip(shared_param.shared_init, shared_shapes):
+            self.assertIsInstance(shared_init, images.SimpleTensorParameterization)
+            self.assertEqual(list(shared_init().shape), list(shape))
+        
+        self.assertIsInstance(shared_param.parameterization, images.SimpleTensorParameterization)
+        self.assertIsNone(shared_param.offset)
+
     def test_sharedimage_interpolate_bilinear(self) -> None:
         shared_shapes = (128 // 2, 128 // 2)
         test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -859,10 +859,26 @@ class TestStackImage(BaseTest):
         fft_param_2 = images.FFTImage(size=size)
         param_list = [fft_param_1, fft_param_2]
         stack_param = images.StackImage(parameterizations=param_list)
+
+        self.assertIsInstance(stack_param.parameterization, torch.nn.ModuleList)
+        self.assertEqual(stack_param.dim, 0)
+
         for image_param in stack_param.parameterizations:
             self.assertIsInstance(image_param, images.FFTImage)
             self.assertEqual(list(image_param().shape), [1, 3] + list(size))
             self.assertTrue(image_param().requires_grad)
+
+    def test_stackimage_dim(self) -> None:
+        img_param_r = images.SimpleTensorParameterization(torch.ones(1, 1, 4, 4))
+        img_param_g = images.SimpleTensorParameterization(torch.ones(1, 1, 4, 4))
+        img_param_b = images.SimpleTensorParameterization(torch.ones(1, 1, 4, 4))
+        param_list = [img_param_r, img_param_g, img_param_b]
+        stack_param = images.StackImage(parameterizations=param_list, dim=1)
+        
+        self.assertEqual(stack_param.dim, 1)
+        
+        test_output = stack_param()
+        self.assertEqual(list(test_output.shape), [1, 3, 4, 4])
 
     def test_stackimage_forward(self) -> None:
         if torch.__version__ <= "1.2.0":


### PR DESCRIPTION
* Added the `dim` variable to `StackImage` so that users can choose what dimension to stack the image parameterizations across.