### PR TITLE
Improvements to custom_composable_op

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -86,7 +86,7 @@ class Loss(ABC):
     def __rpow__(self, other: Union[int, float, "Loss"]) -> "CompositeLoss":
         rmodule_op(self, other, operator.pow)
 
-    def mean(self, dim: Optional = None, keepdim: bool = False) -> "CompositeLoss":
+    def mean(self, dim: Optional[Union[int, Tuple[int, ...]]] = None, keepdim: bool = False) -> "CompositeLoss":
         """
         Composable torch.mean reduction operator. See torch.mean for more details:
         https://pytorch.org/docs/stable/generated/torch.mean.html
@@ -106,7 +106,7 @@ class Loss(ABC):
         else:
             return custom_composable_op(self, torch.mean, dim=dim, keepdim=keepdim)
 
-    def sum(self, dim: Optional = None, keepdim: bool = False) -> "CompositeLoss":
+    def sum(self, dim: Optional[Union[int, Tuple[int, ...]]] = None, keepdim: bool = False) -> "CompositeLoss":
         """
         Composable torch.sum reduction operator. See torch.sum for more details:
         https://pytorch.org/docs/stable/generated/torch.sum.html

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -197,9 +197,9 @@ def custom_composable_op(
     **kwargs: Any,
 ) -> "CompositeLoss":
     """
-    Implement composability for operations that take a single tensor or list
-    of tensors. Custom user defined functions can be used in addition to some built-in
-    Python functions and PyTorch operations.
+    Implement composability for operations that take a single tensor or list of tensors
+    and then return a single tensor. Custom user defined functions can be used in
+    addition to some built-in Python functions and PyTorch operations.
 
     Args:
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -220,10 +220,6 @@ def custom_composable_op(
     """
 
     if isinstance(loss, (tuple, list)):
-
-        def identity(x: torch.Tensor) -> torch.Tensor:
-            return x
-
         if "to_scalar_fn" not in kwargs:
             to_scalar_fn = None
         else:

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -87,7 +87,9 @@ class Loss(ABC):
     def __rpow__(self, other: Union[int, float, "Loss"]) -> "CompositeLoss":
         rmodule_op(self, other, operator.pow)
 
