### PR TITLE
Fix bug with nn.Sequential targets

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -128,8 +128,16 @@ def module_op(
 
         name = f"Compose({', '.join([self.__name__, other.__name__])})"
         target = (
-            self.target if hasattr(self.target, "__iter__")  and not isinstance(self.target, nn.Module) else [self.target]
-        ) + (other.target if hasattr(other.target, "__iter__") and not isinstance(other.target, nn.Module) else [other.target])
+            self.target
+            if hasattr(self.target, "__iter__")
+            and not isinstance(self.target, nn.Module)
+            else [self.target]
+        ) + (
+            other.target
+            if hasattr(other.target, "__iter__")
+            and not isinstance(other.target, nn.Module)
+            else [other.target]
+        )
     else:
         raise TypeError(
             "Can only apply math operations with int, float or Loss. Received type "
@@ -268,7 +276,7 @@ class DeepDream(BaseLoss):
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
         activations = targets_to_values[self.target]
         activations = activations[self.batch_index[0] : self.batch_index[1]]
-        return activations ** 2
+        return activations**2
 
 
 @loss_wrapper
@@ -588,7 +596,7 @@ class AngledNeuronDirection(BaseLoss):
             return activations * vec
 
         dot = torch.mean(activations * vec)
-        cossims = dot / (self.eps + torch.sqrt(torch.sum(activations ** 2)))
+        cossims = dot / (self.eps + torch.sqrt(torch.sum(activations**2)))
         return dot * torch.clamp(cossims, min=0.1) ** self.cossim_pow
 
 

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -128,8 +128,8 @@ def module_op(
 
         name = f"Compose({', '.join([self.__name__, other.__name__])})"
         target = (
-            self.target if hasattr(self.target, "__iter__") else [self.target]
-        ) + (other.target if hasattr(other.target, "__iter__") else [other.target])
+            self.target if hasattr(self.target, "__iter__")  and not isinstance(self.target, nn.Module) else [self.target]
+        ) + (other.target if hasattr(other.target, "__iter__") and not isinstance(other.target, nn.Module) else [other.target])
     else:
         raise TypeError(
             "Can only apply math operations with int, float or Loss. Received type "

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -276,7 +276,7 @@ class DeepDream(BaseLoss):
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
         activations = targets_to_values[self.target]
         activations = activations[self.batch_index[0] : self.batch_index[1]]
-        return activations**2
+        return activations ** 2
 
 
 @loss_wrapper
@@ -596,7 +596,7 @@ class AngledNeuronDirection(BaseLoss):
             return activations * vec
 
         dot = torch.mean(activations * vec)
-        cossims = dot / (self.eps + torch.sqrt(torch.sum(activations**2)))
+        cossims = dot / (self.eps + torch.sqrt(torch.sum(activations ** 2)))
         return dot * torch.clamp(cossims, min=0.1) ** self.cossim_pow
 
 

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -64,7 +64,8 @@ class InputOptimization(Objective, Parameterized):
             self.hooks = ModuleOutputsHook([loss_function.target])
         self.input_param = input_param or NaturalImage((224, 224))
         if isinstance(self.model, Iterable):
-            self.input_param.to(next(self.model.parameters()).device)
+            if list(self.model.parameters()) != []:
+                self.input_param.to(next(self.model.parameters()).device)
         self.transform = transform or torch.nn.Sequential(
             RandomScale(scale=(1, 0.975, 1.025, 0.95, 1.05)), RandomSpatialJitter(16)
         )

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -58,7 +58,9 @@ class InputOptimization(Objective, Parameterized):
         """
         self.model = model
         # Grab targets from loss_function
-        if hasattr(loss_function.target, "__iter__") and not isinstance(loss_function.target, nn.Module):
+        if hasattr(loss_function.target, "__iter__") and not isinstance(
+            loss_function.target, nn.Module
+        ):
             self.hooks = ModuleOutputsHook(loss_function.target)
         else:
             self.hooks = ModuleOutputsHook([loss_function.target])

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -58,7 +58,7 @@ class InputOptimization(Objective, Parameterized):
         """
         self.model = model
         # Grab targets from loss_function
-        if hasattr(loss_function.target, "__iter__"):
+        if hasattr(loss_function.target, "__iter__") and not isinstance(loss_function.target, nn.Module):
             self.hooks = ModuleOutputsHook(loss_function.target)
         else:
             self.hooks = ModuleOutputsHook([loss_function.target])


### PR DESCRIPTION
Some PyTorch modules that can be used as targets have an `__iter__` attribute, like `torch.nn.Sequential`. The current target system only checks for the `__iter__` attribute to determine if a target is already in a list or not, and thus doesn't work with targets like Sequential modules. This PR fixes this big.