### PR TITLE
Add model preparation tutorial

### DIFF
--- a/tutorials/optimviz/GettingStarted_ModelPreparation_OptimViz.ipynb
+++ b/tutorials/optimviz/GettingStarted_ModelPreparation_OptimViz.ipynb
@@ -7,7 +7,8 @@
       "provenance": [],
       "collapsed_sections": [
         "3MSB2RhA4h8E"
-      ]
+      ],
+      "toc_visible": true
     },
     "kernelspec": {
       "name": "python3",
@@ -109,7 +110,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "## Targetable Layers\n",
+        "## The Basics: Targetable Layers\n",
         "\n",
         "The optim module's `opt.models.collect_activations` function and loss objectives (`opt.loss.LossObjective`) rely on forward hooks using PyTorch's hook system. This means that functional layers cannot be used as optimization targets, and activations cannot be collected for them.\n",
         "\n",
@@ -215,7 +216,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "## Redirected ReLU\n",
+        "## Visualization: Redirected ReLU\n",
         "\n",
         "In some cases, the target of interest may not be activated at all by the initial random input. If this happens, the zero derivative stops the gradient from flowing backwards and thus we never move towards any meaningful visualization. To solve this problem, we can replace the ReLU layers in a model with a special version of ReLU called `RedirectedReLU`. The `RedirectedReLU` layer allows the gradient to flow temporarily in these zero gradient situations.\n",
         "\n",
@@ -268,7 +269,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "## Linear Operation Layers\n",
+        "## Circuits: Linear Operation Layers\n",
         "\n",
         "Certain functions like `opt.circuits.extract_expanded_weights` require using modules that only perform linear operations. This can become slightly more complicated when dealing with layers that have multiple preset set variables. Luckily the `opt.models.replace_layers` can easily handle these variable transfers if the `transfer_vars` variable is set to `True`.\n",
         "\n",

--- a/tutorials/optimviz/GettingStarted_ModelPreparation_OptimViz.ipynb
+++ b/tutorials/optimviz/GettingStarted_ModelPreparation_OptimViz.ipynb
@@ -1,0 +1,343 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "GettingStarted_ModelPreparation_OptimViz.ipynb",
+      "provenance": [],
+      "collapsed_sections": [
+        "3MSB2RhA4h8E"
+      ]
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Preparing Models For Captum's Optim Module\n",
+        "\n",
+        "This tutorial demonstrates how to easily perform the suggested & required  changes to models for use with the Optim module."
+      ],
+      "metadata": {
+        "id": "QVpft54KA-P_"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%load_ext autoreload\n",
+        "%autoreload 2\n",
+        "\n",
+        "import torch\n",
+        "import captum.optim as opt\n",
+        "\n",
+        "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")"
+      ],
+      "metadata": {
+        "id": "KD5InqKt3Hjc"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Model Layer Changes\n",
+        "\n",
+        "The Optim module's layer related functions, and optimization systems rely on layers being defined as `nn.Module` classes rather than functional layers.\n",
+        "\n",
+        "\n",
+        "For the purpose of this tutorial, our test model does not use any functional layers. Though if you are wishing to use your own model then you should verify that all applicable functional layers have been changed to their `nn.Module` equivalents in your chosen model.\n",
+        "\n",
+        "* A list of all PyTorch's `torch.nn.functional` layers can be found [here](https://pytorch.org/docs/stable/nn.functional.html), and each layer has links to their `nn.Module` equivalents.\n",
+        "\n",
+        "* The most common change you will likely encounter, is converting the functional [`F.relu`](https://pytorch.org/docs/stable/generated/torch.nn.functional.relu.html#torch.nn.functional.relu) layers to [`nn.ReLU`](https://pytorch.org/docs/stable/generated/torch.nn.ReLU.html)."
+      ],
+      "metadata": {
+        "id": "3MSB2RhA4h8E"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Tutorial Setup\n",
+        "\n",
+        "Below we define a simple test model for use in our examples."
+      ],
+      "metadata": {
+        "id": "QGIfQki3Dn2M"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class Model(torch.nn.Module):\n",
+        "    def __init__(self) -> None:\n",
+        "        super().__init__()\n",
+        "        self.basic_module = torch.nn.Sequential(\n",
+        "            torch.nn.Conv2d(3, 4, kernel_size=3, stride=2),\n",
+        "            torch.nn.ReLU(),\n",
+        "            torch.nn.MaxPool2d(kernel_size=3, stride=2),\n",
+        "        )\n",
+        "        self.conv = torch.nn.Conv2d(4, 4, kernel_size=3, stride=2)\n",
+        "        self.relu = torch.nn.ReLU()\n",
+        "        self.pooling = torch.nn.AdaptiveAvgPool2d((2, 2))\n",
+        "        self.linear = torch.nn.Linear(16, 4)\n",
+        "\n",
+        "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
+        "        x = self.basic_module(x)\n",
+        "        x = self.conv(x)\n",
+        "        x = self.relu(x)\n",
+        "        x = self.pooling(x)\n",
+        "        x = x.flatten()\n",
+        "        x = self.linear(x)\n",
+        "        return x"
+      ],
+      "metadata": {
+        "id": "X79d0fh_3LuT"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Targetable Layers\n",
+        "\n",
+        "The optim module's `opt.models.collect_activations` function and loss objectives (`opt.loss.LossObjective`) rely on forward hooks using PyTorch's hook system. This means that functional layers cannot be used as optimization targets, and activations cannot be collected for them.\n",
+        "\n",
+        "Below we use the `opt.models.get_model_layers` function to see a list of all the hookable layers in our model that we can use as targets."
+      ],
+      "metadata": {
+        "id": "UjEdNgauOdbZ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "target_model = Model().eval().to(device)\n",
+        "\n",
+        "# Get hookable layers\n",
+        "possible_targets = opt.models.get_model_layers(target_model)\n",
+        "\n",
+        "# Display hookable layers\n",
+        "for t in possible_targets:\n",
+        "    print(\"target_model.\" + t)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "TlZ5UwiVPptG",
+        "outputId": "7ea27b2a-53bf-4437-f64b-028776d87daf"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "target_model.basic_module\n",
+            "target_model.basic_module[0]\n",
+            "target_model.basic_module[1]\n",
+            "target_model.basic_module[2]\n",
+            "target_model.conv\n",
+            "target_model.relu\n",
+            "target_model.pooling\n",
+            "target_model.linear\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can then easily use any of the targets found above for optimization and activation collection, as we show below."
+      ],
+      "metadata": {
+        "id": "iHTSN71dWh5o"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Set layer target\n",
+        "target_layer=target_model.conv\n",
+        "\n",
+        "# Collect activations from target\n",
+        "activations_dict = opt.models.collect_activations(\n",
+        "    model=target_model, targets=target_layer\n",
+        ")\n",
+        "\n",
+        "# Collect target from activations dict\n",
+        "activations = activations_dict[target_layer]\n",
+        "\n",
+        "# Display activation shape\n",
+        "print(\"Output shape of the {} layer:\".format(type(target_layer)))\n",
+        "print(\"  {} \\n\".format(activations.shape))\n",
+        "\n",
+        "# We can also use the target for loss objectives\n",
+        "loss_fn = opt.loss.LayerActivation(target=target_layer)\n",
+        "\n",
+        "# Print loss objective\n",
+        "print(\"Loss objective:\", loss_fn)\n",
+        "print(\"  target:\", loss_fn.target)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "tiD7qBzlQ6Zw",
+        "outputId": "3a9471cf-69b0-44a5-b36c-dcbad0d6620e"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Output shape of the <class 'torch.nn.modules.conv.Conv2d'> layer:\n",
+            "  torch.Size([1, 4, 27, 27]) \n",
+            "\n",
+            "Loss objective: LayerActivation []\n",
+            "  target: Conv2d(4, 4, kernel_size=(3, 3), stride=(2, 2))\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Redirected ReLU\n",
+        "\n",
+        "In some cases, the target of interest may not be activated at all by the initial random input. If this happens, the zero derivative stops the gradient from flowing backwards and thus we never move towards any meaningful visualization. To solve this problem, we can replace the ReLU layers in a model with a special version of ReLU called `RedirectedReLU`. The `RedirectedReLU` layer allows the gradient to flow temporarily in these zero gradient situations.\n",
+        "\n",
+        "Below we use the `opt.models.replace_layers` function to replace all instances of `nn.ReLU` in our test model with `opt.models.RedirectedReluLayer`."
+      ],
+      "metadata": {
+        "id": "MlGvyhd0AalX"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "relu_model = Model().eval().to(device)\n",
+        "\n",
+        "# Replace the ReLU with RedirectedReluLayer\n",
+        "opt.models.replace_layers(\n",
+        "    relu_model, layer1=torch.nn.ReLU, layer2=opt.models.RedirectedReluLayer\n",
+        ")\n",
+        "\n",
+        "print(relu_model)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4w34RcZU_DrU",
+        "outputId": "7f0adaf6-08a2-4ea9-f2c6-f69ee2f984e0"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model(\n",
+            "  (basic_module): Sequential(\n",
+            "    (0): Conv2d(3, 4, kernel_size=(3, 3), stride=(2, 2))\n",
+            "    (1): RedirectedReluLayer()\n",
+            "    (2): MaxPool2d(kernel_size=3, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+            "  )\n",
+            "  (conv): Conv2d(4, 4, kernel_size=(3, 3), stride=(2, 2))\n",
+            "  (relu): RedirectedReluLayer()\n",
+            "  (pooling): AdaptiveAvgPool2d(output_size=(2, 2))\n",
+            "  (linear): Linear(in_features=16, out_features=4, bias=True)\n",
+            ")\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Linear Operation Layers\n",
+        "\n",
+        "Certain functions like `opt.circuits.extract_expanded_weights` require using modules that only perform linear operations. This can become slightly more complicated when dealing with layers that have multiple preset set variables. Luckily the `opt.models.replace_layers` can easily handle these variable transfers if the `transfer_vars` variable is set to `True`.\n",
+        "\n",
+        "\n",
+        "Common linear layer replacements are as follows:\n",
+        "\n",
+        "* `nn.ReLU` layers need to be skipped, which can be done by replacing them with either `nn.Identity` or Captum's `SkipLayer` layer.\n",
+        "\n",
+        "* `nn.MaxPool2d` layers need to be converted to their linear `nn.AvgPool2d` layer equivalents.\n",
+        "\n",
+        "* `nn.AdaptiveMaxPool2d` layers need to be converted to their linear `nn.AdaptiveAvgPool2d` layer equivalents.\n",
+        "\n",
+        "Some of the layers which are already linear operations are:\n",
+        "\n",
+        "* `nn.BatchNorm2d` is linear when it's in evaluation mode (`.eval()`).\n",
+        "* `nn.Conv2d` is linear.\n",
+        "* `nn.Linear` is linear."
+      ],
+      "metadata": {
+        "id": "KJVG3KDC31dy"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "linear_only_model = Model().eval().to(device)\n",
+        "\n",
+        "# Replace MaxPool2d with AvgPool2d using the same settings\n",
+        "opt.models.replace_layers(\n",
+        "    linear_only_model,\n",
+        "    layer1=torch.nn.MaxPool2d,\n",
+        "    layer2=torch.nn.AvgPool2d,\n",
+        "    transfer_vars=True,\n",
+        ")\n",
+        "\n",
+        "# Replace the ReLU with Identity\n",
+        "opt.models.replace_layers(\n",
+        "    linear_only_model, layer1=torch.nn.ReLU, layer2=torch.nn.Identity\n",
+        ")\n",
+        "\n",
+        "print(linear_only_model)"
+      ],
+      "metadata": {
+        "id": "hYbm5Cg34She",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "564f94ff-4713-4b2d-c817-a7cd600786bb"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model(\n",
+            "  (basic_module): Sequential(\n",
+            "    (0): Conv2d(3, 4, kernel_size=(3, 3), stride=(2, 2))\n",
+            "    (1): Identity()\n",
+            "    (2): AvgPool2d(kernel_size=3, stride=2, padding=0)\n",
+            "  )\n",
+            "  (conv): Conv2d(4, 4, kernel_size=(3, 3), stride=(2, 2))\n",
+            "  (relu): Identity()\n",
+            "  (pooling): AdaptiveAvgPool2d(output_size=(2, 2))\n",
+            "  (linear): Linear(in_features=16, out_features=4, bias=True)\n",
+            ")\n"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I noticed a gap in our tutorials for how users can use their own models with the optim module. Bit and pieces of this information can be found across different tutorials, but these do no show how to prepare third party models. So, I created a simple tutorial notebook that teaches users the relevant model setup suggestions and requirements.