### PR TITLE
Add tensor support to basic_torch_module_op for list operations

### DIFF
--- a/captum/optim/__init__.py
+++ b/captum/optim/__init__.py
@@ -6,6 +6,7 @@ from captum.optim._core.optimization import InputOptimization  # noqa: F401
 from captum.optim._param.image import images, transforms  # noqa: F401
 from captum.optim._param.image.images import ImageTensor  # noqa: F401
 from captum.optim._utils import circuits, reducer  # noqa: F401
+from captum.optim._utils.image import atlas  # noqa: F401
 from captum.optim._utils.image.common import (  # noqa: F401
     nchannels_to_rgb,
     save_tensor_as_image,
@@ -23,6 +24,7 @@ __all__ = [
     "circuits",
     "models",
     "reducer",
+    "atlas",
     "nchannels_to_rgb",
     "save_tensor_as_image",
     "show",

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -1,7 +1,7 @@
 import functools
 import operator
 from abc import ABC, abstractmethod, abstractproperty
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -31,7 +31,7 @@ class Loss(ABC):
         super(Loss, self).__init__()
 
     @abstractproperty
-    def target(self) -> nn.Module:
+    def target(self) -> Union[nn.Module, List[nn.Module]]:
         pass
 
     @abstractmethod
@@ -269,7 +269,9 @@ def basic_torch_module_op(
 
 class BaseLoss(Loss):
     def __init__(
-        self, target: nn.Module = [], batch_index: Optional[int] = None
+        self,
+        target: Union[nn.Module, List[nn.Module]] = [],
+        batch_index: Optional[int] = None,
     ) -> None:
         super(BaseLoss, self).__init__()
         self._target = target
@@ -279,7 +281,7 @@ class BaseLoss(Loss):
             self._batch_index = (batch_index, batch_index + 1)
 
     @property
-    def target(self) -> nn.Module:
+    def target(self) -> Union[nn.Module, List[nn.Module]]:
         return self._target
 
     @property
@@ -289,7 +291,10 @@ class BaseLoss(Loss):
 
 class CompositeLoss(BaseLoss):
     def __init__(
-        self, loss_fn: Callable, name: str = "", target: nn.Module = []
+        self,
+        loss_fn: Callable,
+        name: str = "",
+        target: Union[nn.Module, List[nn.Module]] = [],
     ) -> None:
         super(CompositeLoss, self).__init__(target)
         self.__name__ = name
@@ -629,6 +634,94 @@ class NeuronDirection(BaseLoss):
 
 
 @loss_wrapper
+class AngledNeuronDirection(BaseLoss):
+    """
+    Visualize a direction vector with an optional whitened activation vector to
+    unstretch the activation space. Compared to the traditional Direction objectives,
+    this objective places more emphasis on angle by optionally multiplying the dot
+    product by the cosine similarity.
+
+    When cossim_pow is equal to 0, this objective works as a euclidean
+    neuron objective. When cossim_pow is greater than 0, this objective works as a
+    cosine similarity objective. An additional whitened neuron direction vector
+    can optionally be supplied to improve visualization quality for some models.
+
+    More information on the algorithm this objective uses can be found here:
+    https://github.com/tensorflow/lucid/issues/116
+
+    This Lucid equivalents of this loss function can be found here:
+    https://github.com/tensorflow/lucid/blob/master/notebooks/
+    activation-atlas/activation-atlas-simple.ipynb
+    https://github.com/tensorflow/lucid/blob/master/notebooks/
+    activation-atlas/class-activation-atlas.ipynb
+
+    Like the Lucid equivalents, our implementation differs slightly from the
+    associated research paper.
+
+    Carter, et al., "Activation Atlas", Distill, 2019.
+    https://distill.pub/2019/activation-atlas/
+    """
+
+    def __init__(
+        self,
+        target: torch.nn.Module,
+        vec: torch.Tensor,
+        vec_whitened: Optional[torch.Tensor] = None,
+        cossim_pow: float = 4.0,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        eps: float = 1.0e-4,
+        batch_index: Optional[int] = None,
+    ) -> None:
+        """
+        Args:
+            target (nn.Module): A target layer instance.
+            vec (torch.Tensor): A neuron direction vector to use.
+            vec_whitened (torch.Tensor, optional): A whitened neuron direction vector.
+            cossim_pow (float, optional): The desired cosine similarity power to use.
+            x (int, optional): Optionally provide a specific x position for the target
+                neuron.
+            y (int, optional): Optionally provide a specific y position for the target
+                neuron.
+            eps (float, optional): If cossim_pow is greater than zero, the desired
+                epsilon value to use for cosine similarity calculations.
+        """
+        BaseLoss.__init__(self, target, batch_index)
+        self.vec = vec.unsqueeze(0) if vec.dim() == 1 else vec
+        self.vec_whitened = vec_whitened
+        self.cossim_pow = cossim_pow
+        self.eps = eps
+        self.x = x
+        self.y = y
+        if self.vec_whitened is not None:
+            assert self.vec_whitened.dim() == 2
+        assert self.vec.dim() == 2
+
+    def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
+        activations = targets_to_values[self.target]
+        activations = activations[self.batch_index[0] : self.batch_index[1]]
+        assert activations.dim() == 4 or activations.dim() == 2
+        assert activations.shape[1] == self.vec.shape[1]
+        if activations.dim() == 4:
+            _x, _y = get_neuron_pos(
+                activations.size(2), activations.size(3), self.x, self.y
+            )
+            activations = activations[..., _x, _y]
+
+        vec = (
+            torch.matmul(self.vec, self.vec_whitened)[0]
+            if self.vec_whitened is not None
+            else self.vec
+        )
+        if self.cossim_pow == 0:
+            return activations * vec
+
+        dot = torch.mean(activations * vec)
+        cossims = dot / (self.eps + torch.sqrt(torch.sum(activations ** 2)))
+        return dot * torch.clamp(cossims, min=0.1) ** self.cossim_pow
+
+
+@loss_wrapper
 class TensorDirection(BaseLoss):
     """
     Visualize a tensor direction vector.
@@ -719,6 +812,47 @@ class ActivationWeights(BaseLoss):
         return activations
 
 
+def sum_loss_list(
+    loss_list: List,
+    to_scalar_fn: Callable[[torch.Tensor], torch.Tensor] = torch.mean,
+) -> CompositeLoss:
+    """
+    Summarize a large number of losses without recursion errors. By default using 300+
+    loss functions for a single optimization task will result in exceeding Python's
+    default maximum recursion depth limit. This function can be used to avoid the
+    recursion depth limit for tasks such as summarizing a large list of loss functions
+    with the built-in sum() function.
+
+    This function works similar to Lucid's optvis.objectives.Objective.sum() function.
+
+    Args:
+
+        loss_list (list): A list of loss function objectives.
+        to_scalar_fn (Callable): A function for converting loss function outputs to
+            scalar values, in order to prevent size mismatches.
+            Default: torch.mean
+
+    Returns:
+        loss_fn (CompositeLoss): A composite loss function containing all the loss
+            functions from `loss_list`.
+    """
+
+    def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
+        return sum([to_scalar_fn(loss(module)) for loss in loss_list])
+
+    name = "Sum(" + ", ".join([loss.__name__ for loss in loss_list]) + ")"
+    # Collect targets from losses
+    target = [
+        target
+        for targets in [
+            [loss.target] if not hasattr(loss.target, "__iter__") else loss.target
+            for loss in loss_list
+        ]
+        for target in targets
+    ]
+    return CompositeLoss(loss_fn, name=name, target=target)
+
+
 def default_loss_summarize(loss_value: torch.Tensor) -> torch.Tensor:
     """
     Helper function to summarize tensor outputs from loss functions.
@@ -747,7 +881,9 @@ __all__ = [
     "Alignment",
     "Direction",
     "NeuronDirection",
+    "AngledNeuronDirection",
     "TensorDirection",
     "ActivationWeights",
+    "sum_loss_list",
     "default_loss_summarize",
 ]

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -232,7 +232,12 @@ def basic_torch_module_op(
             del kwargs["to_scalar_fn"]
 
         def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
-            loss_tensors = [to_scalar_fn(loss_obj(module)) for loss_obj in loss]
+            loss_tensors = [
+                to_scalar_fn(loss_obj(module))
+                if not isinstance(loss_obj, torch.Tensor)
+                else loss_obj
+                for loss_obj in loss
+            ]
             return torch_op(loss_tensors, *args, **kwargs)
 
         name_list = ", ".join([loss_obj.__name__ for loss_obj in loss])

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -197,14 +197,17 @@ def basic_torch_module_op(
     **kwargs: Any,
 ) -> "CompositeLoss":
     """
-    Implement composability for PyTorch operation that take a single tensor or list
-    of tensors as it's first input variable.
+    Implement composability for functions like PyTorch operations that take a single
+    tensor or list of tensors as their first input variable.
+
     See here for possible torch_op choices: https://pytorch.org/docs/stable/torch.html
-    Some built-in Python functions can also be used as well if supported by PyTorch.
+    In addition to custom user defined functions, built-in Python functions can also be
+    used as well if supported by PyTorch.
 
     Args:
 
-        loss (Loss or list of Loss): A loss objective or list of loss objectives.
+        loss (Loss or list of Loss and torch.Tensor): A loss objective or list of loss
+            objectives and tensors.
         torch_op (Callable): A PyTorch or supported Python function. Ex: torch.mean,
              torch.sum,, torch.linalg.norm, torch.sin, torch.cat, torch.stack, max, min,
              sum, math.ceil, and others.

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -133,10 +133,16 @@ class ImageParameterization(InputParameterization):
     pass
 
 
+class AugmentedImageParameterization(ImageParameterization):
+    pass
+
+
 class FFTImage(ImageParameterization):
     """
     Parameterize an image using inverse real 2D FFT
     """
+
+    __constants__ = ["size", "_supports_is_scripting"]
 
     def __init__(
         self,
@@ -197,6 +203,9 @@ class FFTImage(ImageParameterization):
         self.register_buffer("spectrum_scale", spectrum_scale)
         self.fourier_coeffs = nn.Parameter(fourier_coeffs)
 
+        # Check & store whether or not we can use torch.jit.is_scripting()
+        self._supports_is_scripting = torch.__version__ >= "1.6.0"
+
     def rfft2d_freqs(self, height: int, width: int) -> torch.Tensor:
         """
         Computes 2D spectrum frequencies.
@@ -214,6 +223,12 @@ class FFTImage(ImageParameterization):
         fx = self.torch_fftfreq(width)[: width // 2 + 1]
         return torch.sqrt((fx * fx) + (fy * fy))
 
+    @torch.jit.export
+    def torch_irfftn(self, x: torch.Tensor) -> torch.Tensor:
+        if x.dtype != torch.complex64:
+            x = torch.view_as_complex(x)
+        return torch.fft.irfftn(x, s=self.size)  # type: ignore
+
     def get_fft_funcs(self) -> Tuple[Callable, Callable, Callable]:
         """
         Support older versions of PyTorch. This function ensures that the same FFT
@@ -226,26 +241,24 @@ class FFTImage(ImageParameterization):
         """
 
         if TORCH_VERSION >= "1.7.0":
-            import torch.fft
+            if TORCH_VERSION < "1.8.0":
+                global torch
+                import torch.fft
 
             def torch_rfft(x: torch.Tensor) -> torch.Tensor:
                 return torch.view_as_real(torch.fft.rfftn(x, s=self.size))
 
-            def torch_irfft(x: torch.Tensor) -> torch.Tensor:
-                if type(x) is not torch.complex64:
-                    x = torch.view_as_complex(x)
-                return torch.fft.irfftn(x, s=self.size)  # type: ignore
+            torch_irfftn = self.torch_irfftn
 
             def torch_fftfreq(v: int, d: float = 1.0) -> torch.Tensor:
                 return torch.fft.fftfreq(v, d)
 
         else:
-            import torch
 
             def torch_rfft(x: torch.Tensor) -> torch.Tensor:
                 return torch.rfft(x, signal_ndim=2)
 
-            def torch_irfft(x: torch.Tensor) -> torch.Tensor:
+            def torch_irfftn(x: torch.Tensor) -> torch.Tensor:
                 return torch.irfft(x, signal_ndim=2)[
                     :, :, : self.size[0], : self.size[1]
                 ]
@@ -258,7 +271,7 @@ class FFTImage(ImageParameterization):
                 results[s:] = torch.arange(-(v // 2), 0)
                 return results * (1.0 / (v * d))
 
-        return torch_rfft, torch_irfft, torch_fftfreq
+        return torch_rfft, torch_irfftn, torch_fftfreq
 
     def forward(self) -> torch.Tensor:
         """
@@ -268,6 +281,9 @@ class FFTImage(ImageParameterization):
 
         scaled_spectrum = self.fourier_coeffs * self.spectrum_scale
         output = self.torch_irfft(scaled_spectrum)
+        if self._supports_is_scripting:
+            if torch.jit.is_scripting():
+                return output
         return output.refine_names("B", "C", "H", "W")
 
 
@@ -275,6 +291,8 @@ class PixelImage(ImageParameterization):
     """
     Parameterize a simple pixel image tensor that requires no additional transforms.
     """
+
+    __constants__ = ["_supports_is_scripting"]
 
     def __init__(
         self,
@@ -305,11 +323,15 @@ class PixelImage(ImageParameterization):
             assert init.dim() == 3 or init.dim() == 4
             if init.dim() == 3:
                 init = init.unsqueeze(0)
-            assert init.shape[1] == 3, "PixelImage init should have 3 channels, "
-            f"input has {init.shape[1]} channels."
         self.image = nn.Parameter(init)
 
+        # Check & store whether or not we can use torch.jit.is_scripting()
+        self._supports_is_scripting = torch.__version__ >= "1.6.0"
+
     def forward(self) -> torch.Tensor:
+        if self._supports_is_scripting:
+            if torch.jit.is_scripting():
+                return self.image
         return self.image.refine_names("B", "C", "H", "W")
 
 
@@ -407,7 +429,39 @@ class LaplacianImage(ImageParameterization):
         return torch.stack(A).refine_names("B", "C", "H", "W")
 
 
-class SharedImage(ImageParameterization):
+class SimpleTensorParameterization(ImageParameterization):
+    """
+    Parameterize a simple tensor with or without it requiring grad.
+    Compared to PixelImage, this parameterization has no specific shape requirements
+    and does not wrap inputs in nn.Parameter.
+
+    This parameterization can for example be combined with StackImage for batch
+    dimensions that both require and don't require gradients.
+
+    This parameterization can also be combined with nn.ModuleList as workaround for
+    TorchScript / JIT not supporting nn.ParameterList. SharedImage uses this module
+    internally for this purpose.
+    """
+
+    def __init__(self, tensor: torch.Tensor = None) -> None:
+        """
+        Args:
+
+            tensor (torch.tensor): The tensor to return everytime this module is called.
+        """
+        super().__init__()
+        assert isinstance(tensor, torch.Tensor)
+        self.tensor = tensor
+
+    def forward(self) -> torch.Tensor:
+        """
+        Returns:
+            tensor (torch.Tensor): The tensor stored during initialization.
+        """
+        return self.tensor
+
+
+class SharedImage(AugmentedImageParameterization):
     """
     Share some image parameters across the batch to increase spatial alignment,
     by using interpolated lower resolution tensors.
@@ -419,6 +473,13 @@ class SharedImage(ImageParameterization):
     Mordvintsev, et al., "Differentiable Image Parameterizations", Distill, 2018.
     https://distill.pub/2018/differentiable-parameterizations/
     """
+
+    __constants__ = [
+        "offset",
+        "_supports_is_scripting",
+        "_has_align_corners",
+        "_has_recompute_scale_factor",
+    ]
 
     def __init__(
         self,
@@ -445,10 +506,18 @@ class SharedImage(ImageParameterization):
             assert len(shape) >= 2 and len(shape) <= 4
             shape = ([1] * (4 - len(shape))) + list(shape)
             batch, channels, height, width = shape
-            A.append(torch.nn.Parameter(torch.randn([batch, channels, height, width])))
-        self.shared_init = torch.nn.ParameterList(A)
+            shape_param = torch.nn.Parameter(
+                torch.randn([batch, channels, height, width])
+            )
+            A.append(SimpleTensorParameterization(shape_param))
+        self.shared_init = torch.nn.ModuleList(A)
         self.parameterization = parameterization
         self.offset = self._get_offset(offset, len(A)) if offset is not None else None
+
+        # Check & store whether or not we can use torch.jit.is_scripting()
+        self._supports_is_scripting = torch.__version__ >= "1.6.0"
+        self._has_align_corners = torch.__version__ >= "1.3.0"
+        self._has_recompute_scale_factor = torch.__version__ >= "1.6.0"
 
     def _get_offset(self, offset: Union[int, Tuple[int]], n: int) -> List[List[int]]:
         """
@@ -475,6 +544,7 @@ class SharedImage(ImageParameterization):
         assert all([all([type(o) is int for o in v]) for v in offset])
         return offset
 
+    @torch.jit.ignore
     def _apply_offset(self, x_list: List[torch.Tensor]) -> List[torch.Tensor]:
         """
         Apply list of offsets to list of tensors.
@@ -508,6 +578,75 @@ class SharedImage(ImageParameterization):
             A.append(x)
         return A
 
+    def _interpolate_bilinear(
+        self,
+        x: torch.Tensor,
+        size: Tuple[int, int],
+    ) -> torch.Tensor:
+        """
+        Perform interpolation without any warnings.
+
+        Args:
+
+            x (torch.Tensor): The NCHW tensor to resize.
+            size (tuple of int): The desired output size to resize the input
+                to, with a format of: [height, width].
+
+        Returns:
+            x (torch.Tensor): A resized NCHW tensor.
+        """
+        assert x.dim() == 4
+        assert len(size) == 2
+
+        if self._has_align_corners:
+            if self._has_recompute_scale_factor:
+                x = F.interpolate(
+                    x,
+                    size=size,
+                    mode="bilinear",
+                    align_corners=False,
+                    recompute_scale_factor=False,
+                )
+            else:
+                x = F.interpolate(x, size=size, mode="bilinear", align_corners=False)
+        else:
+            x = F.interpolate(x, size=size, mode="bilinear")
+        return x
+
+    def _interpolate_trilinear(
+        self,
+        x: torch.Tensor,
+        size: Tuple[int, int, int],
+    ) -> torch.Tensor:
+        """
+        Perform interpolation without any warnings.
+
+        Args:
+
+            x (torch.Tensor): The NCHW tensor to resize.
+            size (tuple of int): The desired output size to resize the input
+                to, with a format of: [channels, height, width].
+
+        Returns:
+            x (torch.Tensor): A resized NCHW tensor.
+        """
+        x = x.unsqueeze(0)
+        assert x.dim() == 5
+        if self._has_align_corners:
+            if self._has_recompute_scale_factor:
+                x = F.interpolate(
+                    x,
+                    size=size,
+                    mode="trilinear",
+                    align_corners=False,
+                    recompute_scale_factor=False,
+                )
+            else:
+                x = F.interpolate(x, size=size, mode="trilinear", align_corners=False)
+        else:
+            x = F.interpolate(x, size=size, mode="trilinear")
+        return x.squeeze(0)
+
     def _interpolate_tensor(
         self, x: torch.Tensor, batch: int, channels: int, height: int, width: int
     ) -> torch.Tensor:
@@ -528,29 +667,26 @@ class SharedImage(ImageParameterization):
         """
 
         if x.size(1) == channels:
-            mode = "bilinear"
             size = (height, width)
+            x = self._interpolate_bilinear(x, size=size)
         else:
-            mode = "trilinear"
-            x = x.unsqueeze(0)
             size = (channels, height, width)
-        x = F.interpolate(x, size=size, mode=mode)
-        x = x.squeeze(0) if len(size) == 3 else x
+            x = self._interpolate_trilinear(x, size=size)
         if x.size(0) != batch:
             x = x.permute(1, 0, 2, 3)
-            x = F.interpolate(
-                x.unsqueeze(0),
-                size=(batch, x.size(2), x.size(3)),
-                mode="trilinear",
-            ).squeeze(0)
+            x = self._interpolate_trilinear(x, size=(batch, x.size(2), x.size(3)))
             x = x.permute(1, 0, 2, 3)
         return x
 
     def forward(self) -> torch.Tensor:
+        """
+        Returns:
+            output (torch.Tensor): An NCHW image parameterization output.
+        """
         image = self.parameterization()
         x = [
             self._interpolate_tensor(
-                shared_tensor,
+                shared_tensor(),
                 image.size(0),
                 image.size(1),
                 image.size(2),
@@ -560,7 +696,80 @@ class SharedImage(ImageParameterization):
         ]
         if self.offset is not None:
             x = self._apply_offset(x)
-        return (image + sum(x)).refine_names("B", "C", "H", "W")
+        output = image + torch.cat(x, 0).sum(0, keepdim=True)
+
+        if self._supports_is_scripting:
+            if torch.jit.is_scripting():
+                return output
+        return output.refine_names("B", "C", "H", "W")
+
+
+class StackImage(AugmentedImageParameterization):
+    """
+    Stack multiple NCHW image parameterizations along their batch dimensions.
+    """
+
+    __constants__ = ["_supports_is_scripting", "output_device", "dim"]
+
+    def __init__(
+        self,
+        parameterizations: List[Union[ImageParameterization, torch.Tensor]],
+        dim: int = 0,
+        output_device: Optional[torch.device] = None,
+    ) -> None:
+        """
+        Args:
+
+            parameterizations (list of ImageParameterization and torch.Tensor): A list
+                 of image parameterizations to stack across their batch dimensions.
+            output_device (torch.device): If the parameterizations are on different
+                devices, then their outputs will be moved to the device specified by
+                this variable. Default is set to None with the expectation that all
+                parameterizations are on the same device.
+                Default: None
+        """
+        super().__init__()
+        assert len(parameterizations) > 0
+        assert isinstance(parameterizations, (list, tuple))
+        assert all(
+            [
+                isinstance(param, (ImageParameterization, torch.Tensor))
+                for param in parameterizations
+            ]
+        )
+        parameterizations = [
+            SimpleTensorParameterization(p) if isinstance(p, torch.Tensor) else p
+            for p in parameterizations
+        ]
+        self.parameterizations = torch.nn.ModuleList(parameterizations)
+        self.dim = dim
+        self.output_device = output_device
+
+        # Check & store whether or not we can use torch.jit.is_scripting()
+        self._supports_is_scripting = torch.__version__ >= "1.6.0"
+
+    def forward(self) -> torch.Tensor:
+        """
+        Returns:
+            image (torch.Tensor): A set of NCHW image parameterization outputs stacked
+                along the batch dimension.
+        """
+        P = []
+        for image_param in self.parameterizations:
+            img = image_param()
+            if self.output_device is not None:
+                img = img.to(self.output_device, dtype=img.dtype)
+            P.append(img)
+
+        assert P[0].dim() == 4
+        assert all([im.shape == P[0].shape for im in P])
+        assert all([im.device == P[0].device for im in P])
+
+        image = torch.cat(P, dim=self.dim)
+        if self._supports_is_scripting:
+            if torch.jit.is_scripting():
+                return image
+        return image.refine_names("B", "C", "H", "W")
 
 
 class NaturalImage(ImageParameterization):
@@ -582,7 +791,9 @@ class NaturalImage(ImageParameterization):
         channels: int = 3,
         batch: int = 1,
         init: Optional[torch.Tensor] = None,
-        parameterization: ImageParameterization = FFTImage,
+        parameterization: Union[
+            ImageParameterization, AugmentedImageParameterization
+        ] = FFTImage,
         squash_func: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
         decorrelation_module: Optional[nn.Module] = ToRGB(transform="klt"),
         decorrelate_init: bool = True,
@@ -600,7 +811,7 @@ class NaturalImage(ImageParameterization):
                 nn.Parameter tensor, or stacking init images.
                 Default: 1
             parameterization (ImageParameterization, optional): An image
-                parameterization class.
+                parameterization class, or instance of an image parameterization class.
                 Default: FFTImage
             squash_func (Callable[[torch.Tensor], torch.Tensor]], optional): The squash
                 function to use after color recorrelation. A funtion or lambda function.
@@ -612,8 +823,14 @@ class NaturalImage(ImageParameterization):
                 Default: True
         """
         super().__init__()
+        if not isinstance(parameterization, ImageParameterization):
+            # Verify uninitialized class is correct type
+            assert issubclass(parameterization, ImageParameterization)
+        else:
+            assert isinstance(parameterization, ImageParameterization)
+
         self.decorrelate = decorrelation_module
-        if init is not None:
+        if init is not None and not isinstance(parameterization, ImageParameterization):
             assert init.dim() == 3 or init.dim() == 4
             if decorrelate_init and self.decorrelate is not None:
                 init = (
@@ -622,36 +839,53 @@ class NaturalImage(ImageParameterization):
                     else init.refine_names("C", "H", "W")
                 )
                 init = self.decorrelate(init, inverse=True).rename(None)
+
             if squash_func is None:
+                squash_func = self._clamp_image
 
-                def squash_func(x: torch.Tensor) -> torch.Tensor:
-                    return x.clamp(0, 1)
+        self.squash_func = torch.sigmoid if squash_func is None else squash_func
+        if not isinstance(parameterization, ImageParameterization):
+            parameterization = parameterization(
+                size=size, channels=channels, batch=batch, init=init
+            )
+        self.parameterization = parameterization
 
-        else:
-            if squash_func is None:
+    @torch.jit.export
+    def _clamp_image(self, x: torch.Tensor) -> torch.Tensor:
+        """JIT supported squash function."""
+        return x.clamp(0, 1)
 
-                squash_func = torch.sigmoid
+    @torch.jit.ignore
+    def _to_image_tensor(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Wrap ImageTensor in torch.jit.ignore for JIT support.
 
-        self.squash_func = squash_func
-        self.parameterization = parameterization(
-            size=size, channels=channels, batch=batch, init=init
-        )
+        Args:
+
+            x (torch.tensor): An input tensor.
+
+        Returns:
+            x (ImageTensor): An instance of ImageTensor with the input tensor.
+        """
+        return ImageTensor(x)
 
     def forward(self) -> torch.Tensor:
         image = self.parameterization()
         if self.decorrelate is not None:
             image = self.decorrelate(image)
         image = image.rename(None)  # TODO: the world is not yet ready
-        return ImageTensor(self.squash_func(image))
+        return self._to_image_tensor(self.squash_func(image))
 
 
 __all__ = [
     "ImageTensor",
     "InputParameterization",
     "ImageParameterization",
+    "AugmentedImageParameterization",
     "FFTImage",
     "PixelImage",
     "LaplacianImage",
     "SharedImage",
+    "StackImage",
     "NaturalImage",
 ]

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from captum.optim._utils.image.common import nchannels_to_rgb
-from captum.optim._utils.typing import IntSeqOrIntType, NumSeqOrTensorType
+from captum.optim._utils.typing import IntSeqOrIntType, NumSeqOrTensorOrProbDistType
 
 
 class BlendAlpha(nn.Module):
@@ -79,6 +79,7 @@ class ToRGB(nn.Module):
     Computer Graphics and Image Processing, vol. 13, no. 3, pp. 222–241, 1980
     https://www.sciencedirect.com/science/article/pii/0146664X80900477
     """
+    __constants__ = ["_supports_is_scripting", "_supports_named_dims"]
 
     @staticmethod
     def klt_transform() -> torch.Tensor:
@@ -130,8 +131,12 @@ class ToRGB(nn.Module):
             raise ValueError(
                 "transform has to be either 'klt', 'i1i2i3'," + " or a matrix tensor."
             )
+        # Check & store whether or not we can use torch.jit.is_scripting()
+        self._supports_is_scripting = torch.__version__ >= "1.6.0"
+        self._supports_named_dims = torch.__version__ >= "1.3.0"
 
-    def forward(self, x: torch.Tensor, inverse: bool = False) -> torch.Tensor:
+    @torch.jit.ignore
+    def _forward(self, x: torch.Tensor, inverse: bool = False) -> torch.Tensor:
         """
         Args:
 
@@ -145,6 +150,12 @@ class ToRGB(nn.Module):
         """
 
         assert x.dim() == 3 or x.dim() == 4
+        assert x.shape[-3] >= 3
+        assert (
+            x.names == ("C", "H", "W")
+            if x.dim() == 3
+            else x.names == ("B", "C", "H", "W")
+        )
 
         # alpha channel is taken off...
         has_alpha = x.size("C") == 4
@@ -175,17 +186,99 @@ class ToRGB(nn.Module):
 
         return chw
 
+    def _forward_without_named_dims(
+        self, x: torch.Tensor, inverse: bool = False
+    ) -> torch.Tensor:
+        """
+        JIT compatible forward function for ToRGB.
+
+        Args:
+
+            x (torch.tensor):  A CHW pr NCHW RGB or RGBA image tensor.
+            inverse (bool, optional):  Whether to recorrelate or decorrelate colors.
+                Default: False.
+
+        Returns:
+            chw (torch.tensor):  A tensor with it's colors recorrelated or
+                decorrelated.
+        """
+
+        assert x.dim() == 4 or x.dim() == 3
+        assert x.shape[-3] >= 3
+
+        # alpha channel is taken off...
+        has_alpha = x.shape[-3] == 4
+        if has_alpha:
+            if x.dim() == 3:
+                x, alpha_channel = x[:3], x[3:]
+            else:
+                x, alpha_channel = x[:, :3], x[:, 3:]
+            assert x.dim() == alpha_channel.dim()  # ensure we "keep_dim"
+        else:
+            # JIT requires a placeholder
+            alpha_channel = torch.tensor([0])
+
+        c_dim = 1 if x.dim() == 4 else 0
+        h, w = x.shape[c_dim + 1 :]
+        flat = x.reshape(list(x.shape[: c_dim + 1]) + [h * w])
+
+        if inverse:
+            correct = torch.inverse(self.transform.to(x.device, x.dtype)) @ flat
+        else:
+            correct = self.transform.to(x.device, x.dtype) @ flat
+        chw = correct.reshape(x.shape)
+
+        # ...alpha channel is concatenated on again.
+        if has_alpha:
+            d = 0 if x.dim() == 3 else 1
+            chw = torch.cat([chw, alpha_channel], d)
+
+        return chw
+
+    def forward(self, x: torch.Tensor, inverse: bool = False) -> torch.Tensor:
+        """
+        JIT does not yet support named dimensions.
+
+        Args:
+
+            x (torch.tensor):  A CHW or NCHW RGB or RGBA image tensor.
+            inverse (bool, optional):  Whether to recorrelate or decorrelate colors.
+                Default: False.
+
+        Returns:
+            chw (torch.tensor):  A tensor with it's colors recorrelated or
+                decorrelated.
+        """
+        if self._supports_is_scripting:
+            if torch.jit.is_scripting():
+                return self._forward_without_named_dims(x, inverse)
+        if self._supports_named_dims:
+            if list(x.names) in [[None] * 3, [None] * 4]:
+                return self._forward_without_named_dims(x, inverse)
+        return self._forward(x, inverse)
+
 
 class CenterCrop(torch.nn.Module):
     """
-    Center crop a specified amount from a tensor.
+    Center crop a specified amount from a tensor. If input are smaller than the
+    specified crop size, padding will be applied.
     """
+
+    __constants__ = [
+        "size",
+        "pixels_from_edges",
+        "offset_left",
+        "padding_mode",
+        "padding_value",
+    ]
 
     def __init__(
         self,
         size: IntSeqOrIntType = 0,
         pixels_from_edges: bool = False,
         offset_left: bool = False,
+        padding_mode: str = "constant",
+        padding_value: float = 0.0,
     ) -> None:
         """
         Args:
@@ -194,21 +287,48 @@ class CenterCrop(torch.nn.Module):
                 pixels_from_edges (bool, optional): Whether to treat crop size
                 values as the number of pixels from the tensor's edge, or an
                 exact shape in the center.
+            pixels_from_edges (bool, optional): Whether to treat crop size
+                values as the number of pixels from the tensor's edge, or an
+                exact shape in the center.
+                Default: False
             offset_left (bool, optional): If the cropped away sides are not
                 equal in size, offset center by +1 to the left and/or top.
                 This parameter is only valid when `pixels_from_edges` is False.
                 Default: False
+            padding_mode (optional, str): One of "constant", "reflect", "replicate"
+                or "circular". This parameter is only used if the crop size is larger
+                than the image size.
+                Default: "constant"
+            padding_value (float, optional): fill value for "constant" padding. This
+                parameter is only used if the crop size is larger than the image size.
+                Default: 0.0
         """
         super().__init__()
-        self.crop_vals = size
+        if not hasattr(size, "__iter__"):
+            size = [int(size), int(size)]
+        elif isinstance(size, (tuple, list)):
+            if len(size) == 1:
+                size = list((size[0], size[0]))
+            elif len(size) == 2:
+                size = list(size)
+            else:
+                raise ValueError("Crop size length of {} too large".format(len(size)))
+        else:
+            raise ValueError("Unsupported crop size value {}".format(size))
+        assert len(size) == 2
+        self.size = cast(List[int], size)
         self.pixels_from_edges = pixels_from_edges
         self.offset_left = offset_left
+        self.padding_mode = padding_mode
+        self.padding_value = padding_value
 
+    @torch.jit.ignore
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """
         Center crop an input.
 
         Args:
+
             input (torch.Tensor): Input to center crop.
 
         Returns:
@@ -216,18 +336,26 @@ class CenterCrop(torch.nn.Module):
         """
 
         return center_crop(
-            input, self.crop_vals, self.pixels_from_edges, self.offset_left
+            input,
+            self.size,
+            self.pixels_from_edges,
+            self.offset_left,
+            self.padding_mode,
+            self.padding_value,
         )
 
 
 def center_crop(
     input: torch.Tensor,
-    crop_vals: IntSeqOrIntType,
+    size: Union[int, List[int]],
     pixels_from_edges: bool = False,
     offset_left: bool = False,
+    padding_mode: str = "constant",
+    padding_value: float = 0.0,
 ) -> torch.Tensor:
     """
-    Center crop a specified amount from a tensor.
+    Center crop a specified amount from a tensor. If input are smaller than the
+    specified crop size, padding will be applied.
 
     Args:
 
@@ -241,111 +369,478 @@ def center_crop(
             equal in size, offset center by +1 to the left and/or top.
             This parameter is only valid when `pixels_from_edges` is False.
             Default: False
+        padding_mode (optional, str): One of "constant", "reflect", "replicate" or
+            "circular". This parameter is only used if the crop size is larger than
+            the image size.
+            Default: "constant"
+        padding_value (float, optional): fill value for "constant" padding. This
+            parameter is only used if the crop size is larger than the image size.
+            Default: 0.0
 
     Returns:
         **tensor**:  A center cropped *tensor*.
     """
 
     assert input.dim() == 3 or input.dim() == 4
-    crop_vals = [crop_vals] * 2 if not hasattr(crop_vals, "__iter__") else crop_vals
-    crop_vals = list(crop_vals) * 2 if len(crop_vals) == 1 else crop_vals
-    crop_vals = cast(Union[List[int], Tuple[int, int]], crop_vals)
-    assert len(crop_vals) == 2
+    if isinstance(size, int):
+        size = [int(size), int(size)]
+    elif isinstance(size, (tuple, list)):
+        if len(size) == 1:
+            size = [size[0], size[0]]
+        elif len(size) == 2:
+            size = list(size)
+        else:
+            raise ValueError("Crop size length of {} too large".format(len(size)))
+    else:
+        raise ValueError("Unsupported crop size value {}".format(size))
+    assert len(size) == 2
 
     if input.dim() == 4:
-        h, w = input.size(2), input.size(3)
-    if input.dim() == 3:
-        h, w = input.size(1), input.size(2)
+        h, w = input.shape[2:]
+    elif input.dim() == 3:
+        h, w = input.shape[1:]
+    else:
+        raise ValueError("Input has too many dimensions: {}".format(input.dim()))
 
     if pixels_from_edges:
-        h_crop = h - crop_vals[0]
-        w_crop = w - crop_vals[1]
+        h_crop = h - size[0]
+        w_crop = w - size[1]
         sw, sh = w // 2 - (w_crop // 2), h // 2 - (h_crop // 2)
         x = input[..., sh : sh + h_crop, sw : sw + w_crop]
     else:
-        h_crop = h - int(math.ceil((h - crop_vals[0]) / 2.0))
-        w_crop = w - int(math.ceil((w - crop_vals[1]) / 2.0))
-        if h % 2 == 0 and crop_vals[0] % 2 != 0 or h % 2 != 0 and crop_vals[0] % 2 == 0:
+        h_crop = h - int(math.ceil((h - size[0]) / 2.0)) if h > size[0] else size[0]
+        w_crop = w - int(math.ceil((w - size[1]) / 2.0)) if w > size[1] else size[1]
+
+        if h % 2 == 0 and size[0] % 2 != 0 or h % 2 != 0 and size[0] % 2 == 0:
             h_crop = h_crop + 1 if offset_left else h_crop
-        if w % 2 == 0 and crop_vals[1] % 2 != 0 or w % 2 != 0 and crop_vals[1] % 2 == 0:
+        if w % 2 == 0 and size[1] % 2 != 0 or w % 2 != 0 and size[1] % 2 == 0:
             w_crop = w_crop + 1 if offset_left else w_crop
-        x = input[..., h_crop - crop_vals[0] : h_crop, w_crop - crop_vals[1] : w_crop]
+
+        if size[0] > h or size[1] > w:
+            # Padding functionality like Torchvision's center crop
+            padding = [
+                math.ceil((size[1] - w) / 2) if size[1] > w else 0,
+                math.ceil((size[0] - h) / 2) if size[0] > h else 0,
+                (size[1] - w + 1) // 2 if size[1] > w else 0,
+                (size[0] - h + 1) // 2 if size[0] > h else 0,
+            ]
+            input = F.pad(input, padding, mode=padding_mode, value=padding_value)
+
+        x = input[..., h_crop - size[0] : h_crop, w_crop - size[1] : w_crop]
     return x
 
 
-def _rand_select(
-    transform_values: NumSeqOrTensorType,
-) -> Union[int, float, torch.Tensor]:
+class RandomRotation(nn.Module):
     """
-    Randomly return a single value from the provided tuple, list, or tensor.
-
-    Args:
-
-        transform_values (sequence):  A sequence of values to randomly select from.
-
-    Returns:
-        **value**:  A single value from the specified sequence.
+    Apply random rotation transforms on a NCHW tensor, using a sequence of degrees or
+    torch.distributions instance.
     """
-    n = torch.randint(low=0, high=len(transform_values), size=[1]).item()
-    return transform_values[n]
+
+    __constants__ = [
+        "degrees",
+        "mode",
+        "padding_mode",
+        "align_corners",
+        "_has_align_corners",
+        "_is_distribution",
+    ]
+
+    def __init__(
+        self,
+        degrees: NumSeqOrTensorOrProbDistType,
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
+        align_corners: bool = False,
+    ) -> None:
+        """
+        Args:
+            degrees (float, sequence, or torch.distribution): Tuple of degrees values
+                to randomly select from, or a torch.distributions instance.
+            mode (str, optional): Interpolation mode to use. See documentation of
+                F.grid_sample for more details. One of; "bilinear", "nearest", or
+                "bicubic".
+                Default: "bilinear"
+            padding_mode (str, optional): Padding mode for values that fall outside of
+                the grid. See documentation of F.grid_sample for more details. One of;
+                "zeros", "border", or "reflection".
+                Default: "zeros"
+            align_corners (bool, optional): Whether or not to align corners. See
+                documentation of F.affine_grid & F.grid_sample for more details.
+                Default: False
+        """
+        super().__init__()
+        if isinstance(degrees, torch.distributions.distribution.Distribution):
+            # Distributions are not supported by TorchScript / JIT yet
+            assert degrees.batch_shape == torch.Size([])
+            self.degrees_distribution = degrees
+            self._is_distribution = True
+            self.degrees = []
+        else:
+            assert hasattr(degrees, "__iter__")
+            if torch.is_tensor(degrees):
+                assert cast(torch.Tensor, degrees).dim() == 1
+                degrees = degrees.tolist()
+            assert len(degrees) > 0
+            self.degrees = [float(d) for d in degrees]
+            self._is_distribution = False
+
+        self.mode = mode
+        self.padding_mode = padding_mode
+        self.align_corners = align_corners
+        self._has_align_corners = torch.__version__ >= "1.3.0"
+
+    def _get_rot_mat(
+        self,
+        theta: float,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """
+        Create a rotation matrix tensor.
+        Args:
+            theta (float): The rotation value in degrees.
+        Returns:
+            **rot_mat** (torch.Tensor): A rotation matrix.
+        """
+        theta = theta * math.pi / 180.0
+        rot_mat = torch.tensor(
+            [
+                [math.cos(theta), -math.sin(theta), 0.0],
+                [math.sin(theta), math.cos(theta), 0.0],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        return rot_mat
+
+    def _rotate_tensor(self, x: torch.Tensor, theta: float) -> torch.Tensor:
+        """
+        Rotate an NCHW image tensor based on a specified degree value.
+        Args:
+            x (torch.Tensor): The NCHW image tensor to rotate.
+            theta (float): The amount to rotate the NCHW image, in degrees.
+        Returns:
+            **x** (torch.Tensor): A rotated NCHW image tensor.
+        """
+        rot_matrix = self._get_rot_mat(theta, x.device, x.dtype)[None, ...].repeat(
+            x.shape[0], 1, 1
+        )
+        if self._has_align_corners:
+            # Pass align_corners explicitly for torch >= 1.3.0
+            grid = F.affine_grid(rot_matrix, x.size(), align_corners=self.align_corners)
+            x = F.grid_sample(
+                x,
+                grid,
+                mode=self.mode,
+                padding_mode=self.padding_mode,
+                align_corners=self.align_corners,
+            )
+        else:
+            grid = F.affine_grid(rot_matrix, x.size())
+            x = F.grid_sample(x, grid, mode=self.mode, padding_mode=self.padding_mode)
+        return x
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Randomly rotate an NCHW image tensor.
+        Args:
+            x (torch.Tensor): NCHW image tensor to randomly rotate.
+        Returns:
+            **x** (torch.Tensor): A randomly rotated NCHW image *tensor*.
+        """
+        assert x.dim() == 4
+        if self._is_distribution:
+            rotate_angle = float(self.degrees_distribution.sample().item())
+        else:
+            n = int(
+                torch.randint(
+                    low=0,
+                    high=len(self.degrees),
+                    size=[1],
+                    dtype=torch.int64,
+                    layout=torch.strided,
+                    device=x.device,
+                ).item()
+            )
+            rotate_angle = self.degrees[n]
+        return self._rotate_tensor(x, rotate_angle)
 
 
 class RandomScale(nn.Module):
     """
-    Apply random rescaling on a NCHW tensor.
+    Apply random rescaling on a NCHW tensor using the F.interpolate function.
     """
 
-    def __init__(self, scale: NumSeqOrTensorType) -> None:
+    __constants__ = [
+        "scale",
+        "mode",
+        "align_corners",
+        "_has_align_corners",
+        "recompute_scale_factor",
+        "_has_recompute_scale_factor",
+        "_is_distribution",
+    ]
+
+    def __init__(
+        self,
+        scale: NumSeqOrTensorOrProbDistType,
+        mode: str = "bilinear",
+        align_corners: Optional[bool] = False,
+        recompute_scale_factor: bool = False,
+    ) -> None:
         """
         Args:
 
-            scale (float, sequence): Tuple of rescaling values to randomly select from.
+            scale (float, sequence, or torch.distribution): Sequence of rescaling
+                values to randomly select from, or a torch.distributions instance.
+            mode (str, optional): Interpolation mode to use. See documentation of
+                F.interpolate for more details. One of; "bilinear", "nearest", "area",
+                or "bicubic".
+                Default: "bilinear"
+            align_corners (bool, optional): Whether or not to align corners. See
+                documentation of F.interpolate for more details.
+                Default: False
+            recompute_scale_factor (bool, optional): Whether or not to recompute the
+                scale factor See documentation of F.interpolate for more details.
+                Default: False
         """
         super().__init__()
-        self.scale = scale
+        if isinstance(scale, torch.distributions.distribution.Distribution):
+            # Distributions are not supported by TorchScript / JIT yet
+            assert scale.batch_shape == torch.Size([])
+            self.scale_distribution = scale
+            self._is_distribution = True
+            self.scale = []
+        else:
+            assert hasattr(scale, "__iter__")
+            if torch.is_tensor(scale):
+                assert cast(torch.Tensor, scale).dim() == 1
+                scale = scale.tolist()
+            assert len(scale) > 0
+            self.scale = [float(s) for s in scale]
+            self._is_distribution = False
+        self.mode = mode
+        self.align_corners = align_corners if mode not in ["nearest", "area"] else None
+        self.recompute_scale_factor = recompute_scale_factor
+        self._has_align_corners = torch.__version__ >= "1.3.0"
+        self._has_recompute_scale_factor = torch.__version__ >= "1.6.0"
 
-    def get_scale_mat(
-        self, m: IntSeqOrIntType, device: torch.device, dtype: torch.dtype
+    def _scale_tensor(self, x: torch.Tensor, scale: float) -> torch.Tensor:
+        """
+        Scale an NCHW image tensor based on a specified scale value.
+
+        Args:
+
+            x (torch.Tensor): The NCHW image tensor to scale.
+            scale (float): The amount to scale the NCHW image by.
+
+        Returns:
+            **x** (torch.Tensor): A scaled NCHW image tensor.
+        """
+        if self._has_align_corners:
+            if self._has_recompute_scale_factor:
+                x = F.interpolate(
+                    x,
+                    scale_factor=scale,
+                    mode=self.mode,
+                    align_corners=self.align_corners,
+                    recompute_scale_factor=self.recompute_scale_factor,
+                )
+            else:
+                x = F.interpolate(
+                    x,
+                    scale_factor=scale,
+                    mode=self.mode,
+                    align_corners=self.align_corners,
+                )
+        else:
+            x = F.interpolate(x, scale_factor=scale, mode=self.mode)
+        return x
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Randomly scale an NCHW image tensor.
+
+        Args:
+
+            x (torch.Tensor): NCHW image tensor to randomly scale.
+
+        Returns:
+            **x** (torch.Tensor): A randomly scaled NCHW image *tensor*.
+        """
+        assert x.dim() == 4
+        if self._is_distribution:
+            scale = float(self.scale_distribution.sample().item())
+        else:
+            n = int(
+                torch.randint(
+                    low=0,
+                    high=len(self.scale),
+                    size=[1],
+                    dtype=torch.int64,
+                    layout=torch.strided,
+                    device=x.device,
+                ).item()
+            )
+            scale = self.scale[n]
+        return self._scale_tensor(x, scale=scale)
+
+
+class RandomScaleAffine(nn.Module):
+    """
+    Apply random rescaling on a NCHW tensor.
+
+    This random scaling transform utilizes F.affine_grid & F.grid_sample, and as a
+    result has two key differences to the default RandomScale transforms This
+    transform either shrinks an image while adding a background, or center crops image
+    and then resizes it to a larger size. This means that the output image shape is the
+    same shape as the input image.
+
+    In constrast to RandomScaleAffine, the default RandomScale transform simply resizes
+    the input image using F.interpolate.
+    """
+
+    __constants__ = [
+        "scale",
+        "mode",
+        "padding_mode",
+        "align_corners",
+        "_has_align_corners",
+        "_is_distribution",
+    ]
+
+    def __init__(
+        self,
+        scale: NumSeqOrTensorOrProbDistType,
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
+        align_corners: bool = False,
+    ) -> None:
+        """
+        Args:
+
+            scale (float, sequence, or torch.distribution): Sequence of rescaling
+                values to randomly select from, or a torch.distributions instance.
+            mode (str, optional): Interpolation mode to use. See documentation of
+                F.grid_sample for more details. One of; "bilinear", "nearest", or
+                "bicubic".
+                Default: "bilinear"
+            padding_mode (str, optional): Padding mode for values that fall outside of
+                the grid. See documentation of F.grid_sample for more details. One of;
+                "zeros", "border", or "reflection".
+                Default: "zeros"
+            align_corners (bool, optional): Whether or not to align corners. See
+                documentation of F.affine_grid & F.grid_sample for more details.
+                Default: False
+        """
+        super().__init__()
+        if isinstance(scale, torch.distributions.distribution.Distribution):
+            # Distributions are not supported by TorchScript / JIT yet
+            assert scale.batch_shape == torch.Size([])
+            self.scale_distribution = scale
+            self._is_distribution = True
+            self.scale = []
+        else:
+            assert hasattr(scale, "__iter__")
+            if torch.is_tensor(scale):
+                assert cast(torch.Tensor, scale).dim() == 1
+                scale = scale.tolist()
+            assert len(scale) > 0
+            self.scale = [float(s) for s in scale]
+            self._is_distribution = False
+        self.mode = mode
+        self.padding_mode = padding_mode
+        self.align_corners = align_corners
+        self._has_align_corners = torch.__version__ >= "1.3.0"
+
+    def _get_scale_mat(
+        self,
+        m: float,
+        device: torch.device,
+        dtype: torch.dtype,
     ) -> torch.Tensor:
+        """
+        Create a scale matrix tensor.
+
+        Args:
+
+            m (float): The scale value to use.
+
+        Returns:
+            **scale_mat** (torch.Tensor): A scale matrix.
+        """
         scale_mat = torch.tensor(
             [[m, 0.0, 0.0], [0.0, m, 0.0]], device=device, dtype=dtype
         )
         return scale_mat
 
-    def scale_tensor(
-        self, x: torch.Tensor, scale: Union[int, float, torch.Tensor]
-    ) -> torch.Tensor:
-        scale_matrix = self.get_scale_mat(scale, x.device, x.dtype)[None, ...].repeat(
-            x.shape[0], 1, 1
-        )
-        if torch.__version__ >= "1.3.0":
-            # Pass align_corners explicitly for torch >= 1.3.0
-            grid = F.affine_grid(scale_matrix, x.size(), align_corners=False)
-            x = F.grid_sample(x, grid, align_corners=False)
-        else:
-            grid = F.affine_grid(scale_matrix, x.size())
-            x = F.grid_sample(x, grid)
-        return x
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
+    def _scale_tensor(self, x: torch.Tensor, scale: float) -> torch.Tensor:
         """
-        Randomly scale / zoom in or out of a tensor.
+        Scale an NCHW image tensor based on a specified scale value.
 
         Args:
 
-            input (torch.Tensor): Input to randomly scale.
+            x (torch.Tensor): The NCHW image tensor to scale.
+            scale (float): The amount to scale the NCHW image by.
 
         Returns:
-            **tensor** (torch.Tensor): Scaled *tensor*.
+            **x** (torch.Tensor): A scaled NCHW image tensor.
         """
-        scale = _rand_select(self.scale)
-        return self.scale_tensor(input, scale=scale)
+        scale_matrix = self._get_scale_mat(scale, x.device, x.dtype)[None, ...].repeat(
+            x.shape[0], 1, 1
+        )
+        if self._has_align_corners:
+            # Pass align_corners explicitly for torch >= 1.3.0
+            grid = F.affine_grid(
+                scale_matrix, x.size(), align_corners=self.align_corners
+            )
+            x = F.grid_sample(
+                x,
+                grid,
+                mode=self.mode,
+                padding_mode=self.padding_mode,
+                align_corners=self.align_corners,
+            )
+        else:
+            grid = F.affine_grid(scale_matrix, x.size())
+            x = F.grid_sample(x, grid, mode=self.mode, padding_mode=self.padding_mode)
+        return x
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Randomly scale an NCHW image tensor.
+
+        Args:
+
+            x (torch.Tensor): NCHW image tensor to randomly scale.
+
+        Returns:
+            **x** (torch.Tensor): A randomly scaled NCHW image *tensor*.
+        """
+        assert x.dim() == 4
+        if self._is_distribution:
+            scale = float(self.scale_distribution.sample().item())
+        else:
+            n = int(
+                torch.randint(
+                    low=0,
+                    high=len(self.scale),
+                    size=[1],
+                    dtype=torch.int64,
+                    layout=torch.strided,
+                    device=x.device,
+                ).item()
+            )
+            scale = self.scale[n]
+        return self._scale_tensor(x, scale=scale)
 
 
 class RandomSpatialJitter(torch.nn.Module):
     """
     Apply random spatial translations on a NCHW tensor.
     """
+
+    __constants__ = ["pad_range"]
 
     def __init__(self, translate: int) -> None:
         """
@@ -380,7 +875,13 @@ class RandomSpatialJitter(torch.nn.Module):
         Returns:
             **tensor** (torch.Tensor): A randomly translated *tensor*.
         """
-        insets = torch.randint(high=self.pad_range, size=(2,))
+        insets = torch.randint(
+            high=self.pad_range,
+            size=(2,),
+            dtype=input.dtype,
+            layout=input.layout,
+            device=input.device,
+        )
         return self.translate_tensor(input, insets)
 
 
@@ -389,6 +890,8 @@ class ScaleInputRange(nn.Module):
     Multiplies the input by a specified multiplier for models with input ranges other
     than [0,1].
     """
+
+    __constants__ = ["multiplier"]
 
     def __init__(self, multiplier: float = 1.0) -> None:
         """
@@ -473,6 +976,8 @@ class GaussianSmoothing(nn.Module):
     1d, 2d or 3d tensor. Filtering is performed seperately for each channel
     in the input using a depthwise convolution.
     """
+
+    __constants__ = ["groups"]
 
     def __init__(
         self,
@@ -603,6 +1108,8 @@ class NChannelsToRGB(nn.Module):
     Convert an NCHW image with n channels into a 3 channel RGB image.
     """
 
+    __constants__ = ["warp"]
+
     def __init__(self, warp: bool = False) -> None:
         """
         Args:
@@ -633,6 +1140,8 @@ class RandomCrop(nn.Module):
     Randomly crop out a specific size from an NCHW image tensor.
     """
 
+    __constants__ = ["crop_size"]
+
     def __init__(
         self,
         crop_size: IntSeqOrIntType,
@@ -649,20 +1158,155 @@ class RandomCrop(nn.Module):
         assert len(crop_size) == 2
         self.crop_size = crop_size
 
+    def _center_crop(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Center crop an NCHW image tensor based on self.crop_size.
+
+        Args:
+
+            x (torch.Tensor): The NCHW image tensor to center crop.
+
+        Returns
+            x (torch.Tensor): The center cropped NCHW image tensor.
+        """
+        h, w = x.shape[2:]
+        h_crop = h - int(math.ceil((h - self.crop_size[0]) / 2.0))
+        w_crop = w - int(math.ceil((w - self.crop_size[1]) / 2.0))
+        return x[
+            ...,
+            h_crop - self.crop_size[0] : h_crop,
+            w_crop - self.crop_size[1] : w_crop,
+        ]
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 4
-        hs = x.shape[2] - self.crop_size[0]
-        ws = x.shape[3] - self.crop_size[1]
+        hs = int(math.ceil((x.shape[2] - self.crop_size[0]) / 2.0))
+        ws = int(math.ceil((x.shape[3] - self.crop_size[1]) / 2.0))
         shifts = [
-            torch.randint(low=-hs, high=hs, size=[1]),
-            torch.randint(low=-ws, high=ws, size=[1]),
+            torch.randint(
+                low=-hs,
+                high=hs,
+                size=[1],
+                dtype=torch.int64,
+                layout=torch.strided,
+                device=x.device,
+            ),
+            torch.randint(
+                low=-ws,
+                high=ws,
+                size=[1],
+                dtype=torch.int64,
+                layout=torch.strided,
+                device=x.device,
+            ),
         ]
-        x = torch.roll(x, shifts, dims=(2, 3))
-        return center_crop(
-            x,
-            crop_vals=self.crop_size,
-            pixels_from_edges=False,
+        x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
+        return self._center_crop(x)
+
+
+class TransformationRobustness(nn.Module):
+    """
+    This transform combines the standard transforms together for ease of use.
+
+    Multiple jitter transforms can be used to create roughly gaussian distribution
+    of jitter.
+
+    Outputs can be optionally cropped or padded so that they have the same shape as
+    inputs.
+    """
+
+    __constants__ = ["crop_or_pad_output"]
+
+    def __init__(
+        self,
+        padding_transform: Optional[nn.Module] = nn.ConstantPad2d(2, value=0.5),
+        translate: Optional[Union[int, List[int]]] = [4] * 10,
+        scale: Optional[NumSeqOrTensorOrProbDistType] = [
+            0.995 ** n for n in range(-5, 80)
+        ]
+        + [0.998 ** n for n in 2 * list(range(20, 40))],
+        degrees: Optional[NumSeqOrTensorOrProbDistType] = list(range(-20, 20))
+        + list(range(-10, 10))
+        + list(range(-5, 5))
+        + 5 * [0],
+        final_translate: Optional[int] = 2,
+        crop_or_pad_output: bool = False,
+    ) -> None:
+        """
+        Args:
+
+            padding_transform (nn.Module, optional): A padding module instance. No
+                padding will be applied before transforms if set to None.
+                Default: nn.ConstantPad2d(2, value=0.5)
+            translate (int or list of int, optional): The max horizontal and vertical
+                 translation to use for each jitter transform.
+                 Default: [4] * 10
+            scale (float, sequence, or torch.distribution, optional): Sequence of
+                rescaling values to randomly select from, or a torch.distributions
+                instance. If set to None, no rescaling transform will be used.
+                Default: A set of optimal values.
+            degrees (float, sequence, or torch.distribution, optional): Sequence of
+                degrees to randomly select from, or a torch.distributions
+                instance. If set to None, no rotation transform will be used.
+                Default: A set of optimal values.
+            final_translate (int, optional): The max horizontal and vertical
+                 translation to use for the final jitter transform on fractional
+                 pixels.
+                 Default: 2
+            crop_or_pad_output (bool, optional): Whether or not to crop or pad the
+                transformed output so that it is the same shape as the input.
+                Default: False
+        """
+        super().__init__()
+        self.padding_transform = padding_transform
+        if translate is not None:
+            jitter_transforms = []
+            if hasattr(translate, "__iter__"):
+                jitter_transforms = []
+                for t in translate:
+                    jitter_transforms.append(RandomSpatialJitter(t))
+                self.jitter_transforms = nn.Sequential(*jitter_transforms)
+            else:
+                self.jitter_transforms = RandomSpatialJitter(translate)
+        else:
+            self.jitter_transforms = translate
+        self.random_scale = None if scale is None else RandomScale(scale)
+        self.random_rotation = None if degrees is None else RandomRotation(degrees)
+        self.final_jitter = (
+            None if final_translate is None else RandomSpatialJitter(final_translate)
         )
+        self.crop_or_pad_output = crop_or_pad_output
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        assert x.dim() == 4
+        crop_size = x.shape[2:]
+
+        # Apply padding if enabled
+        if self.padding_transform is not None:
+            x = self.padding_transform(x)
+
+        # Jitter real pixels
+        if self.jitter_transforms is not None:
+            x = self.jitter_transforms(x)
+
+        # Apply Random Scaling, turning real pixels into
+        # fractional values of real pixels
+        if self.random_scale is not None:
+            x = self.random_scale(x)
+
+        # Apply Random Rotation
+        if self.random_rotation is not None:
+            x = self.random_rotation(x)
+
+        # Jitter fractional pixels if random_scale is not None
+        if self.final_jitter is not None:
+            x = self.final_jitter(x)
+
+        # Ensure the output is the same shape as the input
+        if self.crop_or_pad_output:
+            x = center_crop(x, size=crop_size)
+            assert x.shape[2:] == crop_size
+        return x
 
 
 __all__ = [
@@ -673,10 +1317,12 @@ __all__ = [
     "center_crop",
     "RandomScale",
     "RandomSpatialJitter",
+    "RandomRotation",
     "ScaleInputRange",
     "RGBToBGR",
     "GaussianSmoothing",
     "SymmetricPadding",
     "NChannelsToRGB",
     "RandomCrop",
+    "TransformationRobustness",
 ]

--- a/captum/optim/_utils/image/atlas.py
+++ b/captum/optim/_utils/image/atlas.py
@@ -1,0 +1,286 @@
+from typing import Callable, List, Tuple, Union, cast
+
+import torch
+
+
+def normalize_grid(
+    xy_grid: torch.Tensor,
+    min_percentile: float = 0.01,
+    max_percentile: float = 0.99,
+    relative_margin: float = 0.1,
+) -> torch.Tensor:
+    """
+    Remove outliers from an xy coordinate grid tensor, and rescale it to [0, 1].
+
+    Args:
+
+        xy_grid (torch.tensor): The xy coordinate grid tensor to normalize,
+            with a shape of: [n_points, n_axes].
+        min_percentile (float, optional): The minimum percentile to use when
+            normalizing the tensor. Value must be in the range [0, 1].
+            Default: 0.01
+        max_percentile (float, optional): The maximum percentile to use when
+            normalizing the tensor. Value must be in the range [0, 1].
+            Default: 0.99
+        relative_margin (float, optional): The relative margin to use when
+            normalizing the tensor.
+            Default: 0.1
+
+    Returns:
+        normalized_grid (torch.tensor): A normalized xy coordinate grid tensor.
+    """
+
+    assert xy_grid.dim() == 2
+    assert 0.0 <= min_percentile <= 1.0
+    assert 0.0 <= max_percentile <= 1.0
+    assert min_percentile < max_percentile
+
+    mins = torch.quantile(xy_grid, min_percentile, dim=0)
+    maxs = torch.quantile(xy_grid, max_percentile, dim=0)
+
+    mins = mins - relative_margin * (maxs - mins)
+    maxs = maxs + relative_margin * (maxs - mins)
+
+    normalized_grid = torch.max(torch.min(xy_grid, maxs), mins)
+    normalized_grid = normalized_grid - normalized_grid.min(0)[0]
+    return normalized_grid / normalized_grid.max(0)[0]
+
+
+def calc_grid_indices(
+    xy_grid: torch.Tensor,
+    grid_size: Tuple[int, int],
+    x_extent: Tuple[float, float] = (0.0, 1.0),
+    y_extent: Tuple[float, float] = (0.0, 1.0),
+) -> List[List[torch.Tensor]]:
+    """
+    This function draws a 2D grid across the irregular grid of points, and then groups
+    point indices based on the grid cell they fall within. The grid cells are then
+    filled with 1D tensors that have anywhere from 0 to n_indices values in them. The
+    sets of grid indices can then be used with the extract_grid_vectors function to
+    create atlas grid cell direction vectors.
+
+    Indices are stored for grid cells in an xy matrix, where the outer lists represent
+    x positions and the inner lists represent y positions. Each grid cell is filled
+    with 1D tensors that have anywhere from 0 to n_indices index values inside them.
+
+    Below is an example of the index list format for a grid_size of (3, 3):
+    indices = [x1[y1, y2, y3], x2[y1, y2, y3], x3[y1, y2, y3]]
+
+    Grid cells would then be ordered like this, where each cell contains a list of
+    indices for that particular cell:
+    indices = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+
+    Args:
+        xy_grid (torch.tensor): The xy coordinate grid activation samples, with a shape
+            of: [n_points, 2].
+        grid_size (Tuple[int, int]): The grid_size of grid cells to use. The grid_size
+            variable should be in the format of: [width, height].
+        x_extent (Tuple[float, float], optional): The x axis range to use.
+            Default: (0.0, 1.0)
+        y_extent (Tuple[float, float], optional): The y axis range to use.
+            Default: (0.0, 1.0)
+    Returns:
+        indices (list of list of torch.Tensors): List of lists of grid indices
+            stored inside tensors to use. Each 1D tensor of indices has a size of:
+            0 to n_indices.
+    """
+
+    assert xy_grid.dim() == 2 and xy_grid.size(1) == 2
+
+    #  Convert coordinates to bins
+    x_bin = ((xy_grid[:, 0] - x_extent[0]) / (x_extent[1] - x_extent[0])) * grid_size[0]
+    y_bin = ((xy_grid[:, 1] - y_extent[0]) / (y_extent[1] - y_extent[0])) * grid_size[1]
+
+    indices: List[List[torch.Tensor]] = []
+    for x in range(grid_size[0]):
+        indice_bounds: List[torch.Tensor] = []
+        for y in range(grid_size[1]):
+            in_bounds_x = torch.logical_and(x <= x_bin, x_bin <= x + 1)
+            in_bounds_y = torch.logical_and(y <= y_bin, y_bin <= y + 1)
+            in_bounds_indices = torch.where(
+                torch.logical_and(in_bounds_x, in_bounds_y)
+            )[0]
+            indice_bounds.append(in_bounds_indices)
+        indices.append(indice_bounds)
+    return indices
+
+
+def extract_grid_vectors(
+    grid_indices: List[List[torch.Tensor]],
+    raw_activations: torch.Tensor,
+    grid_size: Tuple[int, int],
+    min_density: int = 8,
+) -> Tuple[torch.Tensor, List[Tuple[int, int, int]]]:
+    """
+    Create direction vectors for activation samples and grid indices. Grid cells
+    without the minimum number of points as specified by min_density will be
+    ignored. The calc_grid_indices function can be used to produce the values required
+    for the grid_indices variable.
+
+    Carter, et al., "Activation Atlas", Distill, 2019.
+    https://distill.pub/2019/activation-atlas/
+
+    Args:
+
+        grid_indices (list of list of torch.tensor): List of lists of grid indices
+            stored inside tensors to use. Each 1D tensor of indices has a size of:
+            0 to n_indices.
+        raw_activations (torch.tensor): Raw unmodified activation samples, with a shape
+            of: [n_samples, n_channels].
+        grid_size (Tuple[int, int]): The grid_size of grid cells to use. The grid_size
+            variable should be in the format of: [width, height].
+        min_density (int, optional): The minimum number of points for a cell to be
+            counted.
+            Default: 8
+
+    Returns:
+        cell_vecs (torch.tensor): A tensor containing all the direction vectors that
+            were created, stacked along the batch dimension with a shape of:
+            [n_vecs, n_channels].
+        cell_coords (list of Tuple[int, int, int]): List of coordinates for grid
+            spatial positions of each direction vector, and the number of samples used
+            for the cell. The list for each cell is in the format of:
+            [x_coord, y_coord, number_of_samples_used].
+    """
+
+    assert raw_activations.dim() == 2
+
+    cell_coords: List[Tuple[int, int, int]] = []
+    average_activations: List[torch.Tensor] = []
+    for x in range(grid_size[0]):
+        for y in range(grid_size[1]):
+            indices = grid_indices[x][y]
+            if len(indices) >= min_density:
+                average_activations.append(torch.mean(raw_activations[indices], 0))
+                cell_coords.append((x, y, len(indices)))
+    assert len(cell_coords) > 0, "No grid vectors were able to be created."
+    return torch.stack(average_activations), cell_coords
+
+
+def create_atlas_vectors(
+    xy_grid: torch.Tensor,
+    raw_activations: torch.Tensor,
+    grid_size: Tuple[int, int],
+    min_density: int = 8,
+    normalize: bool = True,
+    x_extent: Tuple[float, float] = (0.0, 1.0),
+    y_extent: Tuple[float, float] = (0.0, 1.0),
+) -> Tuple[torch.Tensor, List[Tuple[int, int, int]]]:
+    """
+    Create direction vectors by splitting an irregular grid of activation samples into
+    cells. Grid cells without the minimum number of points as specified by min_density
+    will be ignored.
+
+    Carter, et al., "Activation Atlas", Distill, 2019.
+    https://distill.pub/2019/activation-atlas/
+
+    Args:
+
+        xy_grid (torch.tensor): The xy coordinate grid activation samples, with a shape
+            of: [n_points, 2].
+        raw_activations (torch.tensor): Raw unmodified activation samples, with a shape
+            of: [n_samples, n_channels].
+        grid_size (Tuple[int, int]): The size of grid cells to use. The grid_size
+            variable should be in the format of: [width, height].
+        min_density (int, optional): The minimum number of points for a cell to be
+            counted.
+            Default: 8
+        normalize (bool, optional): Whether or not to remove outliers from an xy
+            coordinate grid tensor, and rescale it to [0, 1].
+            Default: True
+        x_extent (Tuple[float, float], optional): The x axis range to use.
+            Default: (0.0, 1.0)
+        y_extent (Tuple[float, float], optional): The y axis range to use.
+            Default: (0.0, 1.0)
+
+    Returns:
+        grid_vecs (torch.tensor): A tensor containing all the direction vectors that
+            were created, stacked along the batch dimension, with a shape of:
+            [n_vecs, n_channels].
+        cell_coords (list of Tuple[int, int, int]): List of coordinates for grid
+            spatial positions of each direction vector, and the number of samples used
+            for the cell. The list for each cell is in the format of:
+            [x_coord, y_coord, number_of_samples_used].
+    """
+
+    assert xy_grid.dim() == 2 and xy_grid.size(1) == 2
+    assert raw_activations.dim() == 2
+
+    if normalize:
+        xy_grid = normalize_grid(xy_grid)
+    indices = calc_grid_indices(
+        xy_grid, grid_size, x_extent=x_extent, y_extent=y_extent
+    )
+    grid_vecs, vec_coords = extract_grid_vectors(
+        indices, raw_activations, grid_size, min_density
+    )
+    return grid_vecs, vec_coords
+
+
+def create_atlas(
+    cells: Union[torch.Tensor, List[torch.Tensor]],
+    coords: List[Tuple[int, int]],
+    grid_size: Tuple[int, int],
+    base_tensor: Callable = torch.ones,
+) -> torch.Tensor:
+    """
+    Create an NCHW atlas grid image tensor from a set of NCHW image tensors and their
+    corresponding grid coordinates.
+
+    Args:
+
+        cells (list of torch.tensor or torch.tensor): A list or stack of NCHW image
+            tensors made with atlas direction vectors.
+        coords (list of Tuple[int, int] or list of Tuple[int, int, int]): A list of
+            coordinates to use for the atlas image tensors. The first 2 values in each
+            coordinate list should be: [x, y, ...].
+        grid_size (Tuple[int, int]): The size of grid cells to use. The grid_size
+            variable should be in the format of: [width, height].
+        base_tensor (Callable, optional): What to use for the atlas base tensor. Basic
+            choices are: torch.ones or torch.zeros.
+            Default: torch.ones
+
+    Returns:
+        atlas_canvas (torch.tensor): The full activation atlas visualization, with a
+            shape of NCHW.
+    """
+
+    if torch.is_tensor(cells):
+        assert cast(torch.Tensor, cells).dim() == 4
+        cells = [c.unsqueeze(0) for c in cells]
+
+    assert len(cells) == len(coords)
+    assert all([c.shape == cells[0].shape for c in cells])
+    assert all([c.device == cells[0].device for c in cells])
+    assert cells[0].dim() == 4
+
+    #  cell_b -> number of images
+    #  cell_c -> image channel
+    #  cell_h ->  image hight
+    #  cell_w -> image width
+    cell_b, cell_c, cell_h, cell_w = cells[0].shape
+    atlas_canvas = base_tensor(
+        cell_b,
+        cell_c,
+        cell_h * grid_size[1],
+        cell_w * grid_size[0],
+        device=cells[0].device,
+    )
+    for i, img in enumerate(cells):
+        y = int(coords[i][1])
+        x = int(coords[i][0])
+        atlas_canvas[
+            ...,
+            (grid_size[1] - y - 1) * cell_h : (grid_size[1] - y) * cell_h,
+            (grid_size[0] - x - 1) * cell_w : (grid_size[0] - x) * cell_w,
+        ] = img.flip([3])
+    return torch.flip(atlas_canvas, [3])
+
+
+__all__ = [
+    "normalize_grid",
+    "calc_grid_indices",
+    "extract_grid_vectors",
+    "create_atlas_vectors",
+    "create_atlas",
+]

--- a/captum/optim/_utils/image/common.py
+++ b/captum/optim/_utils/image/common.py
@@ -55,7 +55,7 @@ def save_tensor_as_image(x: torch.Tensor, filename: str, scale: float = 255.0) -
         raise ValueError(
             f"Incompatible number of dimensions. x.dim() = {x.dim()}; should be 3 or 4."
         )
-    x = x[0] if x.dim() == 4 else x
+    x = torch.cat([t[0] for t in x.split(1)], dim=2) if x.dim() == 4 else x
     x = x.clone().cpu().detach().permute(1, 2, 0) * scale
     colorspace = "RGB" if x.shape[2] == 3 else "RGBA"
     im = Image.fromarray(x.numpy().astype(np.uint8), colorspace)
@@ -110,6 +110,7 @@ def _dot_cossim(
     return dot * torch.clamp(torch.cosine_similarity(x, y, eps=eps), 0.1) ** cossim_pow
 
 
+@torch.jit.ignore
 def nchannels_to_rgb(x: torch.Tensor, warp: bool = True) -> torch.Tensor:
     """
     Convert an NCHW image with n channels into a 3 channel RGB image.
@@ -176,21 +177,23 @@ def weights_to_heatmap_2d(
     colors: List[str] = ["0571b0", "92c5de", "f7f7f7", "f4a582", "ca0020"],
 ) -> torch.Tensor:
     """
-    Create a color heatmap of an input weight tensor.
-    By default red represents excitatory values,
-    blue represents inhibitory values, and white represents
+    Create a color heatmap of an input weight tensor. By default red represents
+    excitatory values, blue represents inhibitory values, and white represents
     no excitation or inhibition.
 
     Args:
         weight (torch.Tensor):  A 2d tensor to create the heatmap from.
-        colors (List of strings):  A list of strings containing color
-        hex values to use for coloring the heatmap.
+        colors (list of str):  A list of 5 strings containing hex triplet
+            (six digit), three-byte hexadecimal color values to use for coloring
+            the heatmap.
+
     Returns:
-        *tensor*:  A weight heatmap.
+        color_tensor (torch.Tensor):  A weight heatmap.
     """
 
     assert weight.dim() == 2
     assert len(colors) == 5
+    assert all([len(c) == 6 for c in colors])
 
     def get_color(x: str, device: torch.device = torch.device("cpu")) -> torch.Tensor:
         def hex2base10(x: str) -> float:
@@ -200,31 +203,19 @@ def weights_to_heatmap_2d(
             [hex2base10(x[0:2]), hex2base10(x[2:4]), hex2base10(x[4:6])], device=device
         )
 
-    def color_scale(x: torch.Tensor) -> torch.Tensor:
-        if x < 0:
-            x = -x
-            if x < 0.5:
-                x = x * 2
-                return (1 - x) * get_color(colors[2], x.device) + x * get_color(
-                    colors[1], x.device
-                )
-            else:
-                x = (x - 0.5) * 2
-                return (1 - x) * get_color(colors[1], x.device) + x * get_color(
-                    colors[0], x.device
-                )
-        else:
-            if x < 0.5:
-                x = x * 2
-                return (1 - x) * get_color(colors[2], x.device) + x * get_color(
-                    colors[3], x.device
-                )
-            else:
-                x = (x - 0.5) * 2
-                return (1 - x) * get_color(colors[3], x.device) + x * get_color(
-                    colors[4], x.device
-                )
+    color_list = [get_color(c, weight.device) for c in colors]
+    x = weight.expand((3, weight.shape[0], weight.shape[1])).permute(1, 2, 0)
 
-    return torch.stack(
-        [torch.stack([color_scale(x) for x in t]) for t in weight]
+    color_tensor = (
+        (x >= 0) * (x < 0.5) * ((1 - x * 2) * color_list[2] + x * 2 * color_list[3])
+        + (x >= 0)
+        * (x >= 0.5)
+        * ((1 - (x - 0.5) * 2) * color_list[3] + (x - 0.5) * 2 * color_list[4])
+        + (x < 0)
+        * (x > -0.5)
+        * ((1 - (-x * 2)) * color_list[2] + (-x * 2) * color_list[1])
+        + (x < 0)
+        * (x <= -0.5)
+        * ((1 - (-x - 0.5) * 2) * color_list[1] + (-x - 0.5) * 2 * color_list[0])
     ).permute(2, 0, 1)
+    return color_tensor

--- a/captum/optim/_utils/typing.py
+++ b/captum/optim/_utils/typing.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
-from torch import Tensor
+from torch import Tensor, __version__
 from torch.nn import Module
 from torch.optim import Optimizer
 
@@ -33,6 +33,16 @@ StopCriteria = Callable[[int, Objective, Iterable[Tensor], Optimizer], bool]
 LossFunction = Callable[[ModuleOutputMapping], Tensor]
 SingleTargetLossFunction = Callable[[Tensor], Tensor]
 
-NumSeqOrTensorType = Union[Sequence[int], Sequence[float], Tensor]
+if __version__ < "1.4.0":
+    NumSeqOrTensorOrProbDistType = Union[Sequence[int], Sequence[float], Tensor]
+else:
+    from torch import distributions
+
+    NumSeqOrTensorOrProbDistType = Union[
+        Sequence[int],
+        Sequence[float],
+        Tensor,
+        distributions.distribution.Distribution,
+    ]
 IntSeqOrIntType = Union[List[int], Tuple[int], Tuple[int, int], int]
 TupleOfTensorsOrTensorType = Union[Tuple[Tensor, ...], Tensor]

--- a/captum/optim/models/_image/inception_v1.py
+++ b/captum/optim/models/_image/inception_v1.py
@@ -165,7 +165,7 @@ class InceptionV1(nn.Module):
     def _transform_input(self, x: torch.Tensor) -> torch.Tensor:
         if self.transform_input:
             assert x.dim() == 3 or x.dim() == 4
-            assert x.min() >= 0.0 and x.max() <= 1.0
+            #assert x.min() >= 0.0 and x.max() <= 1.0
             x = x.unsqueeze(0) if x.dim() == 3 else x
             x = x * 255 - 117
             x = x[:, [2, 1, 0]] if self.bgr_transform else x

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -300,3 +300,10 @@ def TestBasisTorchModuleOP(BaseTest):
             loss_list, torch_op=sum, to_scalar_fn=torch.mean
         )
         self.assertAlmostEqual(get_loss_value(model, loss), 5.0, places=1)
+
+    def test_python_max(self) -> None:
+        model = torch.nn.Identity()
+        loss = opt_loss.LayerActivation(model)
+        loss = opt_loss.basic_torch_module_op([loss, torch.zeros(1, 3, 1, 1)], torch_op=max)
+        loss = loss.sum()
+        self.assertAlmostEqual(get_loss_value(model, loss), 3.0, places=1)

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -134,6 +134,31 @@ class TestNeuronDirection(BaseTest):
         self.assertAlmostEqual(get_loss_value(model, loss), dot, places=6)
 
 
+class TestAngledNeuronDirection(BaseTest):
+    def test_angled_neuron_direction(self) -> None:
+        model = BasicModel_ConvNet_Optim()
+        loss = opt_loss.AngledNeuronDirection(
+            model.layer, vec=torch.ones(1, 2), cossim_pow=0
+        )
+        a = 1
+        b = [CHANNEL_ACTIVATION_0_LOSS, CHANNEL_ACTIVATION_1_LOSS]
+        dot = np.sum(np.inner(a, b))
+        self.assertAlmostEqual(np.sum(get_loss_value(model, loss)), dot, places=6)
+
+    def test_angled_neuron_direction_whitened(self) -> None:
+        model = BasicModel_ConvNet_Optim()
+        loss = opt_loss.AngledNeuronDirection(
+            model.layer,
+            vec=torch.ones(1, 2),
+            vec_whitened=torch.ones(2, 2),
+            cossim_pow=0,
+        )
+        a = 1
+        b = [CHANNEL_ACTIVATION_0_LOSS, CHANNEL_ACTIVATION_1_LOSS]
+        dot = np.sum(np.inner(a, b)) * 2
+        self.assertAlmostEqual(np.sum(get_loss_value(model, loss)), dot, places=6)
+
+
 class TestTensorDirection(BaseTest):
     def test_tensor_direction(self) -> None:
         model = BasicModel_ConvNet_Optim()
@@ -307,3 +332,19 @@ def TestBasisTorchModuleOP(BaseTest):
         loss = opt_loss.basic_torch_module_op([loss, torch.zeros(1, 3, 1, 1)], torch_op=max)
         loss = loss.sum()
         self.assertAlmostEqual(get_loss_value(model, loss), 3.0, places=1)
+
+    def test_sum_loss_list(self) -> None:
+        n_batch = 400
+        model = torch.nn.Identity()
+        loss_fn_list = [opt_loss.LayerActivation(model) for i in range(n_batch)]
+        loss_fn = opt_loss.sum_loss_list(loss_fn_list)
+        out = get_loss_value(model, loss_fn, [n_batch, 3, 1, 1])
+        self.assertEqual(out, float(n_batch))
+
+    def test_sum_loss_list_compose_add(self) -> None:
+        n_batch = 400
+        model = torch.nn.Identity()
+        loss_fn_list = [opt_loss.LayerActivation(model) for i in range(n_batch)]
+        loss_fn = opt_loss.sum_loss_list(loss_fn_list) + opt_loss.LayerActivation(model)
+        out = get_loss_value(model, loss_fn, [n_batch, 3, 1, 1])
+        self.assertEqual(out, float(n_batch + 1.0))

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 
 from captum.optim._param.image import images
-from captum.optim._param.image.transforms import SymmetricPadding
+from captum.optim._param.image.transforms import SymmetricPadding, ToRGB
 from tests.helpers.basic import (
     BaseTest,
     assertArraysAlmostEqual,
@@ -79,7 +79,7 @@ class TestImageTensor(BaseTest):
         self.assertTrue(torch.is_tensor(new_tensor))
         assertTensorAlmostEqual(self, image_tensor, new_tensor)
 
-    def test_natural_image_cuda(self) -> None:
+    def test_image_tensor_cuda(self) -> None:
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
                 "Skipping ImageTensor CUDA test due to not supporting CUDA."
@@ -88,7 +88,31 @@ class TestImageTensor(BaseTest):
         self.assertTrue(image_t.is_cuda)
 
 
+class TestInputParameterization(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(issubclass(images.InputParameterization, torch.nn.Module))
+
+
+class TestImageParameterization(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(
+            issubclass(images.ImageParameterization, images.InputParameterization)
+        )
+
+
+class TestAugmentedImageParameterization(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(
+            issubclass(
+                images.AugmentedImageParameterization, images.ImageParameterization
+            )
+        )
+
+
 class TestFFTImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(issubclass(images.FFTImage, images.ImageParameterization))
+
     def test_pytorch_fftfreq(self) -> None:
         image = images.FFTImage((1, 1))
         _, _, fftfreq = image.get_fft_funcs()
@@ -105,6 +129,127 @@ class TestFFTImage(BaseTest):
             torch.tensor([[0.0000, 0.3333], [0.5000, 0.6009]]),
         )
 
+    def test_irfftn(self) -> None:
+        size = (4, 4)
+        image = images.FFTImage(size)
+        test_fft_tensor = (
+            torch.arange(0, 1 * 1 * size[1] * size[0] * 2)
+            .view(1, 1, size[1], size[0], 2)
+            .float()
+        )
+
+        test_output = image.torch_irfft(test_fft_tensor)
+
+        if torch.__version__ >= "1.7.0":
+            # torch.fft.irfftn output
+            expected_tensor = torch.tensor(
+                [
+                    [
+                        [
+                            [14.0000, -8.5000, 0.0000, 6.5000],
+                            [0.0000, 4.0000, 0.0000, -4.0000],
+                            [-4.0000, 2.0000, 0.0000, -2.0000],
+                            [-8.0000, 0.0000, 0.0000, 0.0000],
+                        ]
+                    ]
+                ]
+            )
+            delta = 0.0001
+
+        else:
+            # torch.irfft output
+            expected_tensor = torch.tensor(
+                [
+                    [
+                        [
+                            [14.8571, -12.4554, 1.5140, -4.1097],
+                            [-1.2143, 3.7929, -1.7647, 0.2188],
+                            [-3.4286, 3.0750, 0.2962, 1.2880],
+                            [-6.7857, 1.2143, 1.2143, 1.2143],
+                        ]
+                    ]
+                ]
+            )
+            delta = 0.0004
+        assertTensorAlmostEqual(self, test_output, expected_tensor, delta=delta)
+
+    def test_init_spectrum_scale_init_tensor(self) -> None:
+        size = (4, 4)
+        image_param = images.FFTImage(init=torch.ones(1, 3, size[0], size[1]))
+        scale = torch.tensor(
+            [
+                [4.0000, 4.0000, 2.0000],
+                [4.0000, 2.8284, 1.7889],
+                [2.0000, 1.7889, 1.4142],
+                [4.0000, 2.8284, 1.7889],
+            ]
+        )
+        scale = scale * ((size[0] * size[1]) ** (1 / 2))
+        spectrum_scale = scale[None, :, :, None]
+        assertTensorAlmostEqual(
+            self, image_param.spectrum_scale, spectrum_scale, delta=0.0009
+        )
+
+    @unittest.skipIf(
+        torch.__version__ < "1.8.0",
+        "Skipping FFTImage fourier_coeffs with init"
+        + " tensor test due to newer Torch version.",
+    )
+    def test_init_fourier_coeffs_init_tensor_after_v1_7_0(self) -> None:
+        size = (4, 4)
+        init_tensor = torch.ones(1, 3, size[0], size[1])
+        image_param = images.FFTImage(init=init_tensor.clone())
+
+        torch_rfft_init = torch.view_as_real(torch.fft.rfftn(init_tensor, s=size))
+
+        scale = torch.tensor(
+            [
+                [4.0000, 4.0000, 2.0000],
+                [4.0000, 2.8284, 1.7889],
+                [2.0000, 1.7889, 1.4142],
+                [4.0000, 2.8284, 1.7889],
+            ]
+        )
+        scale = scale * ((size[0] * size[1]) ** (1 / 2))
+        spectrum_scale = scale[None, :, :, None]
+
+        fourier_coeffs = torch_rfft_init / spectrum_scale
+        assertTensorAlmostEqual(self, image_param.fourier_coeffs, fourier_coeffs)
+        self.assertTrue(image_param.fourier_coeffs.requires_grad)
+
+    @unittest.skipUnless(
+        torch.__version__ < "1.7.0",
+        "Skipping FFTImage fourier_coeffs with init"
+        + " tensor test due to newer Torch version.",
+    )
+    def test_init_fourier_coeffs_init_tensor_before_v1_7_0(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping FFTImage fourier_coeffs with init tensor test due to newer"
+                + " Torch version."
+            )
+
+        size = (4, 4)
+        init_tensor = torch.ones(1, 3, size[0], size[1])
+        image_param = images.FFTImage(init=init_tensor.clone())
+
+        torch_rfft_init = torch.rfft(init_tensor, signal_ndim=2)  # type: ignore
+
+        scale = torch.tensor(
+            [
+                [4.0000, 4.0000, 2.0000],
+                [4.0000, 2.8284, 1.7889],
+                [2.0000, 1.7889, 1.4142],
+                [4.0000, 2.8284, 1.7889],
+            ]
+        )
+        scale = scale * ((size[0] * size[1]) ** (1 / 2))
+        spectrum_scale = scale[None, :, :, None]
+
+        fourier_coeffs = torch_rfft_init * spectrum_scale
+        assertTensorAlmostEqual(self, image_param.fourier_coeffs, fourier_coeffs)
+        self.assertTrue(image_param.fourier_coeffs.requires_grad)
+
     def test_fftimage_forward_randn_init(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -117,8 +262,19 @@ class TestFFTImage(BaseTest):
 
         fftimage_tensor = fftimage.forward()
         fftimage_array = fftimage_np.forward()
-
+        self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
+        self.assertTrue(fftimage.fourier_coeffs.requires_grad)
+
+    def test_fftimage_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping FFTImage JIT module test due to insufficient Torch version."
+            )
+        fftimage = images.FFTImage(size=(224, 224))
+        jit_fftimage = torch.jit.script(fftimage)
+        fftimage_tensor = jit_fftimage()
+        self.assertTrue(torch.is_tensor(fftimage_tensor))
 
     def test_fftimage_forward_init_randn_batch(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -177,6 +333,7 @@ class TestFFTImage(BaseTest):
         fftimage_tensor = fftimage.forward()
         fftimage_array = fftimage_np.forward()
 
+        self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
         assertArraysAlmostEqual(fftimage_tensor.detach().numpy(), fftimage_array, 25.0)
 
@@ -195,6 +352,7 @@ class TestFFTImage(BaseTest):
         fftimage_tensor = fftimage.forward()
         fftimage_array = fftimage_np.forward()
 
+        self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
         assertArraysAlmostEqual(fftimage_tensor.detach().numpy(), fftimage_array, 25.0)
 
@@ -214,11 +372,15 @@ class TestFFTImage(BaseTest):
         fftimage_tensor = fftimage.forward()
         fftimage_array = fftimage_np.forward()
 
+        self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
         assertArraysAlmostEqual(fftimage_tensor.detach().numpy(), fftimage_array, 25.0)
 
 
 class TestPixelImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(issubclass(images.PixelImage, images.ImageParameterization))
+
     def test_pixelimage_random(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -233,6 +395,7 @@ class TestPixelImage(BaseTest):
         self.assertEqual(image_param.image.size(1), channels)
         self.assertEqual(image_param.image.size(2), size[0])
         self.assertEqual(image_param.image.size(3), size[1])
+        self.assertTrue(image_param.image.requires_grad)
 
     def test_pixelimage_init(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -250,17 +413,7 @@ class TestPixelImage(BaseTest):
         self.assertEqual(image_param.image.size(2), size[0])
         self.assertEqual(image_param.image.size(3), size[1])
         assertTensorAlmostEqual(self, image_param.image, init_tensor, 0)
-
-    def test_pixelimage_init_error(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping PixelImage init due to insufficient Torch version."
-            )
-        size = (224, 224)
-        channels = 2
-        init_tensor = torch.randn(channels, *size)
-        with self.assertRaises(AssertionError):
-            images.PixelImage(size=size, channels=channels, init=init_tensor)
+        self.assertTrue(image_param.image.requires_grad)
 
     def test_pixelimage_random_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -277,6 +430,17 @@ class TestPixelImage(BaseTest):
         self.assertEqual(test_tensor.size(1), channels)
         self.assertEqual(test_tensor.size(2), size[0])
         self.assertEqual(test_tensor.size(3), size[1])
+
+    def test_pixelimage_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping PixelImage JIT module test due to insufficient Torch"
+                + " version."
+            )
+        image_param = images.PixelImage(size=(224, 224), channels=3)
+        jit_image_param = torch.jit.script(image_param)
+        output_tensor = jit_image_param()
+        self.assertTrue(torch.is_tensor(output_tensor))
 
     def test_pixelimage_init_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -298,6 +462,9 @@ class TestPixelImage(BaseTest):
 
 
 class TestLaplacianImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(issubclass(images.LaplacianImage, images.ImageParameterization))
+
     def test_laplacianimage_random_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -325,7 +492,154 @@ class TestLaplacianImage(BaseTest):
         assertArraysAlmostEqual(np.ones_like(test_np) * 0.5, test_np)
 
 
+class TestSimpleTensorParameterization(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(
+            issubclass(
+                images.SimpleTensorParameterization, images.ImageParameterization
+            )
+        )
+
+    def test_simple_tensor_parameterization_no_grad(self) -> None:
+        test_input = torch.randn(1, 3, 4, 4)
+        image_param = images.SimpleTensorParameterization(test_input)
+        assertTensorAlmostEqual(self, image_param.tensor, test_input, 0.0)
+        self.assertFalse(image_param.tensor.requires_grad)
+
+        test_output = image_param()
+        assertTensorAlmostEqual(self, test_output, test_input, 0.0)
+        self.assertFalse(image_param.tensor.requires_grad)
+
+    def test_simple_tensor_parameterization_jit_module_no_grad(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping SimpleTensorParameterization JIT module test due to"
+                + "  insufficient Torch version."
+            )
+        test_input = torch.randn(1, 3, 4, 4)
+        image_param = images.SimpleTensorParameterization(test_input)
+        jit_image_param = torch.jit.script(image_param)
+
+        test_output = jit_image_param()
+        assertTensorAlmostEqual(self, test_output, test_input, 0.0)
+        self.assertFalse(image_param.tensor.requires_grad)
+
+    def test_simple_tensor_parameterization_with_grad(self) -> None:
+        test_input = torch.nn.Parameter(torch.randn(1, 3, 4, 4))
+        image_param = images.SimpleTensorParameterization(test_input)
+        assertTensorAlmostEqual(self, image_param.tensor, test_input, 0.0)
+        self.assertTrue(image_param.tensor.requires_grad)
+
+        test_output = image_param()
+        assertTensorAlmostEqual(self, test_output, test_input, 0.0)
+        self.assertTrue(image_param.tensor.requires_grad)
+
+    def test_simple_tensor_parameterization_jit_module_with_grad(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping SimpleTensorParameterization JIT module test due to"
+                + "  insufficient Torch version."
+            )
+        test_input = torch.nn.Parameter(torch.randn(1, 3, 4, 4))
+        image_param = images.SimpleTensorParameterization(test_input)
+        jit_image_param = torch.jit.script(image_param)
+
+        test_output = jit_image_param()
+        assertTensorAlmostEqual(self, test_output, test_input, 0.0)
+        self.assertTrue(image_param.tensor.requires_grad)
+
+    def test_simple_tensor_parameterization_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping SimpleTensorParameterization CUDA test due to not supporting"
+                + " CUDA."
+            )
+        test_input = torch.randn(1, 3, 4, 4).cuda()
+        image_param = images.SimpleTensorParameterization(test_input)
+        self.assertTrue(image_param.tensor.is_cuda)
+        assertTensorAlmostEqual(self, image_param.tensor, test_input, 0.0)
+        self.assertFalse(image_param.tensor.requires_grad)
+
+        test_output = image_param()
+        self.assertTrue(test_output.is_cuda)
+        assertTensorAlmostEqual(self, test_output, test_input, 0.0)
+        self.assertFalse(image_param.tensor.requires_grad)
+
+
 class TestSharedImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(
+            issubclass(images.SharedImage, images.AugmentedImageParameterization)
+        )
+
+    def test_sharedimage_interpolate_bilinear(self) -> None:
+        shared_shapes = (128 // 2, 128 // 2)
+        test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
+        image_param = images.SharedImage(
+            shapes=shared_shapes, parameterization=test_param
+        )
+
+        size = (224, 128)
+        test_input = torch.randn(1, 3, 128, 128)
+
+        test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)
+        expected_output = torch.nn.functional.interpolate(
+            test_input.clone(), size=size, mode="bilinear"
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+        size = (128, 128)
+        test_input = torch.randn(1, 3, 224, 224)
+
+        test_output = image_param._interpolate_bilinear(test_input.clone(), size=size)
+        expected_output = torch.nn.functional.interpolate(
+            test_input.clone(), size=size, mode="bilinear"
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+    def test_sharedimage_interpolate_trilinear(self) -> None:
+        shared_shapes = (128 // 2, 128 // 2)
+        test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
+        image_param = images.SharedImage(
+            shapes=shared_shapes, parameterization=test_param
+        )
+
+        size = (3, 224, 128)
+        test_input = torch.randn(1, 1, 128, 128)
+
+        test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)
+        expected_output = torch.nn.functional.interpolate(
+            test_input.clone().unsqueeze(0), size=size, mode="trilinear"
+        ).squeeze(0)
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+        size = (2, 128, 128)
+        test_input = torch.randn(1, 4, 224, 224)
+
+        test_output = image_param._interpolate_trilinear(test_input.clone(), size=size)
+        expected_output = torch.nn.functional.interpolate(
+            test_input.clone().unsqueeze(0), size=size, mode="trilinear"
+        ).squeeze(0)
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+    def test_torch_version_check(self) -> None:
+        shared_shapes = (128 // 2, 128 // 2)
+        test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
+        image_param = images.SharedImage(
+            shapes=shared_shapes, parameterization=test_param
+        )
+
+        has_align_corners = torch.__version__ >= "1.3.0"
+        self.assertEqual(image_param._has_align_corners, has_align_corners)
+
+        has_recompute_scale_factor = torch.__version__ >= "1.6.0"
+        self.assertEqual(
+            image_param._has_recompute_scale_factor, has_recompute_scale_factor
+        )
+
+        supports_is_scripting = torch.__version__ >= "1.6.0"
+        self.assertEqual(image_param._supports_is_scripting, supports_is_scripting)
+
     def test_sharedimage_get_offset_single_number(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -502,9 +816,9 @@ class TestSharedImage(BaseTest):
         test_tensor = image_param.forward()
 
         self.assertIsNone(image_param.offset)
-        self.assertEqual(image_param.shared_init[0].dim(), 4)
+        self.assertEqual(image_param.shared_init[0]().dim(), 4)
         self.assertEqual(
-            list(image_param.shared_init[0].shape), [1, 1] + list(shared_shapes)
+            list(image_param.shared_init[0]().shape), [1, 1] + list(shared_shapes)
         )
         self.assertEqual(test_tensor.dim(), 4)
         self.assertEqual(test_tensor.size(0), batch)
@@ -529,9 +843,9 @@ class TestSharedImage(BaseTest):
         test_tensor = image_param.forward()
 
         self.assertIsNone(image_param.offset)
-        self.assertEqual(image_param.shared_init[0].dim(), 4)
+        self.assertEqual(image_param.shared_init[0]().dim(), 4)
         self.assertEqual(
-            list(image_param.shared_init[0].shape), [1] + list(shared_shapes)
+            list(image_param.shared_init[0]().shape), [1] + list(shared_shapes)
         )
         self.assertEqual(test_tensor.dim(), 4)
         self.assertEqual(test_tensor.size(0), batch)
@@ -556,8 +870,8 @@ class TestSharedImage(BaseTest):
         test_tensor = image_param.forward()
 
         self.assertIsNone(image_param.offset)
-        self.assertEqual(image_param.shared_init[0].dim(), 4)
-        self.assertEqual(list(image_param.shared_init[0].shape), list(shared_shapes))
+        self.assertEqual(image_param.shared_init[0]().dim(), 4)
+        self.assertEqual(list(image_param.shared_init[0]().shape), list(shared_shapes))
         self.assertEqual(test_tensor.dim(), 4)
         self.assertEqual(test_tensor.size(0), batch)
         self.assertEqual(test_tensor.size(1), channels)
@@ -589,9 +903,9 @@ class TestSharedImage(BaseTest):
 
         self.assertIsNone(image_param.offset)
         for i in range(len(shared_shapes)):
-            self.assertEqual(image_param.shared_init[i].dim(), 4)
+            self.assertEqual(image_param.shared_init[i]().dim(), 4)
             self.assertEqual(
-                list(image_param.shared_init[i].shape), list(shared_shapes[i])
+                list(image_param.shared_init[i]().shape), list(shared_shapes[i])
             )
         self.assertEqual(test_tensor.dim(), 4)
         self.assertEqual(test_tensor.size(0), batch)
@@ -624,10 +938,42 @@ class TestSharedImage(BaseTest):
 
         self.assertIsNone(image_param.offset)
         for i in range(len(shared_shapes)):
-            self.assertEqual(image_param.shared_init[i].dim(), 4)
+            self.assertEqual(image_param.shared_init[i]().dim(), 4)
             s_shape = list(shared_shapes[i])
             s_shape = ([1] * (4 - len(s_shape))) + list(s_shape)
-            self.assertEqual(list(image_param.shared_init[i].shape), s_shape)
+            self.assertEqual(list(image_param.shared_init[i]().shape), s_shape)
+
+        self.assertEqual(test_tensor.dim(), 4)
+        self.assertEqual(test_tensor.size(0), batch)
+        self.assertEqual(test_tensor.size(1), channels)
+        self.assertEqual(test_tensor.size(2), size[0])
+        self.assertEqual(test_tensor.size(3), size[1])
+
+    def test_sharedimage_multiple_shapes_diff_len_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping SharedImage JIT module test due to insufficient Torch"
+                + " version."
+            )
+
+        shared_shapes = (
+            (128 // 2, 128 // 2),
+            (7, 3, 128 // 4, 128 // 4),
+            (3, 128 // 8, 128 // 8),
+            (2, 4, 128 // 8, 128 // 8),
+            (1, 3, 128 // 16, 128 // 16),
+            (2, 2, 128 // 16, 128 // 16),
+        )
+        batch = 6
+        channels = 3
+        size = (224, 224)
+        test_input = torch.ones(batch, channels, size[0], size[1])  # noqa: E731
+        test_param = images.SimpleTensorParameterization(test_input)
+        image_param = images.SharedImage(
+            shapes=shared_shapes, parameterization=test_param
+        )
+        jit_image_param = torch.jit.script(image_param)
+        test_tensor = jit_image_param()
 
         self.assertEqual(test_tensor.dim(), 4)
         self.assertEqual(test_tensor.size(0), batch)
@@ -636,7 +982,315 @@ class TestSharedImage(BaseTest):
         self.assertEqual(test_tensor.size(3), size[1])
 
 
+class TestStackImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(
+            issubclass(images.StackImage, images.AugmentedImageParameterization)
+        )
+
+    def test_stackimage_torch_version_check(self) -> None:
+        img_param_1 = images.SimpleTensorParameterization(torch.ones(1, 3, 4, 4))
+        img_param_2 = images.SimpleTensorParameterization(torch.ones(1, 3, 4, 4))
+        param_list = [img_param_1, img_param_2]
+        stack_param = images.StackImage(parameterizations=param_list)
+
+        supports_is_scripting = torch.__version__ >= "1.6.0"
+        self.assertEqual(stack_param._supports_is_scripting, supports_is_scripting)
+
+    def test_stackimage_init(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping StackImage init test due to insufficient Torch version."
+            )
+        size = (4, 4)
+        fft_param_1 = images.FFTImage(size=size)
+        fft_param_2 = images.FFTImage(size=size)
+        param_list = [fft_param_1, fft_param_2]
+        stack_param = images.StackImage(parameterizations=param_list)
+        for image_param in stack_param.parameterizations:
+            self.assertIsInstance(image_param, images.FFTImage)
+            self.assertEqual(list(image_param().shape), [1, 3] + list(size))
+            self.assertTrue(image_param().requires_grad)
+
+    def test_stackimage_forward(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping StackImage forward test due to insufficient Torch version."
+            )
+        size = (4, 4)
+        fft_param_1 = images.FFTImage(size=size)
+        fft_param_2 = images.FFTImage(size=size)
+        param_list = [fft_param_1, fft_param_2]
+        stack_param = images.StackImage(parameterizations=param_list)
+        for image_param in stack_param.parameterizations:
+            self.assertIsInstance(image_param, images.FFTImage)
+            self.assertEqual(list(image_param().shape), [1, 3] + list(size))
+            self.assertTrue(image_param().requires_grad)
+
+        output_tensor = stack_param()
+        self.assertEqual(list(output_tensor.shape), [2, 3] + list(size))
+        self.assertTrue(output_tensor.requires_grad)
+        self.assertIsNone(stack_param.output_device)
+
+    def test_stackimage_forward_diff_image_params(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping StackImage forward with diff image params test due to"
+                + " insufficient Torch version."
+            )
+        size = (4, 4)
+        fft_param = images.FFTImage(size=size)
+        pixel_param = images.PixelImage(size=size)
+        param_list = [fft_param, pixel_param]
+
+        stack_param = images.StackImage(parameterizations=param_list)
+
+        type_list = [images.FFTImage, images.PixelImage]
+        for image_param, expected_type in zip(stack_param.parameterizations, type_list):
+            self.assertIsInstance(image_param, expected_type)
+            self.assertEqual(list(image_param().shape), [1, 3] + list(size))
+            self.assertTrue(image_param().requires_grad)
+
+        output_tensor = stack_param()
+        self.assertEqual(list(output_tensor.shape), [2, 3] + list(size))
+        self.assertTrue(output_tensor.requires_grad)
+        self.assertIsNone(stack_param.output_device)
+
+    def test_stackimage_forward_diff_image_params_and_tensor_with_grad(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping StackImage forward with diff image params and tensor with"
+                + " grad test due to insufficient Torch version."
+            )
+        size = (4, 4)
+        fft_param = images.FFTImage(size=size)
+        pixel_param = images.PixelImage(size=size)
+        test_tensor = torch.nn.Parameter(torch.ones(1, 3, size[0], size[1]))
+        param_list = [fft_param, pixel_param, test_tensor]
+
+        stack_param = images.StackImage(parameterizations=param_list)
+
+        type_list = [
+            images.FFTImage,
+            images.PixelImage,
+            images.SimpleTensorParameterization,
+        ]
+        for image_param, expected_type in zip(stack_param.parameterizations, type_list):
+            self.assertIsInstance(image_param, expected_type)
+            self.assertEqual(list(image_param().shape), [1, 3] + list(size))
+            self.assertTrue(image_param().requires_grad)
+
+        output_tensor = stack_param()
+        self.assertEqual(list(output_tensor.shape), [3, 3] + list(size))
+        self.assertTrue(output_tensor.requires_grad)
+        self.assertIsNone(stack_param.output_device)
+
+    def test_stackimage_forward_diff_image_params_and_tensor_no_grad(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping StackImage forward with diff image params and tensor with"
+                + " no grad test due to insufficient Torch version."
+            )
+        size = (4, 4)
+        fft_param = images.FFTImage(size=size)
+        pixel_param = images.PixelImage(size=size)
+        test_tensor = torch.ones(1, 3, size[0], size[1])
+        param_list = [fft_param, pixel_param, test_tensor]
+
+        stack_param = images.StackImage(parameterizations=param_list)
+
+        type_list = [
+            images.FFTImage,
+            images.PixelImage,
+            images.SimpleTensorParameterization,
+        ]
+        for image_param, expected_type in zip(stack_param.parameterizations, type_list):
+            self.assertIsInstance(image_param, expected_type)
+            self.assertEqual(list(image_param().shape), [1, 3] + list(size))
+
+        self.assertTrue(stack_param.parameterizations[0]().requires_grad)
+        self.assertTrue(stack_param.parameterizations[1]().requires_grad)
+        self.assertFalse(stack_param.parameterizations[2]().requires_grad)
+
+        output_tensor = stack_param()
+        self.assertEqual(list(output_tensor.shape), [3, 3] + list(size))
+        self.assertTrue(output_tensor.requires_grad)
+        self.assertIsNone(stack_param.output_device)
+
+    def test_stackimage_forward_multi_gpu(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping StackImage forward multi GPU test due to insufficient"
+                + " Torch version."
+            )
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping StackImage multi GPU test due to not supporting CUDA."
+            )
+        if torch.cuda.device_count() == 1:
+            raise unittest.SkipTest(
+                "Skipping StackImage multi GPU device test due to not having enough"
+                + " GPUs available."
+            )
+        size = (4, 4)
+
+        num_cuda_devices = torch.cuda.device_count()
+        param_list, device_list = [], []
+
+        fft_param = images.FFTImage(size=size).cpu()
+        param_list.append(fft_param)
+        device_list.append(torch.device("cpu"))
+
+        for i in range(num_cuda_devices - 1):
+            device = torch.device("cuda:" + str(i))
+            device_list.append(device)
+            fft_param = images.FFTImage(size=size).to(device)
+            param_list.append(fft_param)
+
+        output_device = torch.device("cuda:" + str(num_cuda_devices - 1))
+        stack_param = images.StackImage(
+            parameterizations=param_list, output_device=output_device
+        )
+
+        for image_param, torch_device in zip(
+            stack_param.parameterizations, device_list
+        ):
+            self.assertIsInstance(image_param, images.FFTImage)
+            self.assertEqual(list(image_param().shape), [1, 3] + list(size))
+            self.assertEqual(image_param().device, torch_device)
+            self.assertTrue(image_param().requires_grad)
+
+        output_tensor = stack_param()
+        self.assertEqual(
+            list(output_tensor.shape), [len(param_list)] + [3] + list(size)
+        )
+        self.assertTrue(output_tensor.requires_grad)
+        self.assertEqual(stack_param().device, output_device)
+
+    def test_stackimage_forward_multi_device_cpu_gpu(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping StackImage forward multi device test due to insufficient"
+                + " Torch version."
+            )
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping StackImage multi device test due to not supporting CUDA."
+            )
+        size = (4, 4)
+        param_list, device_list = [], []
+
+        fft_param = images.FFTImage(size=size).cpu()
+        param_list.append(fft_param)
+        device_list.append(torch.device("cpu"))
+
+        device = torch.device("cuda:0")
+        device_list.append(device)
+        fft_param = images.FFTImage(size=size).to(device)
+        param_list.append(fft_param)
+
+        output_device = torch.device("cuda:0")
+        stack_param = images.StackImage(
+            parameterizations=param_list, output_device=output_device
+        )
+
+        for image_param, torch_device in zip(
+            stack_param.parameterizations, device_list
+        ):
+            self.assertIsInstance(image_param, images.FFTImage)
+            self.assertEqual(list(image_param().shape), [1, 3] + list(size))
+            self.assertEqual(image_param().device, torch_device)
+            self.assertTrue(image_param().requires_grad)
+
+        output_tensor = stack_param()
+        self.assertEqual(
+            list(output_tensor.shape), [len(param_list)] + [3] + list(size)
+        )
+        self.assertTrue(output_tensor.requires_grad)
+        self.assertEqual(stack_param().device, output_device)
+
+
 class TestNaturalImage(BaseTest):
+    def test_subclass(self) -> None:
+        self.assertTrue(issubclass(images.NaturalImage, images.ImageParameterization))
+
+    def test_natural_image_init_func_default(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage FFTImage init func test due to insufficient"
+                + " Torch version."
+            )
+        image_param = images.NaturalImage(size=(4, 4))
+        self.assertIsInstance(image_param.parameterization, images.FFTImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+
+    def test_natural_image_init_func_fftimage(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage FFTImage init func test due to insufficient"
+                + " Torch version."
+            )
+        image_param = images.NaturalImage(size=(4, 4), parameterization=images.FFTImage)
+        self.assertIsInstance(image_param.parameterization, images.FFTImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+
+    def test_natural_image_init_func_fftimage_instance(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage FFTImage init func FFTImage instance test due"
+                + " to insufficient Torch version."
+            )
+
+        fft_param = images.FFTImage(size=(4, 4))
+        image_param = images.NaturalImage(parameterization=fft_param)
+        self.assertIsInstance(image_param.parameterization, images.FFTImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+
+    def test_natural_image_init_func_pixelimage(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage PixelImage init func test due to insufficient"
+                + " Torch version."
+            )
+        image_param = images.NaturalImage(
+            size=(4, 4), parameterization=images.PixelImage
+        )
+        self.assertIsInstance(image_param.parameterization, images.PixelImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+
+    def test_natural_image_init_func_default_init_tensor(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage FFTImage init func test due to insufficient"
+                + " Torch version."
+            )
+        image_param = images.NaturalImage(init=torch.ones(1, 3, 1, 1))
+        self.assertIsInstance(image_param.parameterization, images.FFTImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, image_param._clamp_image)
+
+    def test_natural_image_init_tensor_pixelimage_sf_sigmoid(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage PixelImage init tensor with sigmoid"
+                + " test due to insufficient Torch version."
+            )
+        image_param = images.NaturalImage(
+            init=torch.ones(1, 3, 1, 1),
+            parameterization=images.PixelImage,
+            squash_func=torch.sigmoid,
+        )
+        output_tensor = image_param()
+
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+        assertTensorAlmostEqual(
+            self, output_tensor, torch.ones_like(output_tensor) * 0.7310586
+        )
+
     def test_natural_image_0(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -663,6 +1317,41 @@ class TestNaturalImage(BaseTest):
         image_param = images.NaturalImage().cuda()
         self.assertTrue(image_param().is_cuda)
 
+    def test_natural_image_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage JIT module test due to"
+                + " insufficient Torch version."
+            )
+        image_param = images.NaturalImage()
+        jit_image_param = torch.jit.script(image_param)
+        output_tensor = jit_image_param()
+        self.assertTrue(torch.is_tensor(output_tensor))
+
+    def test_natural_image_jit_module_init_tensor(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage init tensor JIT module test due to"
+                + " insufficient Torch version."
+            )
+        image_param = images.NaturalImage(init=torch.ones(1, 3, 1, 1))
+        jit_image_param = torch.jit.script(image_param)
+        output_tensor = jit_image_param()
+        assertTensorAlmostEqual(self, output_tensor, torch.ones_like(output_tensor))
+
+    def test_natural_image_jit_module_init_tensor_pixelimage(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage PixelImage init tensor JIT module"
+                + " test due to insufficient Torch version."
+            )
+        image_param = images.NaturalImage(
+            init=torch.ones(1, 3, 1, 1), parameterization=images.PixelImage
+        )
+        jit_image_param = torch.jit.script(image_param)
+        output_tensor = jit_image_param()
+        assertTensorAlmostEqual(self, output_tensor, torch.ones_like(output_tensor))
+
     def test_natural_image_decorrelation_module_none(self) -> None:
         if torch.__version__ <= "1.3.0":
             raise unittest.SkipTest(
@@ -672,4 +1361,5 @@ class TestNaturalImage(BaseTest):
             init=torch.ones(1, 3, 4, 4), decorrelation_module=None
         )
         image = image_param.forward().detach()
+        self.assertIsNone(image_param.decorrelate)
         assertTensorAlmostEqual(self, image, torch.ones_like(image))

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -15,31 +15,306 @@ from tests.helpers.basic import (
 from tests.optim.helpers import numpy_transforms
 
 
-class TestRandSelect(BaseTest):
-    def test_rand_select(self) -> None:
-        a = (1, 2, 3, 4, 5)
-        b = torch.Tensor([0.1, -5, 56.7, 99.0])
-
-        self.assertIn(transforms._rand_select(a), a)
-        self.assertIn(transforms._rand_select(b), b)
-
-
 class TestRandomScale(BaseTest):
-    def test_random_scale(self) -> None:
-        scale_module = transforms.RandomScale(scale=(1, 0.975, 1.025, 0.95, 1.05))
-        test_tensor = torch.ones(1, 3, 3, 3)
+    def test_random_scale_init(self) -> None:
+        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05])
+        self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
+        self.assertFalse(scale_module._is_distribution)
+        self.assertEqual(scale_module.mode, "bilinear")
+        self.assertFalse(scale_module.align_corners)
+        self.assertFalse(scale_module.recompute_scale_factor)
 
-        # Test rescaling
+    def test_random_scale_tensor_scale(self) -> None:
+        scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])
+        scale_module = transforms.RandomScale(scale=scale)
+        self.assertEqual(scale_module.scale, scale.tolist())
+
+    def test_random_scale_int_scale(self) -> None:
+        scale = [1, 2, 3, 4, 5]
+        scale_module = transforms.RandomScale(scale=scale)
+        for s in scale_module.scale:
+            self.assertIsInstance(s, float)
+        self.assertEqual(scale_module.scale, [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def test_random_scale_scale_distributions(self) -> None:
+        scale = torch.distributions.Uniform(0.95, 1.05)
+        scale_module = transforms.RandomScale(scale=scale)
+        self.assertIsInstance(
+            scale_module.scale_distribution,
+            torch.distributions.distribution.Distribution,
+        )
+        self.assertTrue(scale_module._is_distribution)
+
+    def test_random_scale_torch_version_check(self) -> None:
+        scale_module = transforms.RandomScale([1.0])
+
+        has_align_corners = torch.__version__ >= "1.3.0"
+        self.assertEqual(scale_module._has_align_corners, has_align_corners)
+
+        has_recompute_scale_factor = torch.__version__ >= "1.6.0"
+        self.assertEqual(
+            scale_module._has_recompute_scale_factor, has_recompute_scale_factor
+        )
+
+    def test_random_scale_downscaling(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5])
+        test_tensor = torch.arange(0, 1 * 1 * 10 * 10).view(1, 1, 10, 10).float()
+
+        scaled_tensor = scale_module._scale_tensor(test_tensor, 0.5)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [5.5000, 7.5000, 9.5000, 11.5000, 13.5000],
+                        [25.5000, 27.5000, 29.5000, 31.5000, 33.5000],
+                        [45.5000, 47.5000, 49.5000, 51.5000, 53.5000],
+                        [65.5000, 67.5000, 69.5000, 71.5000, 73.5000],
+                        [85.5000, 87.5000, 89.5000, 91.5000, 93.5000],
+                    ]
+                ]
+            ]
+        )
+
         assertTensorAlmostEqual(
             self,
-            scale_module.scale_tensor(test_tensor, 0.5),
-            torch.ones(3, 1).repeat(3, 1, 3).unsqueeze(0),
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_upscaling(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5])
+        test_tensor = torch.arange(0, 1 * 1 * 2 * 2).view(1, 1, 2, 2).float()
+
+        scaled_tensor = scale_module._scale_tensor(test_tensor, 1.5)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0000, 0.5000, 1.0000],
+                        [1.0000, 1.5000, 2.0000],
+                        [2.0000, 2.5000, 3.0000],
+                    ]
+                ]
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_forward_exact(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5])
+        test_tensor = torch.arange(0, 1 * 1 * 10 * 10).view(1, 1, 10, 10).float()
+
+        scaled_tensor = scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [5.5000, 7.5000, 9.5000, 11.5000, 13.5000],
+                        [25.5000, 27.5000, 29.5000, 31.5000, 33.5000],
+                        [45.5000, 47.5000, 49.5000, 51.5000, 53.5000],
+                        [65.5000, 67.5000, 69.5000, 71.5000, 73.5000],
+                        [85.5000, 87.5000, 89.5000, 91.5000, 93.5000],
+                    ]
+                ]
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_forward_exact_nearest(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5], mode="nearest")
+        self.assertIsNone(scale_module.align_corners)
+        self.assertEqual(scale_module.mode, "nearest")
+
+        test_tensor = torch.arange(0, 1 * 1 * 10 * 10).view(1, 1, 10, 10).float()
+
+        scaled_tensor = scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 2.0, 4.0, 6.0, 8.0],
+                        [20.0, 22.0, 24.0, 26.0, 28.0],
+                        [40.0, 42.0, 44.0, 46.0, 48.0],
+                        [60.0, 62.0, 64.0, 66.0, 68.0],
+                        [80.0, 82.0, 84.0, 86.0, 88.0],
+                    ]
+                ]
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_forward_exact_align_corners(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping RandomScale exact align corners forward due to"
+                + " insufficient Torch version."
+            )
+        scale_module = transforms.RandomScale(scale=[0.5], align_corners=True)
+        self.assertTrue(scale_module.align_corners)
+
+        test_tensor = torch.arange(0, 1 * 1 * 10 * 10).view(1, 1, 10, 10).float()
+
+        scaled_tensor = scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0000, 2.2500, 4.5000, 6.7500, 9.0000],
+                        [22.5000, 24.7500, 27.0000, 29.2500, 31.5000],
+                        [45.0000, 47.2500, 49.5000, 51.7500, 54.0000],
+                        [67.5000, 69.7500, 72.0000, 74.2500, 76.5000],
+                        [90.0000, 92.2500, 94.5000, 96.7500, 99.0000],
+                    ]
+                ]
+            ]
+        )
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_forward(self) -> None:
+        scale_module = transforms.RandomScale(scale=[0.5])
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = scale_module(test_tensor)
+        self.assertEqual(list(output_tensor.shape), [1, 3, 5, 5])
+
+    def test_random_scale_forward_distributions(self) -> None:
+        scale = torch.distributions.Uniform(0.95, 1.05)
+        scale_module = transforms.RandomScale(scale=scale)
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = scale_module(test_tensor)
+        self.assertTrue(torch.is_tensor(output_tensor))
+
+    def test_random_scale_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RandomScale JIT module test due to insufficient"
+                + " Torch version."
+            )
+        scale_module = transforms.RandomScale(scale=[1.5])
+        jit_scale_module = torch.jit.script(scale_module)
+
+        test_tensor = torch.arange(0, 1 * 1 * 2 * 2).view(1, 1, 2, 2).float()
+        scaled_tensor = jit_scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0000, 0.5000, 1.0000],
+                        [1.0000, 1.5000, 2.0000],
+                        [2.0000, 2.5000, 3.0000],
+                    ]
+                ]
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+
+class TestRandomScaleAffine(BaseTest):
+    def test_random_scale_affine_init(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[1, 0.975, 1.025, 0.95, 1.05])
+        self.assertEqual(scale_module.scale, [1.0, 0.975, 1.025, 0.95, 1.05])
+        self.assertFalse(scale_module._is_distribution)
+        self.assertEqual(scale_module.mode, "bilinear")
+        self.assertEqual(scale_module.padding_mode, "zeros")
+        self.assertFalse(scale_module.align_corners)
+
+    def test_random_scale_affine_tensor_scale(self) -> None:
+        scale = torch.tensor([1, 0.975, 1.025, 0.95, 1.05])
+        scale_module = transforms.RandomScaleAffine(scale=scale)
+        self.assertEqual(scale_module.scale, scale.tolist())
+
+    def test_random_scale_affine_int_scale(self) -> None:
+        scale = [1, 2, 3, 4, 5]
+        scale_module = transforms.RandomScaleAffine(scale=scale)
+        for s in scale_module.scale:
+            self.assertIsInstance(s, float)
+        self.assertEqual(scale_module.scale, [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def test_random_scale_affine_scale_distributions(self) -> None:
+        scale = torch.distributions.Uniform(0.95, 1.05)
+        scale_module = transforms.RandomScaleAffine(scale=scale)
+        self.assertIsInstance(
+            scale_module.scale_distribution,
+            torch.distributions.distribution.Distribution,
+        )
+        self.assertTrue(scale_module._is_distribution)
+
+    def test_random_scale_affine_torch_version_check(self) -> None:
+        scale_module = transforms.RandomScaleAffine([1.0])
+        _has_align_corners = torch.__version__ >= "1.3.0"
+        self.assertEqual(scale_module._has_align_corners, _has_align_corners)
+
+    def test_random_scale_affine_matrix(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[0.5])
+        test_tensor = torch.ones(1, 3, 3, 3)
+        # Test scale matrices
+
+        assertTensorAlmostEqual(
+            self,
+            scale_module._get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
+            torch.tensor([[0.5000, 0.0000, 0.0000], [0.0000, 0.5000, 0.0000]]),
             0,
         )
 
         assertTensorAlmostEqual(
             self,
-            scale_module.scale_tensor(test_tensor, 1.5),
+            scale_module._get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
+            torch.tensor([[1.2400, 0.0000, 0.0000], [0.0000, 1.2400, 0.0000]]),
+            0,
+        )
+
+    def test_random_scale_affine_downscaling(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[0.5])
+        test_tensor = torch.ones(1, 3, 3, 3)
+
+        assertTensorAlmostEqual(
+            self,
+            scale_module._scale_tensor(test_tensor, 0.5),
+            torch.ones(3, 1).repeat(3, 1, 3).unsqueeze(0),
+            0,
+        )
+
+    def test_random_scale_affine_upscaling(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[1.5])
+        test_tensor = torch.ones(1, 3, 3, 3)
+
+        assertTensorAlmostEqual(
+            self,
+            scale_module._scale_tensor(test_tensor, 1.5),
             torch.tensor(
                 [
                     [0.2500, 0.5000, 0.2500],
@@ -52,27 +327,313 @@ class TestRandomScale(BaseTest):
             0,
         )
 
-    def test_random_scale_matrix(self) -> None:
-        scale_module = transforms.RandomScale(scale=(1, 0.975, 1.025, 0.95, 1.05))
+    def test_random_scale_affine_forward_exact(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[1.5])
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+
+        scaled_tensor = scale_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0000, 0.1875, 0.5625, 0.1875],
+                        [0.7500, 3.7500, 5.2500, 1.5000],
+                        [2.2500, 9.7500, 11.2500, 3.0000],
+                        [0.7500, 3.1875, 3.5625, 0.9375],
+                    ]
+                ]
+            ]
+        )
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_affine_forward_exact_mode_nearest(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[1.5], mode="nearest")
+        self.assertEqual(scale_module.mode, "nearest")
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+
+        scaled_tensor = scale_module(test_tensor)
+        expected_tensor = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 0.0, 0.0, 0.0],
+                        [0.0, 5.0, 6.0, 0.0],
+                        [0.0, 9.0, 10.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0],
+                    ]
+                ]
+            ]
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            scaled_tensor,
+            expected_tensor,
+            0,
+        )
+
+    def test_random_scale_affine_forward(self) -> None:
+        scale_module = transforms.RandomScaleAffine(scale=[0.5])
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = scale_module(test_tensor)
+        self.assertEqual(list(output_tensor.shape), list(test_tensor.shape))
+
+    def test_random_scale_affine_forward_distributions(self) -> None:
+        scale = torch.distributions.Uniform(0.95, 1.05)
+        scale_module = transforms.RandomScaleAffine(scale=scale)
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = scale_module(test_tensor)
+        self.assertEqual(list(output_tensor.shape), list(test_tensor.shape))
+
+    def test_random_scale_affine_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RandomScaleAffine JIT module test due to insufficient"
+                + " Torch version."
+            )
+        scale_module = transforms.RandomScaleAffine(scale=[1.5])
+        jit_scale_module = torch.jit.script(scale_module)
         test_tensor = torch.ones(1, 3, 3, 3)