-    def mean(self, dim: Optional[Union[int, Tuple[int, ...]]] = None, keepdim: bool = False) -> "CompositeLoss":
+    def mean(
+        self, dim: Optional[Union[int, Tuple[int, ...]]] = None, keepdim: bool = False
+    ) -> "CompositeLoss":
         """
         Composable torch.mean reduction operator. See torch.mean for more details:
         https://pytorch.org/docs/stable/generated/torch.mean.html
@@ -107,7 +109,9 @@ class Loss(ABC):
         else:
             return custom_composable_op(self, torch.mean, dim=dim, keepdim=keepdim)
 
-    def sum(self, dim: Optional[Union[int, Tuple[int, ...]]] = None, keepdim: bool = False) -> "CompositeLoss":
+    def sum(
+        self, dim: Optional[Union[int, Tuple[int, ...]]] = None, keepdim: bool = False
+    ) -> "CompositeLoss":
         """
         Composable torch.sum reduction operator. See torch.sum for more details:
         https://pytorch.org/docs/stable/generated/torch.sum.html

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -209,9 +209,7 @@ def custom_composable_op(
     Args:
 
         loss (Loss or list of Loss): A loss objective or list of loss objectives.
-        loss_op_fn (Callable): A PyTorch or supported Python function. Ex: torch.mean,
-             torch.sum,, torch.linalg.norm, torch.sin, torch.cat, torch.stack, max, min,
-             sum, math.ceil, or custom user defined functions.
+        loss_op_fn (Callable): A supported PyTorch, Python, or custom function.
             Default: torch.mean
         args (Any, optional): Any additional arguments to pass to loss_op_fn.
         kwargs (Any, optional): Any additional arguments to pass to loss_op_fn.

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -17,6 +17,7 @@ def _make_arg_str(arg: Any) -> str:
 
 
 # Reduction op for CompositeLoss loss composability size mismatch avoidance
+# REDUCTION_OP is only used for binary math operations using two Loss instances
 REDUCTION_OP: Callable[[torch.Tensor], torch.Tensor] = torch.mean
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -175,7 +175,7 @@ def rmodule_op(
     if isinstance(other, (int, float)):
 
         def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
-            return math_op(other, REDUCTION_OP(self(module)))
+            return math_op(other, self(module))
 
         name = self.__name__
         target = self.target

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -232,7 +232,7 @@ def custom_composable_op(
 
         def loss_fn(module: ModuleOutputMapping) -> torch.Tensor:
             loss_tensors = [loss_obj(module) for loss_obj in loss]
-            if scalar_fn is not None:
+            if to_scalar_fn is not None:
                 loss_tensors = [to_scalar_fn(tensor) for tensor in loss_tensors]
             return torch_op(loss_tensors, *args, **kwargs)
 

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -290,7 +290,7 @@ def TestCustomComposableOP(BaseTest):
     def test_torch_sum(self) -> None:
         model = torch.nn.Identity()
         loss = opt_loss.LayerActivation(model)
-        loss = opt_loss.custom_composable_op(loss, torch_op=torch.sum)
+        loss = opt_loss.custom_composable_op(loss, loss_op_fn=torch.sum)
         self.assertAlmostEqual(get_loss_value(model, loss), 3.0, places=1)
 
     def test_sum_list_with_scalar_fn(self) -> None:
@@ -303,7 +303,7 @@ def TestCustomComposableOP(BaseTest):
             opt_loss.LayerActivation(model),
         ]
         loss = opt_loss.custom_composable_op(
-            loss_list, torch_op=sum, to_scalar_fn=torch.mean
+            loss_list, loss_op_fn=sum, to_scalar_fn=torch.mean
         )
         self.assertAlmostEqual(get_loss_value(model, loss), 5.0, places=1)
 
@@ -317,7 +317,7 @@ def TestCustomComposableOP(BaseTest):
         loss = opt_loss.LayerActivation(model)
 
         loss = opt_loss.custom_composable_op(
-            loss, torch_op=custom_op_fn, add_val=2.0, mul_val=2.0
+            loss, loss_op_fn=custom_op_fn, add_val=2.0, mul_val=2.0
         )
         self.assertAlmostEqual(get_loss_value(model, loss), 7.0, places=1)
 
@@ -339,7 +339,7 @@ def TestCustomComposableOP(BaseTest):
         ]
         loss = opt_loss.custom_composable_op(
             loss_list,
-            torch_op=custom_op_list_fn,
+            loss_op_fn=custom_op_list_fn,
             add_val=2.0,
             mul_val=2.0,
         )

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -286,17 +286,17 @@ class TestCompositeLossReductionOP(BaseTest):
         self.assertEqual(opt_loss.REDUCTION_OP, torch.mean)
 
 
-def TestBasisTorchModuleOP(BaseTest):
+def TestCustomComposableOP(BaseTest):
     def test_torch_sum(self) -> None:
         model = torch.nn.Identity()
         loss = opt_loss.LayerActivation(model)
-        loss = opt_loss.basic_torch_module_op(loss, torch_op=torch.sum)
+        loss = opt_loss.custom_composable_op(loss, torch_op=torch.sum)
         self.assertAlmostEqual(get_loss_value(model, loss), 3.0, places=1)
 
     def test_sum_list_with_scalar_fn(self) -> None:
         model = torch.nn.Identity()
         loss_list = [opt_loss.LayerActivation(model)] * 5
-        loss = opt_loss.basic_torch_module_op(
+        loss = opt_loss.custom_composable_op(
             loss_list, torch_op=sum, to_scalar_fn=torch.mean
         )
         self.assertAlmostEqual(get_loss_value(model, loss), 5.0, places=1)

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -295,7 +295,13 @@ def TestCustomComposableOP(BaseTest):
 
     def test_sum_list_with_scalar_fn(self) -> None:
         model = torch.nn.Identity()
-        loss_list = [opt_loss.LayerActivation(model)] * 5
+        loss_list = [
+            opt_loss.LayerActivation(model),
+            opt_loss.LayerActivation(model),
+            opt_loss.LayerActivation(model),
+            opt_loss.LayerActivation(model),
+            opt_loss.LayerActivation(model),
+        ]
         loss = opt_loss.custom_composable_op(
             loss_list, torch_op=sum, to_scalar_fn=torch.mean
         )

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -323,7 +323,7 @@ def TestCustomComposableOP(BaseTest):
 
     def test_custom_op_list(self) -> None:
         def custom_op_list_fn(
-            losses: List[torch.tensor], add_val: float = 1.0, mul_val: float = 1.0
+            losses: List[torch.Tensor], add_val: float = 1.0, mul_val: float = 1.0
         ) -> torch.Tensor:
             return torch.cat(
                 [torch.sum(loss) + add_val * mul_val for loss in losses], 0


### PR DESCRIPTION
* Improved documentation.
* Renamed `basic_torch_module_op` to `custom_composable_op`.
* Removed the reduction OP from 'r' module calls as it's not required.