### PR TITLE
Add better colorspace support, image grids, & user agent to ImageTensor

### DIFF
--- a/captum/optim/__init__.py
+++ b/captum/optim/__init__.py
@@ -7,6 +7,7 @@ from captum.optim._param.image import images, transforms  # noqa: F401
 from captum.optim._param.image.images import ImageTensor  # noqa: F401
 from captum.optim._utils import circuits, reducer  # noqa: F401
 from captum.optim._utils.image.common import (  # noqa: F401
+    make_grid_image,
     nchannels_to_rgb,
     save_tensor_as_image,
     show,
@@ -23,6 +24,7 @@ __all__ = [
     "circuits",
     "models",
     "reducer",
+    "make_grid_image",
     "nchannels_to_rgb",
     "save_tensor_as_image",
     "show",

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -53,14 +53,15 @@ class ImageTensor(torch.Tensor):
             path (str): A URL or filepath to an image.
             scale (float, optional): The image scale to use.
                 Default: 255.0
-            mode (str, optional): The image loading mode to use.
+            mode (str, optional): The image loading mode / colorspace to use.
                 Default: "RGB"
 
         Returns:
            x (ImageTensor): An `ImageTensor` instance.
         """
         if path.startswith("https://") or path.startswith("http://"):
-            response = requests.get(path, stream=True)
+            headers = {"User-Agent": "Captum"}
+            response = requests.get(path, stream=True, headers=headers)
             img = Image.open(response.raw)
         else:
             img = Image.open(path)
@@ -94,7 +95,12 @@ class ImageTensor(torch.Tensor):
         return super().__torch_function__(func, types, args, kwargs)
 
     def show(
-        self, figsize: Optional[Tuple[int, int]] = None, scale: float = 255.0
+        self,
+        figsize: Optional[Tuple[int, int]] = None,
+        scale: float = 255.0,
+        nrow: Optional[int] = None,
+        padding: int = 2,
+        pad_value: float = 0.0,
     ) -> None:
         """
         Display an `ImageTensor`.
@@ -106,10 +112,34 @@ class ImageTensor(torch.Tensor):
             scale (float, optional): Value to multiply the `ImageTensor` by so that
                 it's value range is [0-255] for display.
                 Default: 255.0
+            nrow (int, optional): The number of rows to use for the grid image. Default
+                is set to None for no grid image creation.
+                Default: None
+            padding (int, optional): The amount of padding between images in the grid
+                images. This parameter only has an effect if `nrow` is not None.
+                Default: 2
+            pad_value (float, optional): The value to use for the padding. This
+                parameter only has an effect if `nrow` is not None.
+                Default: 0.0
         """
-        show(self, figsize=figsize, scale=scale)
+        show(
+            self,
+            figsize=figsize,
+            scale=scale,
+            nrow=nrow,
+            padding=padding,
+            pad_value=pad_value,
+        )
 
-    def export(self, filename: str, scale: float = 255.0) -> None:
+    def export(
+        self,
+        filename: str,
+        scale: float = 255.0,
+        mode: Optional[str] = None,
+        nrow: Optional[int] = None,
+        padding: int = 2,
+        pad_value: float = 0.0,
+    ) -> None:
         """
         Save an `ImageTensor` as an image file.
 
@@ -120,8 +150,28 @@ class ImageTensor(torch.Tensor):
             scale (float, optional): Value to multiply the `ImageTensor` by so that
                 it's value range is [0-255] for saving.
                 Default: 255.0
+            mode (str, optional): A PIL / Pillow supported colorspace. Default is
+                set to None for automatic RGB / RGBA detection and usage.
+                Default: None
+            nrow (int, optional): The number of rows to use for the grid image. Default
+                is set to None for no grid image creation.
+                Default: None
+            padding (int, optional): The amount of padding between images in the grid
+                images. This parameter only has an effect if `nrow` is not None.
+                Default: 2
+            pad_value (float, optional): The value to use for the padding. This
+                parameter only has an effect if `nrow` is not None.
+                Default: 0.0
         """
-        save_tensor_as_image(self, filename=filename, scale=scale)
+        save_tensor_as_image(
+            self,
+            filename=filename,
+            scale=scale,
+            mode=mode,
+            nrow=nrow,
+            padding=padding,
+            pad_value=pad_value,
+        )
 
 
 class InputParameterization(torch.nn.Module):

--- a/tests/optim/utils/image/common.py
+++ b/tests/optim/utils/image/common.py
@@ -130,8 +130,7 @@ class TestMakeGridImage(BaseTest):
     def test_make_grid_image_single_tensor_pad_value_cuda(self) -> None:
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
-                "Skipping make_image_grid CUDA test due to not supporting"
-                + " CUDA."
+                "Skipping make_image_grid CUDA test due to not supporting" + " CUDA."
             )
         test_input = torch.ones(4, 1, 2, 2).cuda()
         test_output = common.make_grid_image(
@@ -164,9 +163,7 @@ class TestMakeGridImage(BaseTest):
             )
         test_input = torch.ones(4, 1, 2, 2)
         jit_make_grid_image = torch.jit.script(common.make_grid_image)
-        test_output = jit_make_grid_image(
-            test_input, nrow=2, padding=1, pad_value=5.0
-        )
+        test_output = jit_make_grid_image(test_input, nrow=2, padding=1, pad_value=5.0)
         expected_output = torch.tensor(
             [
                 [

--- a/tests/optim/utils/image/common.py
+++ b/tests/optim/utils/image/common.py
@@ -8,7 +8,185 @@ from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.optim.helpers import numpy_common
 
 
-class TestGetNeuronPos(unittest.TestCase):
+class TestMakeGridImage(BaseTest):
+    def test_make_grid_image_single_tensor(self) -> None:
+        test_input = torch.ones(6, 1, 2, 2)
+        test_output = common.make_grid_image(
+            test_input, nrow=3, padding=1, pad_value=0.0
+        )
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                ]
+            ]
+        )
+        self.assertEqual(list(expected_output.shape), [1, 1, 7, 10])
+        assertTensorAlmostEqual(self, test_output, expected_output, 0)
+
+    def test_make_grid_image_tensor_list(self) -> None:
+        test_input = [torch.ones(1, 1, 2, 2) for i in range(6)]
+        test_output = common.make_grid_image(
+            test_input, nrow=3, padding=1, pad_value=0.0
+        )
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                ]
+            ]
+        )
+        self.assertEqual(list(expected_output.shape), [1, 1, 7, 10])
+        assertTensorAlmostEqual(self, test_output, expected_output, 0)
+
+    def test_make_grid_image_single_tensor_fewer_tiles(self) -> None:
+        test_input = torch.ones(4, 1, 2, 2)
+        test_output = common.make_grid_image(
+            test_input, nrow=3, padding=1, pad_value=0.0
+        )
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                ]
+            ]
+        )
+        self.assertEqual(list(expected_output.shape), [1, 1, 7, 10])
+        assertTensorAlmostEqual(self, test_output, expected_output, 0)
+
+    def test_make_grid_image_single_tensor_padding(self) -> None:
+        test_input = torch.ones(4, 1, 2, 2)
+        test_output = common.make_grid_image(
+            test_input, nrow=2, padding=2, pad_value=0.0
+        )
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                ]
+            ]
+        )
+        self.assertEqual(list(expected_output.shape), [1, 1, 10, 10])
+        assertTensorAlmostEqual(self, test_output, expected_output, 0)
+
+    def test_make_grid_image_single_tensor_pad_value(self) -> None:
+        test_input = torch.ones(4, 1, 2, 2)
+        test_output = common.make_grid_image(
+            test_input, nrow=2, padding=1, pad_value=5.0
+        )
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+                    ]
+                ]
+            ]
+        )
+        self.assertEqual(list(expected_output.shape), [1, 1, 7, 7])
+        assertTensorAlmostEqual(self, test_output, expected_output, 0)
+
+    def test_make_grid_image_single_tensor_pad_value_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping make_image_grid CUDA test due to not supporting"
+                + " CUDA."
+            )
+        test_input = torch.ones(4, 1, 2, 2).cuda()
+        test_output = common.make_grid_image(
+            test_input, nrow=2, padding=1, pad_value=5.0
+        )
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+                    ]
+                ]
+            ]
+        )
+        self.assertEqual(list(expected_output.shape), [1, 1, 7, 7])
+        self.assertTrue(test_output.is_cuda)
+        assertTensorAlmostEqual(self, test_output, expected_output, 0)
+
+    def test_make_grid_image_single_tensor_pad_value_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping make_image_grid JIT module test due to"
+                + "  insufficient Torch version."
+            )
+        test_input = torch.ones(4, 1, 2, 2)
+        jit_make_grid_image = torch.jit.script(common.make_grid_image)
+        test_output = jit_make_grid_image(
+            test_input, nrow=2, padding=1, pad_value=5.0
+        )
+        expected_output = torch.tensor(
+            [
+                [
+                    [
+                        [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 1.0, 1.0, 5.0, 1.0, 1.0, 5.0],
+                        [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+                    ]
+                ]
+            ]
+        )
+        self.assertEqual(list(expected_output.shape), [1, 1, 7, 7])
+        assertTensorAlmostEqual(self, test_output, expected_output, 0)
+
+
+class TestGetNeuronPos(BaseTest):
     def test_get_neuron_pos_hw(self) -> None:
         W, H = 128, 128
         x, y = common.get_neuron_pos(H, W)


### PR DESCRIPTION
* Added color space support to `save_tensor_as_image` & `ImageTensor.export`.
* Added image grid creation support to `ImageTensor.export` , `ImageTensor.show` , `show` & `save_tensor_as_image` via a new `make_grid_image` function.
* Added user agent to `ImageTensor.open` as sites like Wikipedia require user agents.