-        # Test scale matrices
 
         assertTensorAlmostEqual(
             self,
-            scale_module.get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
-            torch.tensor([[0.5000, 0.0000, 0.0000], [0.0000, 0.5000, 0.0000]]),
+            jit_scale_module(test_tensor),
+            torch.tensor(
+                [
+                    [0.2500, 0.5000, 0.2500],
+                    [0.5000, 1.0000, 0.5000],
+                    [0.2500, 0.5000, 0.2500],
+                ]
+            )
+            .repeat(3, 1, 1)
+            .unsqueeze(0),
             0,
         )
 
-        assertTensorAlmostEqual(
-            self,
-            scale_module.get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
-            torch.tensor([[1.2400, 0.0000, 0.0000], [0.0000, 1.2400, 0.0000]]),
-            0,
+
+class TestRandomRotation(BaseTest):
+    def test_random_rotation_init(self) -> None:
+        test_degrees = [0.0, 1.0, 2.0, 3.0, 4.0]
+        rotation_module = transforms.RandomRotation(test_degrees)
+        degrees = rotation_module.degrees
+        self.assertTrue(hasattr(degrees, "__iter__"))
+        self.assertEqual(degrees, test_degrees)
+        self.assertFalse(rotation_module._is_distribution)
+        self.assertEqual(rotation_module.mode, "bilinear")
+        self.assertEqual(rotation_module.padding_mode, "zeros")
+        self.assertFalse(rotation_module.align_corners)
+
+    def test_random_rotation_tensor_degrees(self) -> None:
+        degrees = torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0])
+        rotation_module = transforms.RandomRotation(degrees=degrees)
+        self.assertEqual(rotation_module.degrees, degrees.tolist())
+
+    def test_random_rotation_int_degrees(self) -> None:
+        degrees = [1, 2, 3, 4, 5]
+        rotation_module = transforms.RandomRotation(degrees=degrees)
+        for r in rotation_module.degrees:
+            self.assertIsInstance(r, float)
+        self.assertEqual(rotation_module.degrees, [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def test_random_rotation_degrees_distributions(self) -> None:
+        degrees = torch.distributions.Uniform(0.95, 1.05)
+        rotation_module = transforms.RandomRotation(degrees=degrees)
+        self.assertIsInstance(
+            rotation_module.degrees_distribution,
+            torch.distributions.distribution.Distribution,
         )
+        self.assertTrue(rotation_module._is_distribution)
+
+    def test_random_rotation_torch_version_check(self) -> None:
+        rotation_module = transforms.RandomRotation([1.0])
+        _has_align_corners = torch.__version__ >= "1.3.0"
+        self.assertEqual(rotation_module._has_align_corners, _has_align_corners)
+
+    def test_random_rotation_matrix(self) -> None:
+        theta = 25.1
+        rotation_module = transforms.RandomRotation([theta])
+        rot_matrix = rotation_module._get_rot_mat(
+            theta, device=torch.device("cpu"), dtype=torch.float32
+        )
+        expected_matrix = torch.tensor(
+            [[0.9056, -0.4242, 0.0000], [0.4242, 0.9056, 0.0000]]
+        )
+
+        assertTensorAlmostEqual(self, rot_matrix, expected_matrix)
+
+    def test_random_rotation_rotate_tensor(self) -> None:
+        rotation_module = transforms.RandomRotation([25.0])
+
+        test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
+        test_output = rotation_module._rotate_tensor(test_input, 25.0)
+
+        expected_output = (
+            torch.tensor(
+                [
+                    [0.1143, 0.0000, 0.0000, 0.0000],
+                    [0.5258, 0.6198, 0.2157, 0.0000],
+                    [0.0000, 0.2157, 0.6198, 0.5258],
+                    [0.0000, 0.0000, 0.0000, 0.1143],
+                ]
+            )
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.005)
+
+    def test_random_rotation_forward_exact(self) -> None:
+        rotation_module = transforms.RandomRotation([25.0])
+
+        test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
+        test_output = rotation_module(test_input)
+
+        expected_output = (
+            torch.tensor(
+                [
+                    [0.1143, 0.0000, 0.0000, 0.0000],
+                    [0.5258, 0.6198, 0.2157, 0.0000],
+                    [0.0000, 0.2157, 0.6198, 0.5258],
+                    [0.0000, 0.0000, 0.0000, 0.1143],
+                ]
+            )
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.005)
+
+    def test_random_rotation_forward_exact_nearest_reflection(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping RandomRotation forward due exact nearest relfection"
+                + " to insufficient Torch version."
+            )
+        rotation_module = transforms.RandomRotation(
+            [45.0], mode="nearest", padding_mode="reflection"
+        )
+        self.assertEqual(rotation_module.mode, "nearest")
+        self.assertEqual(rotation_module.padding_mode, "reflection")
+
+        test_input = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        test_output = rotation_module(test_input)
+
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [2.0, 2.0, 7.0, 11.0],
+                        [1.0, 6.0, 10.0, 11.0],
+                        [4.0, 9.0, 10.0, 14.0],
+                        [8.0, 8.0, 13.0, 14.0],
+                    ]
+                ]
+            ]
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+    def test_random_rotation_forward_exact_nearest(self) -> None:
+        rotation_module = transforms.RandomRotation([45.0], mode="nearest")
+        self.assertEqual(rotation_module.mode, "nearest")
+        self.assertEqual(rotation_module.padding_mode, "zeros")
+
+        test_input = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        test_output = rotation_module(test_input)
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 2.0, 7.0, 0.0],
+                        [1.0, 6.0, 10.0, 11.0],
+                        [4.0, 9.0, 10.0, 14.0],
+                        [0.0, 8.0, 13.0, 0.0],
+                    ]
+                ]
+            ]
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.0)
+
+    def test_random_rotation_forward(self) -> None:
+        degrees = list(range(-25, 25))
+        rotation_module = transforms.RandomRotation(degrees=degrees)
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = rotation_module(test_tensor)
+        self.assertEqual(list(output_tensor.shape), list(test_tensor.shape))
+
+    def test_random_rotation_forward_distributions(self) -> None:
+        degrees = torch.distributions.Uniform(-25, 25)
+        rotation_module = transforms.RandomRotation(degrees=degrees)
+        test_tensor = torch.ones(1, 3, 10, 10)
+        output_tensor = rotation_module(test_tensor)
+        self.assertEqual(list(output_tensor.shape), list(test_tensor.shape))
+
+    def test_random_rotation_forward_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping RandomRotation forward CUDA test due to not supporting"
+                + " CUDA."
+            )
+        rotate_transform = transforms.RandomRotation(list(range(-25, 25)))
+        x = torch.ones(1, 3, 224, 224).cuda()
+        output = rotate_transform(x)
+
+        self.assertTrue(output.is_cuda)
+        self.assertEqual(output.shape, x.shape)
+
+    def test_random_rotation_matrix_torch_math_module(self) -> None:
+        theta = 25.1
+        rotation_module = transforms.RandomRotation([theta])
+        rot_matrix = rotation_module._get_rot_mat(
+            theta, device=torch.device("cpu"), dtype=torch.float32
+        )
+
+        theta_expected = torch.tensor(theta) * 3.141592653589793 / 180.0
+        expected_matrix = torch.tensor(
+            [
+                [torch.cos(theta_expected), -torch.sin(theta_expected), 0.0],
+                [torch.sin(theta_expected), torch.cos(theta_expected), 0.0],
+            ],
+        )
+
+        assertTensorAlmostEqual(self, rot_matrix, expected_matrix, 0.0)
+
+    def test_random_rotation_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RandomRotation JIT test due to insufficient Torch version."
+            )
+        rotation_module = transforms.RandomRotation([25.0])
+        jit_rotation_module = torch.jit.script(rotation_module)
+        test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
+
+        test_output = jit_rotation_module(test_input)
+        expected_output = (
+            torch.tensor(
+                [
+                    [0.1143, 0.0000, 0.0000, 0.0000],
+                    [0.5258, 0.6198, 0.2157, 0.0000],
+                    [0.0000, 0.2157, 0.6198, 0.5258],
+                    [0.0000, 0.0000, 0.0000, 0.1143],
+                ]
+            )
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        assertTensorAlmostEqual(self, test_output, expected_output, 0.005)
 
 
 class TestRandomSpatialJitter(BaseTest):
+    def test_random_spatial_jitter_init(self) -> None:
+        translate = 3
+        spatialjitter = transforms.RandomSpatialJitter(translate)
+
+        self.assertEqual(spatialjitter.pad_range, translate * 2)
+        self.assertIsInstance(spatialjitter.pad, torch.nn.ReflectionPad2d)
+
     def test_random_spatial_jitter_hw(self) -> None:
         translate_vals = [4, 4]
         t_val = 3
@@ -124,9 +685,39 @@ class TestRandomSpatialJitter(BaseTest):
         assertArraysAlmostEqual(jittered_tensor[1].numpy(), jittered_array, 0)
         assertArraysAlmostEqual(jittered_tensor[2].numpy(), jittered_array, 0)
 
+    def test_random_spatial_jitter_forward(self) -> None:
+        t_val = 3
+
+        spatialjitter = transforms.RandomSpatialJitter(t_val)
+        test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
+        jittered_tensor = spatialjitter(test_input)
+        self.assertEqual(list(jittered_tensor.shape), list(test_input.shape))
+
+    def test_random_spatial_jitter_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RandomSpatialJitter JIT module test due to insufficient"
+                + " Torch version."
+            )
+        t_val = 3
+
+        spatialjitter = transforms.RandomSpatialJitter(t_val)
+        jit_spatialjitter = torch.jit.script(spatialjitter)
+        test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
+        jittered_tensor = jit_spatialjitter(test_input)
+        self.assertEqual(list(jittered_tensor.shape), list(test_input.shape))
+
 
 class TestCenterCrop(BaseTest):
