### PR TITLE
Support ToRGB with no named dimensions

### DIFF
--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -252,7 +252,7 @@ class ToRGB(nn.Module):
         if self._supports_is_scripting:
             if torch.jit.is_scripting():
                 return self._forward_without_named_dims(x, inverse)
-        elif self._supports_named_dims:
+        if self._supports_named_dims:
             if list(x.names) in [[None] * 3, [None] * 4]:
                 return self._forward_without_named_dims(x, inverse)
         return self._forward(x, inverse)

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -79,6 +79,7 @@ class ToRGB(nn.Module):
     Computer Graphics and Image Processing, vol. 13, no. 3, pp. 222–241, 1980
     https://www.sciencedirect.com/science/article/pii/0146664X80900477
     """
+
     __constants__ = ["_supports_is_scripting", "_supports_named_dims"]
 
     @staticmethod

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -79,6 +79,7 @@ class ToRGB(nn.Module):
     Computer Graphics and Image Processing, vol. 13, no. 3, pp. 222–241, 1980
     https://www.sciencedirect.com/science/article/pii/0146664X80900477
     """
+    __constants__ = ["_supports_is_scripting", "_supports_named_dims"]
 
     @staticmethod
     def klt_transform() -> torch.Tensor:

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -132,6 +132,7 @@ class ToRGB(nn.Module):
             )
         # Check & store whether or not we can use torch.jit.is_scripting()
         self._supports_is_scripting = torch.__version__ >= "1.6.0"
+        self._supports_named_dims = torch.__version__ >= "1.3.0"
 
     @torch.jit.ignore
     def _forward(self, x: torch.Tensor, inverse: bool = False) -> torch.Tensor:
@@ -249,6 +250,9 @@ class ToRGB(nn.Module):
         """
         if self._supports_is_scripting:
             if torch.jit.is_scripting():
+                return self._forward_without_named_dims(x, inverse)
+        elif self._supports_named_dims:
+            if list(x.names) in [[None] * 3, [None] * 4]:
                 return self._forward_without_named_dims(x, inverse)
         return self._forward(x, inverse)
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1182,6 +1182,7 @@ class TestToRGB(BaseTest):
         expected_rgb_tensor = torch.stack([r, g, b]).unsqueeze(0)
 
         assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), ["B", "C", "H", "W"])
 
         inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
         assertTensorAlmostEqual(
@@ -1204,6 +1205,7 @@ class TestToRGB(BaseTest):
         expected_rgb_tensor = torch.stack([r, g, b, a]).unsqueeze(0)
 
         assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), ["B", "C", "H", "W"])
 
         inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
         assertTensorAlmostEqual(
@@ -1227,6 +1229,7 @@ class TestToRGB(BaseTest):
         expected_rgb_tensor = torch.stack([r, g, b, a])
 
         assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), ["C", "H", "W"])
 
         inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
         assertTensorAlmostEqual(

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1264,7 +1264,7 @@ class TestToRGB(BaseTest):
                 "Skipping ToRGB with Alpha forward due to insufficient Torch version."
             )
         to_rgb = transforms.ToRGB(transform="klt")
-        test_tensor = torch.ones(1, 4, 4, 4).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 4, 4, 4)
         rgb_tensor = to_rgb(test_tensor)
 
         r = torch.ones(4, 4) * 0.8009

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1236,6 +1236,51 @@ class TestToRGB(BaseTest):
             self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
         )
 
+    def test_to_rgb_klt_forward_no_named_dims(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping ToRGB forward due to insufficient Torch version."
+            )
+        to_rgb = transforms.ToRGB(transform="klt")
+        test_tensor = torch.ones(1, 3, 4, 4)
+        rgb_tensor = to_rgb(test_tensor)
+
+        r = torch.ones(4, 4) * 0.8009
+        g = torch.ones(4, 4) * 0.4762
+        b = torch.ones(4, 4) * 0.4546
+        expected_rgb_tensor = torch.stack([r, g, b]).unsqueeze(0)
+
+        assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), [None] * 4)
+
+        inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
+        assertTensorAlmostEqual(
+            self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
+        )
+
+    def test_to_rgb_alpha_klt_forward_no_named_dims(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping ToRGB with Alpha forward due to insufficient Torch version."
+            )
+        to_rgb = transforms.ToRGB(transform="klt")
+        test_tensor = torch.ones(1, 4, 4, 4).refine_names("B", "C", "H", "W")
+        rgb_tensor = to_rgb(test_tensor)
+
+        r = torch.ones(4, 4) * 0.8009
+        g = torch.ones(4, 4) * 0.4762
+        b = torch.ones(4, 4) * 0.4546
+        a = torch.ones(4, 4)
+        expected_rgb_tensor = torch.stack([r, g, b, a]).unsqueeze(0)
+
+        assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), [None] * 4)
+
+        inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
+        assertTensorAlmostEqual(
+            self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
+        )
+
     def test_to_rgb_i1i2i3_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1173,7 +1173,7 @@ class TestToRGB(BaseTest):
                 "Skipping ToRGB forward due to insufficient Torch version."
             )
         to_rgb = transforms.ToRGB(transform="klt")
-        test_tensor = torch.ones(3, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 3, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         r = torch.ones(4, 4) * 0.8009
@@ -1195,7 +1195,7 @@ class TestToRGB(BaseTest):
                 "Skipping ToRGB with Alpha forward due to insufficient Torch version."
             )
         to_rgb = transforms.ToRGB(transform="klt")
-        test_tensor = torch.ones(4, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 4, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         r = torch.ones(4, 4) * 0.8009
@@ -1242,7 +1242,7 @@ class TestToRGB(BaseTest):
                 "Skipping ToRGB forward due to insufficient Torch version."
             )
         to_rgb = transforms.ToRGB(transform="i1i2i3")
-        test_tensor = torch.ones(3, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 3, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         r = torch.ones(4, 4)
@@ -1263,7 +1263,7 @@ class TestToRGB(BaseTest):
                 "Skipping ToRGB with Alpha forward due to insufficient Torch version."
             )
         to_rgb = transforms.ToRGB(transform="i1i2i3")
-        test_tensor = torch.ones(4, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 4, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         r = torch.ones(4, 4)
@@ -1286,7 +1286,7 @@ class TestToRGB(BaseTest):
             )
         matrix = torch.eye(3, 3)
         to_rgb = transforms.ToRGB(transform=matrix)
-        test_tensor = torch.ones(3, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 3, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         to_rgb_np = numpy_transforms.ToRGB(transform=matrix.numpy())
@@ -1308,7 +1308,7 @@ class TestToRGB(BaseTest):
             )
         to_rgb = transforms.ToRGB(transform="klt")
         jit_to_rgb = torch.jit.script(to_rgb)
-        test_tensor = torch.ones(3, 4, 4).unsqueeze(0)
+        test_tensor = torch.ones(1, 3, 4, 4)
         rgb_tensor = jit_to_rgb(test_tensor)
 
         r = torch.ones(4, 4) * 0.8009


### PR DESCRIPTION
This should make it easier to work with the ToRGB module as many PyTorch functions still don't work with named dimensions yet.