-    def test_center_crop_one_number(self) -> None:
+    def test_center_crop_init(self) -> None:
+        crop_module = transforms.CenterCrop(3)
+        self.assertEqual(crop_module.size, [3, 3])
+        self.assertFalse(crop_module.pixels_from_edges)
+        self.assertFalse(crop_module.offset_left)
+        self.assertEqual(crop_module.padding_mode, "constant")
+        self.assertEqual(crop_module.padding_value, 0.0)
+
+    def test_center_crop_forward_one_number(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
             F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
@@ -147,7 +738,60 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_two_numbers(self) -> None:
+    def test_center_crop_forward_one_number_dim_3(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1).repeat(
+            3, 1, 1
+        )
+        crop_vals = 3
+
+        crop_tensor = transforms.CenterCrop(crop_vals, True)
+        cropped_tensor = crop_tensor(test_tensor)
+
+        crop_mod_np = numpy_transforms.CenterCrop(crop_vals, True)
+        cropped_array = crop_mod_np.forward(test_tensor.numpy())
+
+        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        expected_tensor = torch.stack(
+            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
+        )
+        self.assertEqual(cropped_tensor.shape, expected_tensor.shape)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_forward_one_number_list(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        crop_vals = [3]
+
+        crop_tensor = transforms.CenterCrop(crop_vals, True)
+        cropped_tensor = crop_tensor(test_tensor)
+
+        crop_mod_np = numpy_transforms.CenterCrop(crop_vals, True)
+        cropped_array = crop_mod_np.forward(test_tensor.numpy())
+
+        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        expected_tensor = torch.stack(
+            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_list_len_3_value_error(self) -> None:
+        crop_vals = [3, 3, 3]
+
+        with self.assertRaises(ValueError):
+            transforms.CenterCrop(crop_vals, True)
+
+    def test_center_crop_str_value_error(self) -> None:
+        crop_vals = "error"
+
+        with self.assertRaises(ValueError):
+            transforms.CenterCrop(crop_vals, True)
+
+    def test_center_crop_forward_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
             F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
@@ -168,7 +812,7 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_one_number_exact(self) -> None:
+    def test_center_crop_forward_one_number_exact(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
             F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
@@ -201,7 +845,7 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_two_numbers_exact(self) -> None:
+    def test_center_crop_forward_two_numbers_exact(self) -> None:
         pad = (1, 1, 1, 1)
         test_tensor = (
             F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
@@ -224,7 +868,7 @@ class TestCenterCrop(BaseTest):
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
-    def test_center_crop_offset_left_uneven_sides(self) -> None:
+    def test_center_crop_forward_offset_left_uneven_sides(self) -> None:
         crop_mod = transforms.CenterCrop(
             [5, 5], pixels_from_edges=False, offset_left=True
         )
@@ -233,7 +877,7 @@ class TestCenterCrop(BaseTest):
         cropped_tensor = crop_mod(px)
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
-    def test_center_crop_offset_left_even_sides(self) -> None:
+    def test_center_crop_forward_offset_left_even_sides(self) -> None:
         crop_mod = transforms.CenterCrop(
             [5, 5], pixels_from_edges=False, offset_left=True
         )
@@ -241,6 +885,106 @@ class TestCenterCrop(BaseTest):
         px = F.pad(x, (5, 5, 5, 5), value=float("-inf"))
         cropped_tensor = crop_mod(px)
         assertTensorAlmostEqual(self, x, cropped_tensor)
+
+    def test_center_crop_forward_padding(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
+        cropped_tensor = center_crop_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_forward_padding_prime_num_pad(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
+
+        cropped_tensor = center_crop_module(test_tensor)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [2, 1, 2, 1])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_forward_padding_prime_num_pad_offset_left(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=True)
+
+        cropped_tensor = center_crop_module(test_tensor)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [1, 2, 1, 2])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_forward_one_number_exact_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping CenterCrop JIT module test due to insufficient"
+                + " Torch version."
+            )
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+
+        crop_vals = 5
+
+        crop_tensor = transforms.CenterCrop(crop_vals, False)
+        jit_crop_tensor = torch.jit.script(crop_tensor)
+        cropped_tensor = jit_crop_tensor(test_tensor)
+        expected_tensor = torch.stack(
+            [
+                torch.tensor(
+                    [
+                        [1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                )
+            ]
+            * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_forward_padding_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping CenterCrop padding JIT module test due to insufficient"
+                + " Torch version."
+            )
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
+        jit_center_crop = torch.jit.script(center_crop_module)
+        cropped_tensor = jit_center_crop(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
 
 class TestCenterCropFunction(BaseTest):
@@ -263,6 +1007,69 @@ class TestCenterCropFunction(BaseTest):
             [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_one_number_dim_3(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1).repeat(
+            3, 1, 1
+        )
+        crop_vals = 3
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
+        cropped_array = numpy_transforms.center_crop(
+            test_tensor.numpy(), crop_vals, True
+        )
+
+        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        expected_tensor = torch.stack(
+            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
+        )
+        self.assertEqual(cropped_tensor.shape, expected_tensor.shape)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_one_number_list(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        crop_vals = [3]
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals, True)
+        cropped_array = numpy_transforms.center_crop(
+            test_tensor.numpy(), crop_vals, True
+        )
+
+        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        expected_tensor = torch.stack(
+            [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_list_len_3_value_error(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        crop_vals = [3, 3, 3]
+
+        with self.assertRaises(ValueError):
+            transforms.center_crop(test_tensor, crop_vals, True)
+
+    def test_center_crop_str_value_error(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+        crop_vals = "error"
+
+        with self.assertRaises(ValueError):
+            transforms.center_crop(test_tensor, crop_vals, True)
 
     def test_center_crop_two_numbers(self) -> None:
         pad = (1, 1, 1, 1)
@@ -341,7 +1148,7 @@ class TestCenterCropFunction(BaseTest):
         x = torch.ones(1, 3, 5, 5)
         px = F.pad(x, (5, 4, 5, 4), value=float("-inf"))
         cropped_tensor = transforms.center_crop(
-            px, crop_vals=[5, 5], pixels_from_edges=False, offset_left=True
+            px, size=[5, 5], pixels_from_edges=False, offset_left=True
         )
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
@@ -349,12 +1156,111 @@ class TestCenterCropFunction(BaseTest):
         x = torch.ones(1, 3, 5, 5)
         px = F.pad(x, (5, 5, 5, 5), value=float("-inf"))
         cropped_tensor = transforms.center_crop(
-            px, crop_vals=[5, 5], pixels_from_edges=False, offset_left=True
+            px, size=[5, 5], pixels_from_edges=False, offset_left=True
         )
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
+    def test_center_crop_padding(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_padding_prime_num_pad(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [2, 1, 2, 1])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_padding_prime_num_pad_offset_left(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        cropped_tensor = transforms.center_crop(
+            test_tensor, crop_vals, offset_left=True
+        )
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [1, 2, 1, 2])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_one_number_exact_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping center_crop JIT module test due to insufficient"
+                + " Torch version."
+            )
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+
+        crop_vals = 5
+
+        jit_center_crop = transforms.center_crop
+        cropped_tensor = jit_center_crop(test_tensor, crop_vals, False)
+        expected_tensor = torch.stack(
+            [
+                torch.tensor(
+                    [
+                        [1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                )
+            ]
+            * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_padding_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping center_crop padding JIT module test due to insufficient"
+                + " Torch version."
+            )
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        jit_center_crop = torch.jit.script(transforms.center_crop)
+        cropped_tensor = jit_center_crop(test_tensor, crop_vals)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
 
 class TestBlendAlpha(BaseTest):
+    def test_blend_alpha_init(self) -> None:
+        blend_alpha = transforms.BlendAlpha(background=None)
+        self.assertIsNone(blend_alpha.background)
+
     def test_blend_alpha(self) -> None:
         rgb_tensor = torch.ones(3, 3, 3)
         alpha_tensor = ((torch.eye(3, 3) + torch.eye(3, 3).flip(1)) / 2).repeat(1, 1, 1)
@@ -374,6 +1280,31 @@ class TestBlendAlpha(BaseTest):
 
         assertArraysAlmostEqual(blended_tensor.numpy(), blended_array, 0)
 
+    def test_blend_alpha_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping BlendAlpha JIT module test due to insufficient"
+                + " Torch version."
+            )
+        rgb_tensor = torch.ones(3, 3, 3)
+        alpha_tensor = ((torch.eye(3, 3) + torch.eye(3, 3).flip(1)) / 2).repeat(1, 1, 1)
+        test_tensor = torch.cat([rgb_tensor, alpha_tensor]).unsqueeze(0)
+
+        background_tensor = torch.ones_like(rgb_tensor) * 5
+        blend_alpha = transforms.BlendAlpha(background=background_tensor)
+        jit_blend_alpha = torch.jit.script(blend_alpha)
+        blended_tensor = jit_blend_alpha(test_tensor)
+
+        rgb_array = np.ones((3, 3, 3))
+        alpha_array = (np.add(np.eye(3, 3), np.flip(np.eye(3, 3), 1)) / 2)[None, :]
+        test_array = np.concatenate([rgb_array, alpha_array])[None, :]
+
+        background_array = np.ones(rgb_array.shape) * 5
+        blend_alpha_np = numpy_transforms.BlendAlpha(background=background_array)
+        blended_array = blend_alpha_np.blend_alpha(test_array)
+
+        assertArraysAlmostEqual(blended_tensor.numpy(), blended_array, 0)
+
 
 class TestIgnoreAlpha(BaseTest):
     def test_ignore_alpha(self) -> None:
@@ -382,23 +1313,68 @@ class TestIgnoreAlpha(BaseTest):
         rgb_tensor = ignore_alpha(test_input)
         assert rgb_tensor.size(1) == 3
 
+    def test_ignore_alpha_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping IgnoreAlpha JIT module test due to insufficient"
+                + " Torch version."
+            )
+        ignore_alpha = transforms.IgnoreAlpha()
+        jit_ignore_alpha = torch.jit.script(ignore_alpha)
+        test_input = torch.ones(1, 4, 3, 3)
+        rgb_tensor = jit_ignore_alpha(test_input)
+        assert rgb_tensor.size(1) == 3
+
 
 class TestToRGB(BaseTest):
+    def test_to_rgb_init(self) -> None:
+        to_rgb = transforms.ToRGB()
+        self.assertEqual(list(to_rgb.transform.shape), [3, 3])
+        transform = torch.tensor(
+            [
+                [0.5628, 0.1948, 0.0433],
+                [0.5845, 0.0000, -0.1082],
+                [0.5845, -0.1948, 0.0649],
+            ]
+        )
+        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.001)
+
     def test_to_rgb_i1i2i3(self) -> None:
         to_rgb = transforms.ToRGB(transform="i1i2i3")
         to_rgb_np = numpy_transforms.ToRGB(transform="i1i2i3")
         assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
+        transform = torch.tensor(
+            [
+                [0.3333, 0.3333, 0.3333],
+                [0.5000, 0.0000, -0.5000],
+                [-0.2500, 0.5000, -0.2500],
+            ]
+        )
+        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.001)
 
     def test_to_rgb_klt(self) -> None:
         to_rgb = transforms.ToRGB(transform="klt")
         to_rgb_np = numpy_transforms.ToRGB(transform="klt")
         assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
+        transform = torch.tensor(
+            [
+                [0.5628, 0.1948, 0.0433],
+                [0.5845, 0.0000, -0.1082],
+                [0.5845, -0.1948, 0.0649],
+            ]
+        )
+        assertTensorAlmostEqual(self, to_rgb.transform, transform, 0.001)
 
     def test_to_rgb_custom(self) -> None:
         matrix = torch.eye(3, 3)
         to_rgb = transforms.ToRGB(transform=matrix)
         to_rgb_np = numpy_transforms.ToRGB(transform=matrix.numpy())
         assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
+        assertTensorAlmostEqual(self, to_rgb.transform, matrix, 0.0)
+
+    def test_to_rgb_init_value_error(self) -> None:
+        with self.assertRaises(ValueError):
+            transforms.ToRGB(transform="error")
 
     def test_to_rgb_klt_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -435,6 +1411,29 @@ class TestToRGB(BaseTest):
         b = torch.ones(4, 4) * 0.4546
         a = torch.ones(4, 4)
         expected_rgb_tensor = torch.stack([r, g, b, a]).unsqueeze(0)
+
+        assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+
+        inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
+        assertTensorAlmostEqual(
+            self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
+        )
+
+    def test_to_rgb_alpha_klt_forward_dim_3(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping ToRGB with Alpha forward dim 3 due to"
+                + " insufficient Torch version."
+            )
+        to_rgb = transforms.ToRGB(transform="klt")
+        test_tensor = torch.ones(4, 4, 4).refine_names("C", "H", "W")
+        rgb_tensor = to_rgb(test_tensor)
+
+        r = torch.ones(4, 4) * 0.8009
+        g = torch.ones(4, 4) * 0.4762
+        b = torch.ones(4, 4) * 0.4546
+        a = torch.ones(4, 4)
+        expected_rgb_tensor = torch.stack([r, g, b, a])
 
         assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
 
@@ -507,8 +1506,103 @@ class TestToRGB(BaseTest):
             self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
         )
 
+    def test_to_rgb_klt_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping ToRGB forward JIT module test due to insufficient"
+                + " Torch version."
+            )
+        to_rgb = transforms.ToRGB(transform="klt")
+        jit_to_rgb = torch.jit.script(to_rgb)
+        test_tensor = torch.ones(3, 4, 4).unsqueeze(0)
+        rgb_tensor = jit_to_rgb(test_tensor)
+
+        r = torch.ones(4, 4) * 0.8009
+        g = torch.ones(4, 4) * 0.4762
+        b = torch.ones(4, 4) * 0.4546
+        expected_rgb_tensor = torch.stack([r, g, b]).unsqueeze(0)
+
+        assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+
+        inverse_tensor = jit_to_rgb(rgb_tensor.clone(), inverse=True)
+        assertTensorAlmostEqual(
+            self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
+        )
+
 
 class TestGaussianSmoothing(BaseTest):
+    def test_gaussian_smoothing_init_1d(self) -> None:
+        channels = 6
+        kernel_size = 3
+        sigma = 2.0
+        dim = 1
+        smoothening_module = transforms.GaussianSmoothing(
+            channels, kernel_size, sigma, dim
+        )
+        self.assertEqual(smoothening_module.groups, channels)
+        weight = torch.tensor([[0.3192, 0.3617, 0.3192]]).repeat(6, 1, 1)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0.001)
+
+    def test_gaussian_smoothing_init_2d(self) -> None:
+        channels = 3
+        kernel_size = 3
+        sigma = 2.0
+        dim = 2
+        smoothening_module = transforms.GaussianSmoothing(
+            channels, kernel_size, sigma, dim
+        )
+        self.assertEqual(smoothening_module.groups, channels)
+        weight = torch.tensor(
+            [
+                [
+                    [0.1019, 0.1154, 0.1019],
+                    [0.1154, 0.1308, 0.1154],
+                    [0.1019, 0.1154, 0.1019],
+                ]
+            ]
+        ).repeat(3, 1, 1, 1)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0.001)
+
+    def test_gaussian_smoothing_init_3d(self) -> None:
+        channels = 4
+        kernel_size = 3
+        sigma = 1.021
+        dim = 3
+        smoothening_module = transforms.GaussianSmoothing(
+            channels, kernel_size, sigma, dim
+        )
+        self.assertEqual(smoothening_module.groups, channels)
+        weight = torch.tensor(
+            [
+                [
+                    [
+                        [0.0212, 0.0342, 0.0212],
+                        [0.0342, 0.0552, 0.0342],
+                        [0.0212, 0.0342, 0.0212],
+                    ],
+                    [
+                        [0.0342, 0.0552, 0.0342],
+                        [0.0552, 0.0892, 0.0552],
+                        [0.0342, 0.0552, 0.0342],
+                    ],
+                    [
+                        [0.0212, 0.0342, 0.0212],
+                        [0.0342, 0.0552, 0.0342],
+                        [0.0212, 0.0342, 0.0212],
+                    ],
+                ]
+            ]
+        ).repeat(4, 1, 1, 1, 1)
+        assertTensorAlmostEqual(self, smoothening_module.weight, weight, 0.01)
+
+    def test_gaussian_smoothing_init_dim_4_runtime_error(self) -> None:
+        channels = 3
+        kernel_size = 3
+        sigma = 2.0
+        dim = 4
+        with self.assertRaises(RuntimeError):
+            transforms.GaussianSmoothing(channels, kernel_size, sigma, dim)
+
     def test_gaussian_smoothing_1d(self) -> None:
         channels = 6
         kernel_size = 3
@@ -562,12 +1656,51 @@ class TestGaussianSmoothing(BaseTest):
         self.assertLessEqual(t_max, 4.8162e-05)
         self.assertGreaterEqual(t_min, 3.3377e-06)
 
+    def test_gaussian_smoothing_2d_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping GaussianSmoothing 2D JIT module test due to insufficient"
+                + " Torch version."
+            )
+        channels = 3
+        kernel_size = 3
+        sigma = 2.0
+        dim = 2
+        smoothening_module = transforms.GaussianSmoothing(
+            channels, kernel_size, sigma, dim
+        )
+        jit_smoothening_module = torch.jit.script(smoothening_module)
+
+        test_tensor = torch.tensor([1.0, 5.0]).repeat(3, 6, 3).unsqueeze(0)
+
+        diff_tensor = jit_smoothening_module(test_tensor) - torch.tensor(
+            [2.4467, 3.5533]
+        ).repeat(3, 4, 2).unsqueeze(0)
+        self.assertLessEqual(diff_tensor.max().item(), 4.5539e-05)
+        self.assertGreaterEqual(diff_tensor.min().item(), -4.5539e-05)
+
 
 class TestScaleInputRange(BaseTest):
+    def test_scale_input_range_init(self) -> None:
+        scale_input = transforms.ScaleInputRange(255)
+        self.assertEqual(scale_input.multiplier, 255)
+
     def test_scale_input_range(self) -> None:
         x = torch.ones(1, 3, 4, 4)
         scale_input = transforms.ScaleInputRange(255)
         output_tensor = scale_input(x)
+        self.assertEqual(output_tensor.mean(), 255.0)
+
+    def test_scale_input_range_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping ScaleInputRange JIT module test due to insufficient"
+                + " Torch version."
+            )
+        x = torch.ones(1, 3, 4, 4)
+        scale_input = transforms.ScaleInputRange(255)
+        jit_scale_input = torch.jit.script(scale_input)
+        output_tensor = jit_scale_input(x)
         self.assertEqual(output_tensor.mean(), 255.0)
 
 
@@ -576,6 +1709,19 @@ class TestRGBToBGR(BaseTest):
         x = torch.randn(1, 3, 224, 224)
         rgb_to_bgr = transforms.RGBToBGR()
         output_tensor = rgb_to_bgr(x)
+        expected_x = x[:, [2, 1, 0]]
+        assertTensorAlmostEqual(self, output_tensor, expected_x)
+
+    def test_rgb_to_bgr_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RGBToBGR JIT module test due to insufficient"
+                + " Torch version."
+            )
+        x = torch.randn(1, 3, 224, 224)
+        rgb_to_bgr = transforms.RGBToBGR()
+        jit_rgb_to_bgr = torch.jit.script(rgb_to_bgr)
+        output_tensor = jit_rgb_to_bgr(x)
         expected_x = x[:, [2, 1, 0]]
         assertTensorAlmostEqual(self, output_tensor, expected_x)
 
@@ -628,6 +1774,10 @@ class TestSymmetricPadding(BaseTest):
 
 
 class TestNChannelsToRGB(BaseTest):
+    def test_nchannels_to_rgb_init(self) -> None:
+        nchannels_to_rgb = transforms.NChannelsToRGB()
+        self.assertFalse(nchannels_to_rgb.warp)
+
     def test_nchannels_to_rgb_collapse(self) -> None:
         test_input = torch.randn(1, 6, 224, 224)
         nchannels_to_rgb = transforms.NChannelsToRGB()
@@ -640,8 +1790,29 @@ class TestNChannelsToRGB(BaseTest):
         test_output = nchannels_to_rgb(test_input)
         self.assertEqual(list(test_output.size()), [1, 3, 224, 224])
 
+    def test_nchannels_to_rgb_collapse_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NChannelsToRGB collapse JIT module test due to insufficient"
+                + " Torch version."
+            )
+        test_input = torch.randn(1, 6, 224, 224)
+        nchannels_to_rgb = transforms.NChannelsToRGB()
+        jit_nchannels_to_rgb = torch.jit.script(nchannels_to_rgb)
+        test_output = jit_nchannels_to_rgb(test_input)
+        self.assertEqual(list(test_output.size()), [1, 3, 224, 224])
+
 
 class TestRandomCrop(BaseTest):
+    def test_random_crop_center_crop(self) -> None:
+        crop_size = [160, 160]
+        crop_transform = transforms.RandomCrop(crop_size=crop_size)
+        x = torch.ones(1, 4, 224, 224)
+
+        x_out = crop_transform._center_crop(x)
+
+        self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
+
     def test_random_crop(self) -> None:
         crop_size = [160, 160]
         crop_transform = transforms.RandomCrop(crop_size=crop_size)
@@ -650,3 +1821,147 @@ class TestRandomCrop(BaseTest):
         x_out = crop_transform(x)
 
         self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
+
+    def test_random_crop_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RandomCrop JIT module test due to insufficient"
+                + " Torch version."
+            )
+        crop_size = [160, 160]
+        crop_transform = transforms.RandomCrop(crop_size=crop_size)
+        jit_crop_transform = torch.jit.script(crop_transform)
+        x = torch.ones(1, 4, 224, 224)
+
+        x_out = jit_crop_transform(x)
+
+        self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
+
+
+class TestTransformationRobustness(BaseTest):
+    def test_transform_robustness_init(self) -> None:
+        transform_robustness = transforms.TransformationRobustness()
+        self.assertIsInstance(
+            transform_robustness.padding_transform, torch.nn.ConstantPad2d
+        )
+        self.assertIsInstance(
+            transform_robustness.jitter_transforms, torch.nn.Sequential
+        )
+        for module in transform_robustness.jitter_transforms:
+            self.assertIsInstance(module, transforms.RandomSpatialJitter)
+        self.assertIsInstance(transform_robustness.random_scale, transforms.RandomScale)
+        # self.assertIsInstance(
+        #    transform_robustness.random_rotation, transforms.RandomRotation
+        # )
+        self.assertIsInstance(
+            transform_robustness.final_jitter, transforms.RandomSpatialJitter
+        )
+        self.assertFalse(transform_robustness.crop_or_pad_output)
+
+    def test_transform_robustness_init_transform_values(self) -> None:
+        transform_robustness = transforms.TransformationRobustness()
+        self.assertEqual(transform_robustness.padding_transform.padding, (2, 2, 2, 2))
+        self.assertEqual(transform_robustness.padding_transform.value, 0.5)
+
+        self.assertEqual(len(transform_robustness.jitter_transforms), 10)
+        for module in transform_robustness.jitter_transforms:
+            self.assertEqual(module.pad_range, 2 * 4)
+
+        expected_scale = [0.995 ** n for n in range(-5, 80)] + [
+            0.998 ** n for n in 2 * list(range(20, 40))
+        ]
+        self.assertEqual(transform_robustness.random_scale.scale, expected_scale)
+        # expected_degrees = (
+        #    list(range(-20, 20)) + list(range(-10, 10)) + list(range(-5, 5)) + 5 * [0]
+        # )
+        # expected_degrees = [float(d) for d in expected_degrees]
+        # self.assertEqual(
+        #    transform_robustness.random_rotation.degrees, test_expected_degrees
+        # )
+
+        self.assertEqual(transform_robustness.final_jitter.pad_range, 2 * 2)
+
+    def test_transform_robustness_init_single_translate(self) -> None:
+        transform_robustness = transforms.TransformationRobustness(translate=4)
+        self.assertIsInstance(
+            transform_robustness.jitter_transforms, transforms.RandomSpatialJitter
+        )
+
+    def test_transform_robustness_forward(self) -> None:
+        transform_robustness = transforms.TransformationRobustness()
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertTrue(torch.is_tensor(test_output))
+
+    def test_transform_robustness_forward_padding(self) -> None:
+        pad_module = torch.nn.ConstantPad2d(2, value=0.5)
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=pad_module
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertTrue(torch.is_tensor(test_output))
+
+    def test_transform_robustness_forward_no_padding(self) -> None:
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=None
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertTrue(torch.is_tensor(test_output))
+
+    def test_transform_robustness_forward_crop_output(self) -> None:
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=None, crop_or_pad_output=True
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertEqual(test_output.shape, test_input.shape)
+
+    def test_transform_robustness_forward_padding_crop_output(self) -> None:
+        pad_module = torch.nn.ConstantPad2d(2, value=0.5)
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=pad_module, crop_or_pad_output=True
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertEqual(test_output.shape, test_input.shape)
+
+    def test_transform_robustness_forward_all_disabled(self) -> None:
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=None,
+            translate=None,
+            scale=None,
+            degrees=None,
+            final_translate=None,
+            crop_or_pad_output=False,
+        )
+        test_input = torch.randn(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        assertTensorAlmostEqual(self, test_output, test_input, 0)
+
+    def test_transform_robustness_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping TransformationRobustness JIT module test due"
+                + " to insufficient Torch version."
+            )
+        transform_robustness = transforms.TransformationRobustness()
+        jit_transform_robustness = torch.jit.script(transform_robustness)
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = jit_transform_robustness(test_input)
+        self.assertTrue(torch.is_tensor(test_output))
+
+    def test_transform_robustness_forward_padding_crop_output_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping TransformationRobustness with crop or pad output"
+                + " JIT module test due to insufficient Torch version."
+            )
+        pad_module = torch.nn.ConstantPad2d(2, value=0.5)
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=pad_module, crop_or_pad_output=True
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertEqual(test_output.shape, test_input.shape)

--- a/tests/optim/utils/image/common.py
+++ b/tests/optim/utils/image/common.py
@@ -5,7 +5,6 @@ import torch
 
 import captum.optim._utils.image.common as common
 from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
-from tests.optim.helpers import numpy_common
 
 
 class TestGetNeuronPos(unittest.TestCase):
@@ -60,13 +59,38 @@ class TestWeightsToHeatmap2D(BaseTest):
         x[4:5, 0:4] = x[4:5, 0:4] * -0.8
 
         x_out = common.weights_to_heatmap_2d(x)
-        x_out_np = numpy_common.weights_to_heatmap_2d(x.numpy())
-        assertTensorAlmostEqual(self, x_out, torch.as_tensor(x_out_np).float())
+
+        x_out_expected = torch.tensor(
+            [
+                [
+                    [0.9639, 0.9639, 0.9639, 0.9639],
+                    [0.8580, 0.8580, 0.8580, 0.8580],
+                    [0.9686, 0.9686, 0.9686, 0.9686],
+                    [0.8102, 0.8102, 0.8102, 0.8102],
+                    [0.2408, 0.2408, 0.2408, 0.2408],
+                ],
+                [
+                    [0.8400, 0.8400, 0.8400, 0.8400],
+                    [0.2588, 0.2588, 0.2588, 0.2588],
+                    [0.9686, 0.9686, 0.9686, 0.9686],
+                    [0.8902, 0.8902, 0.8902, 0.8902],
+                    [0.5749, 0.5749, 0.5749, 0.5749],
+                ],
+                [
+                    [0.7851, 0.7851, 0.7851, 0.7851],
+                    [0.2792, 0.2792, 0.2792, 0.2792],
+                    [0.9686, 0.9686, 0.9686, 0.9686],
+                    [0.9294, 0.9294, 0.9294, 0.9294],
+                    [0.7624, 0.7624, 0.7624, 0.7624],
+                ],
+            ]
+        )
+        assertTensorAlmostEqual(self, x_out, x_out_expected, delta=0.01)
 
     def test_weights_to_heatmap_2d_cuda(self) -> None:
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
-                "Skipping ImageTensor CUDA test due to not supporting CUDA."
+                "Skipping weights_to_heatmap_2d CUDA test due to not supporting CUDA."
             )
         x = torch.ones(5, 4)
         x[0:1, 0:4] = x[0:1, 0:4] * 0.2
@@ -76,6 +100,31 @@ class TestWeightsToHeatmap2D(BaseTest):
         x[4:5, 0:4] = x[4:5, 0:4] * -0.8
 
         x_out = common.weights_to_heatmap_2d(x.cuda())
-        x_out_np = numpy_common.weights_to_heatmap_2d(x.numpy())
-        assertTensorAlmostEqual(self, x_out, torch.as_tensor(x_out_np).float())
+
+        x_out_expected = torch.tensor(
+            [
+                [
+                    [0.9639, 0.9639, 0.9639, 0.9639],
+                    [0.8580, 0.8580, 0.8580, 0.8580],
+                    [0.9686, 0.9686, 0.9686, 0.9686],
+                    [0.8102, 0.8102, 0.8102, 0.8102],
+                    [0.2408, 0.2408, 0.2408, 0.2408],
+                ],
+                [
+                    [0.8400, 0.8400, 0.8400, 0.8400],
+                    [0.2588, 0.2588, 0.2588, 0.2588],
+                    [0.9686, 0.9686, 0.9686, 0.9686],
+                    [0.8902, 0.8902, 0.8902, 0.8902],
+                    [0.5749, 0.5749, 0.5749, 0.5749],
+                ],
+                [
+                    [0.7851, 0.7851, 0.7851, 0.7851],
+                    [0.2792, 0.2792, 0.2792, 0.2792],
+                    [0.9686, 0.9686, 0.9686, 0.9686],
+                    [0.9294, 0.9294, 0.9294, 0.9294],
+                    [0.7624, 0.7624, 0.7624, 0.7624],
+                ],
+            ]
+        )
+        assertTensorAlmostEqual(self, x_out, x_out_expected, delta=0.01)
         self.assertTrue(x_out.is_cuda)

--- a/tests/optim/utils/image/test_atlas.py
+++ b/tests/optim/utils/image/test_atlas.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+import unittest
+
+import torch
+
+import captum.optim._utils.image.atlas as atlas
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+
+
+class TestNormalizeGrid(BaseTest):
+    def test_normalize_grid(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping normalize grid test due to insufficient Torch version."
+            )
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float()
+
+        xy_grid = atlas.normalize_grid(xy_grid)
+
+        xy_grid_expected = torch.tensor(
+            [
+                [0.0000, 0.0000],
+                [0.1250, 0.1250],
+                [0.2500, 0.2500],
+                [0.3750, 0.3750],
+                [0.5000, 0.5000],
+                [0.6250, 0.6250],
+                [0.7500, 0.7500],
+                [0.8750, 0.8750],
+                [1.0000, 1.0000],
+            ]
+        )
+
+        assertTensorAlmostEqual(self, xy_grid, xy_grid_expected)
+
+    def test_normalize_grid_max_percentile(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping normalize grid test due to insufficient Torch version."
+            )
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float()
+
+        xy_grid = atlas.normalize_grid(xy_grid, max_percentile=0.85)
+
+        xy_grid_expected = torch.tensor(
+            [
+                [0.0000, 0.0000],
+                [0.1326, 0.1326],
+                [0.2653, 0.2653],
+                [0.3979, 0.3979],
+                [0.5306, 0.5306],
+                [0.6632, 0.6632],
+                [0.7958, 0.7958],
+                [0.9285, 0.9285],
+                [1.0000, 1.0000],
+            ]
+        )
+
+        assertTensorAlmostEqual(self, xy_grid, xy_grid_expected, 0.001)
+
+    def test_normalize_grid_min_percentile(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping normalize grid test due to insufficient Torch version."
+            )
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float()
+
+        xy_grid = atlas.normalize_grid(xy_grid, min_percentile=0.5)
+
+        xy_grid_expected = torch.tensor(
+            [
+                [0.0000, 0.0000],
+                [0.0000, 0.0000],
+                [0.0000, 0.0000],
+                [0.0000, 0.0000],
+                [0.0893, 0.0893],
+                [0.3169, 0.3169],
+                [0.5446, 0.5446],
+                [0.7723, 0.7723],
+                [1.0000, 1.0000],
+            ]
+        )
+
+        assertTensorAlmostEqual(self, xy_grid, xy_grid_expected, 0.001)
+
+    def test_normalize_grid_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping normalize grid CUDA test due to not supporting CUDA."
+            )
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping normalize grid CUDA test due to insufficient Torch version."
+            )
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float().cuda()
+
+        xy_grid = atlas.normalize_grid(xy_grid)
+
+        xy_grid_expected = torch.tensor(
+            [
+                [0.0000, 0.0000],
+                [0.1250, 0.1250],
+                [0.2500, 0.2500],
+                [0.3750, 0.3750],
+                [0.5000, 0.5000],
+                [0.6250, 0.6250],
+                [0.7500, 0.7500],
+                [0.8750, 0.8750],
+                [1.0000, 1.0000],
+            ]
+        )
+
+        self.assertTrue(xy_grid.is_cuda)
+        assertTensorAlmostEqual(self, xy_grid.cpu(), xy_grid_expected)
+
+
+class TestCalcGridIndices(BaseTest):
+    def test_calc_grid_indices(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping calc grid indices test due to insufficient Torch version."
+            )
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float()
+        xy_grid = atlas.normalize_grid(xy_grid)
+        indices = atlas.calc_grid_indices(xy_grid, grid_size=(2, 2))
+
+        expected_indices = [
+            [torch.tensor([0, 1, 2, 3, 4]), torch.tensor([4])],
+            [torch.tensor([4]), torch.tensor([4, 5, 6, 7, 8])],
+        ]
+
+        for list1, list2 in zip(indices, expected_indices):
+            for t1, t2 in zip(list1, list2):
+                assertTensorAlmostEqual(self, t1, t2)
+
+    def test_calc_grid_indices_extent(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping calc grid indices extent test due to insufficient Torch"
+                + " version."
+            )
+        xy_grid = torch.arange(0, 2 * 5 * 5).view(5 * 5, 2).float()
+        xy_grid = atlas.normalize_grid(xy_grid)
+        indices = atlas.calc_grid_indices(
+            xy_grid, grid_size=(1, 1), x_extent=(1.0, 2.0), y_extent=(1.0, 2.0)
+        )
+        assertTensorAlmostEqual(self, indices[0][0], torch.tensor([24]), 0)
+
+    def test_calc_grid_indices_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping calc grid indices CUDA test due to not supporting CUDA."
+            )
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping calc grid indices CUDA test due to insufficient Torch"
+                + " version."
+            )
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float().cuda()
+        xy_grid = atlas.normalize_grid(xy_grid)
+        indices = atlas.calc_grid_indices(xy_grid, grid_size=(2, 2))
+
+        expected_indices = [
+            [torch.tensor([0, 1, 2, 3, 4]), torch.tensor([4])],
+            [torch.tensor([4]), torch.tensor([4, 5, 6, 7, 8])],
+        ]
+
+        for list1, list2 in zip(indices, expected_indices):
+            for t1, t2 in zip(list1, list2):
+                self.assertTrue(t1.is_cuda)
+                assertTensorAlmostEqual(self, t1.cpu(), t2)
+
+
+class TestExtractGridVectors(BaseTest):
+    def test_extract_grid_vectors(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping extract grid vectors test due to insufficient Torch version."
+            )
+        grid_size = (2, 2)
+        raw_activ = torch.arange(0, 4 * 3 * 3).view(3 * 3, 4).float()
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float()
+        xy_grid = atlas.normalize_grid(xy_grid)
+        grid_indices = atlas.calc_grid_indices(xy_grid, grid_size=grid_size)
+
+        vecs, vec_coords = atlas.extract_grid_vectors(
+            grid_indices, raw_activ, grid_size=grid_size, min_density=2
+        )
+
+        expected_vecs = torch.tensor([[8.0, 9.0, 10.0, 11.0], [24.0, 25.0, 26.0, 27.0]])
+        expected_coords = [(0, 0, 5), (1, 1, 5)]
+
+        assertTensorAlmostEqual(self, vecs, expected_vecs)
+        self.assertEqual(vec_coords, expected_coords)
+
+    def test_extract_grid_vectors_assertion_error(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping extract grid vectors assertion test due to insufficient"
+                + " Torch version."
+            )
+
+        grid_size = (2, 2)
+        raw_activ = torch.arange(0, 4 * 3 * 3).view(3 * 3, 4).float()
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float()
+        xy_grid = atlas.normalize_grid(xy_grid)
+        grid_indices = atlas.calc_grid_indices(xy_grid, grid_size=grid_size)
+
+        with self.assertRaises(AssertionError):
+            vecs, vec_coords = atlas.extract_grid_vectors(
+                grid_indices, raw_activ, grid_size=grid_size, min_density=50
+            )
+
+    def test_extract_grid_vectors_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping extract grid vectors CUDA test due to not supporting CUDA."
+            )
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping extract grid vectors CUDA test due to insufficient Torch"
+                + " version."
+            )
+        grid_size = (2, 2)
+        raw_activ = torch.arange(0, 4 * 3 * 3).view(3 * 3, 4).float().cuda()
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float().cuda()
+        xy_grid = atlas.normalize_grid(xy_grid)
+        grid_indices = atlas.calc_grid_indices(xy_grid, grid_size=grid_size)
+
+        vecs, vec_coords = atlas.extract_grid_vectors(
+            grid_indices, raw_activ, grid_size=grid_size, min_density=2
+        )
+
+        expected_vecs = torch.tensor([[8.0, 9.0, 10.0, 11.0], [24.0, 25.0, 26.0, 27.0]])
+        expected_coords = [(0, 0, 5), (1, 1, 5)]
+
+        self.assertTrue(vecs.is_cuda)
+        assertTensorAlmostEqual(self, vecs.cpu(), expected_vecs)
+        self.assertEqual(vec_coords, expected_coords)
+
+
+class TestCreateAtlasVectors(BaseTest):
+    def test_create_atlas_vectors(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping create atlas vectors test due to insufficient Torch version."
+            )
+        raw_activ = torch.arange(0, 4 * 3 * 3).view(3 * 3, 4).float()
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float()
+        vecs, vec_coords = atlas.create_atlas_vectors(
+            xy_grid, raw_activ, grid_size=(2, 2), min_density=2, normalize=True
+        )
+
+        expected_vecs = torch.tensor([[8.0, 9.0, 10.0, 11.0], [24.0, 25.0, 26.0, 27.0]])
+        expected_coords = [(0, 0, 5), (1, 1, 5)]
+
+        assertTensorAlmostEqual(self, vecs, expected_vecs)
+        self.assertEqual(vec_coords, expected_coords)
+
+    def test_create_atlas_vectors_diff_grid_sizes(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping create atlas vectors test due to insufficient Torch version."
+            )
+        grid_size = (3, 2)
+        raw_activ = torch.arange(0, 4 * 5 * 4).view(5 * 4, 4).float()
+        xy_grid = torch.arange(0, 2 * 5 * 4).view(5 * 4, 2).float()
+
+        vecs, vec_coords = atlas.create_atlas_vectors(
+            xy_grid, raw_activ, grid_size=grid_size, min_density=4, normalize=True
+        )
+
+        expected_vecs = torch.tensor(
+            [[12.0, 13.0, 14.0, 15.0], [64.0, 65.0, 66.0, 67.0]]
+        )
+        expected_coords = [(0, 0, 7), (2, 1, 7)]
+
+        assertTensorAlmostEqual(self, vecs, expected_vecs)
+        self.assertEqual(vec_coords, expected_coords)
+
+    def test_create_atlas_vectors_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping create atlas vectors CUDA test due to not supporting CUDA."
+            )
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping create atlas vectors CUDA test due to insufficient Torch"
+                + " version."
+            )
+        raw_activ = torch.arange(0, 4 * 3 * 3).view(3 * 3, 4).float().cuda()
+        xy_grid = torch.arange(0, 2 * 3 * 3).view(3 * 3, 2).float().cuda()
+        vecs, vec_coords = atlas.create_atlas_vectors(
+            xy_grid, raw_activ, grid_size=(2, 2), min_density=2, normalize=True
+        )
+
+        expected_vecs = torch.tensor([[8.0, 9.0, 10.0, 11.0], [24.0, 25.0, 26.0, 27.0]])
+        expected_coords = [(0, 0, 5), (1, 1, 5)]
+
+        self.assertTrue(vecs.is_cuda)
+        assertTensorAlmostEqual(self, vecs.cpu(), expected_vecs)
+        self.assertEqual(vec_coords, expected_coords)
+
+
+class TestCreateAtlas(BaseTest):
+    def test_create_atlas_square_grid_size(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping create atlas canvas test due to insufficient Torch version."
+            )
+        grid_size = (2, 2)
+        img_list = [torch.zeros(1, 3, 4, 4)] * 2
+        vec_coords = [(0, 0), (1, 1)]
+
+        atlas_canvas = atlas.create_atlas(img_list, vec_coords, grid_size=grid_size)
+
+        c_pattern = torch.hstack((torch.ones(4, 4), torch.zeros(4, 4)))
+        expected_canvas = torch.stack(
+            [torch.vstack((c_pattern, c_pattern.flip(1)))] * 3, 0
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, atlas_canvas, expected_canvas, 0)
+
+    def test_create_atlas_tensor_stack(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping create atlas canvas tensor stack test due to insufficient"
+                + " Torch version."
+            )
+        grid_size = (2, 2)
+        img_stack = torch.stack([torch.zeros(3, 4, 4)] * 2, dim=0)
+        vec_coords = [(0, 0), (1, 1)]
+
+        atlas_canvas = atlas.create_atlas(img_stack, vec_coords, grid_size=grid_size)
+
+        c_pattern = torch.hstack((torch.ones(4, 4), torch.zeros(4, 4)))
+        expected_canvas = torch.stack(
+            [torch.vstack((c_pattern, c_pattern.flip(1)))] * 3, 0
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, atlas_canvas, expected_canvas, 0)
+
+    def test_create_atlas_test_diff_grid_sizes(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping create atlas canvas test due to insufficient Torch version."
+            )
+        grid_size = (3, 2)
+        img_list = [torch.zeros(1, 3, 4, 4)] * 2
+        vec_coords = [(0, 0), (2, 1)]
+
+        atlas_canvas = atlas.create_atlas(img_list, vec_coords, grid_size=grid_size)
+
+        c_pattern = torch.hstack(
+            (torch.ones(4, 4), torch.ones(4, 4), torch.zeros(4, 4))
+        )
+        expected_canvas = torch.stack(
+            [torch.vstack((c_pattern, c_pattern.flip(1)))] * 3, 0
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, atlas_canvas, expected_canvas, 0)
+
+    def test_create_atlas_zeros(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping create atlas canvas test due to insufficient Torch version."
+            )
+        grid_size = (2, 2)
+        img_list = [torch.ones(1, 3, 4, 4)] * 2
+        vec_coords = [(0, 0), (1, 1)]
+
+        atlas_canvas = atlas.create_atlas(
+            img_list, vec_coords, grid_size=grid_size, base_tensor=torch.zeros
+        )
+
+        c_pattern = torch.hstack((torch.zeros(4, 4), torch.ones(4, 4)))
+        expected_canvas = torch.stack(
+            [torch.vstack((c_pattern, c_pattern.flip(1)))] * 3, 0
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, atlas_canvas, expected_canvas, 0)
+
+    def test_create_atlas_square_grid_size_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping create atlas CUDA test due to not supporting CUDA."
+            )
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping create_atlas canvas CUDA due to insufficient Torch version."
+            )
+        grid_size = (2, 2)
+        img_list = [torch.zeros(1, 3, 4, 4).cuda()] * 2
+        vec_coords = [(0, 0), (1, 1)]
+
+        atlas_canvas = atlas.create_atlas(img_list, vec_coords, grid_size=grid_size)
+
+        c_pattern = torch.hstack((torch.ones(4, 4), torch.zeros(4, 4)))
+        expected_canvas = torch.stack(
+            [torch.vstack((c_pattern, c_pattern.flip(1)))] * 3, 0
+        ).unsqueeze(0)
+
+        self.assertTrue(atlas_canvas.is_cuda)
+        assertTensorAlmostEqual(self, atlas_canvas.cpu(), expected_canvas, 0)


### PR DESCRIPTION
Now it should be possible to perform operations like max(my_tensor, torch.ones_like(my_tensor)) with `basic_torch_module_op`.