### PR TITLE
Fix linting, depreciations, & version checks

### DIFF
--- a/captum/optim/models/_common.py
+++ b/captum/optim/models/_common.py
@@ -73,7 +73,7 @@ def replace_layers(
     layer1: Type[nn.Module],
     layer2: Type[nn.Module],
     transfer_vars: bool = False,
-    **kwargs
+    **kwargs,
 ) -> None:
     """
     Replace all target layers with new layers inside the specified model,

--- a/captum/optim/models/_image/inception_v1.py
+++ b/captum/optim/models/_image/inception_v1.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Type, Union
+from typing import Any, Optional, Tuple, Type, Union
 from warnings import warn
 
 import torch
@@ -16,7 +16,7 @@ def googlenet(
     pretrained: bool = False,
     progress: bool = True,
     model_path: Optional[str] = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> "InceptionV1":
     r"""GoogLeNet (also known as Inception v1 & Inception 5h) model architecture from
     `"Going Deeper with Convolutions" <http://arxiv.org/abs/1409.4842>`_.

--- a/captum/optim/models/_image/inception_v1.py
+++ b/captum/optim/models/_image/inception_v1.py
@@ -16,7 +16,7 @@ def googlenet(
     pretrained: bool = False,
     progress: bool = True,
     model_path: Optional[str] = None,
-    **kwargs
+    **kwargs,
 ) -> "InceptionV1":
     r"""GoogLeNet (also known as Inception v1 & Inception 5h) model architecture from
     `"Going Deeper with Convolutions" <http://arxiv.org/abs/1409.4842>`_.

--- a/captum/optim/models/_image/inception_v1_places365.py
+++ b/captum/optim/models/_image/inception_v1_places365.py
@@ -16,7 +16,7 @@ def googlenet_places365(
     pretrained: bool = False,
     progress: bool = True,
     model_path: Optional[str] = None,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> "InceptionV1Places365":
     r"""GoogLeNet (also known as Inception v1 & Inception 5h) model architecture from
     `"Going Deeper with Convolutions" <http://arxiv.org/abs/1409.4842>`_.

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -144,8 +144,8 @@ class TestAngledNeuronDirection(BaseTest):
         )
         a = 1
         b = [CHANNEL_ACTIVATION_0_LOSS, CHANNEL_ACTIVATION_1_LOSS]
-        dot = np.sum(np.inner(a, b))
-        self.assertAlmostEqual(np.sum(get_loss_value(model, loss)), dot, places=6)
+        dot = torch.sum(torch.as_tensor(np.inner(a, b)))
+        self.assertAlmostEqual(torch.sum(get_loss_value(model, loss)), dot, places=6)
 
     def test_angled_neuron_direction_whitened(self) -> None:
         model = BasicModel_ConvNet_Optim()
@@ -157,8 +157,8 @@ class TestAngledNeuronDirection(BaseTest):
         )
         a = 1
         b = [CHANNEL_ACTIVATION_0_LOSS, CHANNEL_ACTIVATION_1_LOSS]
-        dot = np.sum(np.inner(a, b)) * 2
-        self.assertAlmostEqual(np.sum(get_loss_value(model, loss)), dot, places=6)
+        dot = torch.sum(torch.as_tensor(np.inner(a, b))) * 2
+        self.assertAlmostEqual(torch.sum(get_loss_value(model, loss)), dot, places=6)
 
 
 class TestTensorDirection(BaseTest):

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -28,10 +28,11 @@ class TestDeepDream(BaseTest):
     def test_channel_deepdream(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = opt_loss.DeepDream(model.layer)
+        expected = torch.as_tensor[[[CHANNEL_ACTIVATION_0_LOSS ** 2]], [[CHANNEL_ACTIVATION_1_LOSS ** 2]]])
         assertTensorAlmostEqual(
             self,
-            get_loss_value(model, loss)[None, :],
-            [[[CHANNEL_ACTIVATION_0_LOSS ** 2]], [[CHANNEL_ACTIVATION_1_LOSS ** 2]]],
+            get_loss_value(model, loss),
+            expected,
             mode="max"
         )
 

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -174,7 +174,7 @@ class TestActivationWeights(BaseTest):
     def test_activation_weights_0(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = opt_loss.ActivationWeights(model.layer, weights=torch.zeros(1))
-        assertTensorAlmostEqual(self, get_loss_value(model, loss), torch.zeros((1, 2, 1)), mode="max")
+        assertTensorAlmostEqual(self, get_loss_value(model, loss), torch.zeros(1, 1, 2, 1), mode="max")
 
     def test_activation_weights_1(self) -> None:
         model = BasicModel_ConvNet_Optim()

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -15,7 +15,7 @@ CHANNEL_ACTIVATION_1_LOSS = 1.3
 
 def get_loss_value(
     model: torch.nn.Module, loss: opt_loss.Loss, input_shape: List[int] = [1, 3, 1, 1]
-) -> Union[int, float, np.ndarray]:
+) -> Union[int, float]:
     module_outputs = collect_activations(model, loss.target, torch.ones(*input_shape))
     loss_value = loss(module_outputs)
     try:
@@ -30,7 +30,7 @@ class TestDeepDream(BaseTest):
         loss = opt_loss.DeepDream(model.layer)
         assertTensorAlmostEqual(
             self,
-            get_loss_value(model, loss),
+            get_loss_value(model, loss)[None, :],
             [[[CHANNEL_ACTIVATION_0_LOSS ** 2]], [[CHANNEL_ACTIVATION_1_LOSS ** 2]]],
             mode="max"
         )

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -173,7 +173,7 @@ class TestActivationWeights(BaseTest):
         model = BasicModel_ConvNet_Optim()
         loss = opt_loss.ActivationWeights(model.layer, weights=torch.zeros(1))
         assertTensorAlmostEqual(
-            self, get_loss_value(model, loss), torch.zeros(1, 1, 2, 1), mode="max"
+            self, get_loss_value(model, loss), torch.zeros(1, 2, 1, 1), mode="max"
         )
 
     def test_activation_weights_1(self) -> None:

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -28,7 +28,7 @@ class TestDeepDream(BaseTest):
     def test_channel_deepdream(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = opt_loss.DeepDream(model.layer)
-        expected = torch.as_tensor[[[CHANNEL_ACTIVATION_0_LOSS ** 2]], [[CHANNEL_ACTIVATION_1_LOSS ** 2]]])
+        expected = torch.as_tensor([[[CHANNEL_ACTIVATION_0_LOSS ** 2]], [[CHANNEL_ACTIVATION_1_LOSS ** 2]]])
         assertTensorAlmostEqual(
             self,
             get_loss_value(model, loss),

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -30,7 +30,7 @@ class TestDeepDream(BaseTest):
         loss = opt_loss.DeepDream(model.layer)
         expected = torch.as_tensor(
             [[[CHANNEL_ACTIVATION_0_LOSS ** 2]], [[CHANNEL_ACTIVATION_1_LOSS ** 2]]]
-        )
+        )[None, :]
         assertTensorAlmostEqual(self, get_loss_value(model, loss), expected, mode="max")
 
 

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -141,8 +141,8 @@ class TestAngledNeuronDirection(BaseTest):
         )
         a = 1
         b = [CHANNEL_ACTIVATION_0_LOSS, CHANNEL_ACTIVATION_1_LOSS]
-        dot = torch.sum(torch.as_tensor(np.inner(a, b)))
-        self.assertAlmostEqual(torch.sum(get_loss_value(model, loss)), dot, places=6)
+        dot = torch.sum(torch.as_tensor(np.inner(a, b))).item()
+        self.assertAlmostEqual(torch.sum(get_loss_value(model, loss)).item(), dot, places=6)
 
     def test_angled_neuron_direction_whitened(self) -> None:
         model = BasicModel_ConvNet_Optim()
@@ -154,8 +154,8 @@ class TestAngledNeuronDirection(BaseTest):
         )
         a = 1
         b = [CHANNEL_ACTIVATION_0_LOSS, CHANNEL_ACTIVATION_1_LOSS]
-        dot = torch.sum(torch.as_tensor(np.inner(a, b))) * 2
-        self.assertAlmostEqual(torch.sum(get_loss_value(model, loss)), dot, places=6)
+        dot = torch.sum(torch.as_tensor(np.inner(a, b))).item() * 2
+        self.assertAlmostEqual(torch.sum(get_loss_value(model, loss)).item(), dot, places=6)
 
 
 class TestTensorDirection(BaseTest):

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -28,9 +28,11 @@ class TestDeepDream(BaseTest):
     def test_channel_deepdream(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = opt_loss.DeepDream(model.layer)
-        assertArraysAlmostEqual(
+        assertTensorAlmostEqual(
+            self,
             get_loss_value(model, loss),
             [[[CHANNEL_ACTIVATION_0_LOSS ** 2]], [[CHANNEL_ACTIVATION_1_LOSS ** 2]]],
+            mode="max"
         )
 
 

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -6,7 +6,7 @@ import torch
 
 import captum.optim._core.loss as opt_loss
 from captum.optim.models import collect_activations
-from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.helpers.basic_models import BasicModel_ConvNet_Optim
 
 CHANNEL_ACTIVATION_0_LOSS = 1.3
@@ -21,7 +21,7 @@ def get_loss_value(
     try:
         return loss_value.item()
     except ValueError:
-        return loss_value.detach().numpy()
+        return loss_value.detach()
 
 
 class TestDeepDream(BaseTest):
@@ -172,16 +172,18 @@ class TestActivationWeights(BaseTest):
     def test_activation_weights_0(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = opt_loss.ActivationWeights(model.layer, weights=torch.zeros(1))
-        assertArraysAlmostEqual(get_loss_value(model, loss), np.zeros((1, 2, 1)))
+        assertTensorAlmostEqual(self, get_loss_value(model, loss), torch.zeros((1, 2, 1)), mode="max")
 
     def test_activation_weights_1(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = opt_loss.ActivationWeights(
             model.layer, weights=torch.ones(1), neuron=True
         )
-        assertArraysAlmostEqual(
+        assertTensorAlmostEqual(
+            self,
             get_loss_value(model, loss),
             [CHANNEL_ACTIVATION_0_LOSS, CHANNEL_ACTIVATION_1_LOSS],
+            mode="max",
         )
 
 

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -142,7 +142,9 @@ class TestAngledNeuronDirection(BaseTest):
         a = 1
         b = [CHANNEL_ACTIVATION_0_LOSS, CHANNEL_ACTIVATION_1_LOSS]
         dot = torch.sum(torch.as_tensor(np.inner(a, b))).item()
-        self.assertAlmostEqual(torch.sum(get_loss_value(model, loss)).item(), dot, places=6)
+        self.assertAlmostEqual(
+            torch.sum(get_loss_value(model, loss)).item(), dot, places=6
+        )
 
     def test_angled_neuron_direction_whitened(self) -> None:
         model = BasicModel_ConvNet_Optim()
@@ -155,7 +157,9 @@ class TestAngledNeuronDirection(BaseTest):
         a = 1
         b = [CHANNEL_ACTIVATION_0_LOSS, CHANNEL_ACTIVATION_1_LOSS]
         dot = torch.sum(torch.as_tensor(np.inner(a, b))).item() * 2
-        self.assertAlmostEqual(torch.sum(get_loss_value(model, loss)).item(), dot, places=6)
+        self.assertAlmostEqual(
+            torch.sum(get_loss_value(model, loss)).item(), dot, places=6
+        )
 
 
 class TestTensorDirection(BaseTest):

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -28,13 +28,10 @@ class TestDeepDream(BaseTest):
     def test_channel_deepdream(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = opt_loss.DeepDream(model.layer)
-        expected = torch.as_tensor([[[CHANNEL_ACTIVATION_0_LOSS ** 2]], [[CHANNEL_ACTIVATION_1_LOSS ** 2]]])
-        assertTensorAlmostEqual(
-            self,
-            get_loss_value(model, loss),
-            expected,
-            mode="max"
+        expected = torch.as_tensor(
+            [[[CHANNEL_ACTIVATION_0_LOSS ** 2]], [[CHANNEL_ACTIVATION_1_LOSS ** 2]]]
         )
+        assertTensorAlmostEqual(self, get_loss_value(model, loss), expected, mode="max")
 
 
 class TestChannelActivation(BaseTest):
@@ -175,7 +172,9 @@ class TestActivationWeights(BaseTest):
     def test_activation_weights_0(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = opt_loss.ActivationWeights(model.layer, weights=torch.zeros(1))
-        assertTensorAlmostEqual(self, get_loss_value(model, loss), torch.zeros(1, 1, 2, 1), mode="max")
+        assertTensorAlmostEqual(
+            self, get_loss_value(model, loss), torch.zeros(1, 1, 2, 1), mode="max"
+        )
 
     def test_activation_weights_1(self) -> None:
         model = BasicModel_ConvNet_Optim()

--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -15,7 +15,7 @@ CHANNEL_ACTIVATION_1_LOSS = 1.3
 
 def get_loss_value(
     model: torch.nn.Module, loss: opt_loss.Loss, input_shape: List[int] = [1, 3, 1, 1]
-) -> Union[int, float]:
+) -> Union[int, float, np.ndarray]:
     module_outputs = collect_activations(model, loss.target, torch.ones(*input_shape))
     loss_value = loss(module_outputs)
     try:

--- a/tests/optim/core/test_optimization.py
+++ b/tests/optim/core/test_optimization.py
@@ -10,10 +10,6 @@ from tests.helpers.basic_models import BasicModel_ConvNet_Optim
 
 class TestInputOptimization(BaseTest):
     def test_input_optimization(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping InputOptimization test due to insufficient Torch version."
-            )
         model = BasicModel_ConvNet_Optim()
         loss_fn = opt.loss.ChannelActivation(model.layer, 0)
         obj = opt.InputOptimization(model, loss_function=loss_fn)
@@ -24,10 +20,6 @@ class TestInputOptimization(BaseTest):
 
     def test_input_optimization_param(self) -> None:
         """Test for optimizing param without model"""
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping InputOptimization test due to insufficient Torch version."
-            )
         img_param = opt.images.NaturalImage()
         loss_fn = opt.loss.ChannelActivation(img_param, 0)
         # Use torch.nn.Identity as placeholder for non-model optimization

--- a/tests/optim/core/test_optimization.py
+++ b/tests/optim/core/test_optimization.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-import unittest
-
 import torch
 
 import captum.optim as opt

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import unittest
 from typing import cast
 
 import torch

--- a/tests/optim/core/test_output_hook.py
+++ b/tests/optim/core/test_output_hook.py
@@ -11,10 +11,6 @@ from tests.helpers.basic import BaseTest
 
 class TestActivationFetcher(BaseTest):
     def test_activation_fetcher(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping ActivationFetcher test due to insufficient Torch version."
-            )
         model = googlenet(pretrained=True)
 
         catch_activ = output_hook.ActivationFetcher(model, targets=[model.mixed4d])

--- a/tests/optim/models/test_inceptionv1.py
+++ b/tests/optim/models/test_inceptionv1.py
@@ -11,30 +11,15 @@ from tests.optim.helpers.models import check_layer_in_model
 
 class TestInceptionV1(BaseTest):
     def test_load_inceptionv1_with_redirected_relu(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping load pretrained inception"
-                + " due to insufficient Torch version."
-            )
         model = googlenet(pretrained=True, replace_relus_with_redirectedrelu=True)
         self.assertTrue(check_layer_in_model(model, RedirectedReluLayer))
 
     def test_load_inceptionv1_no_redirected_relu(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping load pretrained inception RedirectedRelu"
-                + " due to insufficient Torch version."
-            )
         model = googlenet(pretrained=True, replace_relus_with_redirectedrelu=False)
         self.assertFalse(check_layer_in_model(model, RedirectedReluLayer))
         self.assertTrue(check_layer_in_model(model, torch.nn.ReLU))
 
     def test_load_inceptionv1_linear(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping load pretrained inception linear"
-                + " due to insufficient Torch version."
-            )
         model = googlenet(pretrained=True, use_linear_modules_only=True)
         self.assertFalse(check_layer_in_model(model, RedirectedReluLayer))
         self.assertFalse(check_layer_in_model(model, torch.nn.ReLU))
@@ -43,11 +28,6 @@ class TestInceptionV1(BaseTest):
         self.assertTrue(check_layer_in_model(model, torch.nn.AvgPool2d))
 
     def test_transform_inceptionv1(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping inceptionV1 internal transform"
-                + " due to insufficient Torch version."
-            )
         x = torch.randn(1, 3, 224, 224).clamp(0, 1)
         model = googlenet(pretrained=True)
         output = model._transform_input(x)
@@ -55,11 +35,6 @@ class TestInceptionV1(BaseTest):
         assertTensorAlmostEqual(self, output, expected_output, 0)
 
     def test_inceptionv1_transform_warning(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping InceptionV1 internal transform warning test due to"
-                + " insufficient Torch version."
-            )
         x = torch.stack(
             [torch.ones(3, 112, 112) * -1, torch.ones(3, 112, 112) * 2], dim=0
         )
@@ -68,11 +43,6 @@ class TestInceptionV1(BaseTest):
             model._transform_input(x)
 
     def test_transform_bgr_inceptionv1(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping inceptionV1 internal transform"
-                + " BGR due to insufficient Torch version."
-            )
         x = torch.randn(1, 3, 224, 224).clamp(0, 1)
         model = googlenet(pretrained=True, bgr_transform=True)
         output = model._transform_input(x)
@@ -80,11 +50,6 @@ class TestInceptionV1(BaseTest):
         assertTensorAlmostEqual(self, output, expected_output, 0)
 
     def test_load_and_forward_basic_inceptionv1(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping basic pretrained inceptionV1 forward"
-                + " due to insufficient Torch version."
-            )
         x = torch.randn(1, 3, 224, 224).clamp(0, 1)
         model = googlenet(pretrained=True)
         try:
@@ -95,11 +60,6 @@ class TestInceptionV1(BaseTest):
         self.assertTrue(test)
 
     def test_load_and_forward_diff_sizes_inceptionv1(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping pretrained inceptionV1 forward with different sized inputs"
-                + " due to insufficient Torch version."
-            )
         x = torch.randn(1, 3, 512, 512).clamp(0, 1)
         x2 = torch.randn(1, 3, 383, 511).clamp(0, 1)
         model = googlenet(pretrained=True)
@@ -112,22 +72,12 @@ class TestInceptionV1(BaseTest):
         self.assertTrue(test)
 
     def test_forward_aux_inceptionv1(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping pretrained inceptionV1 with aux logits forward"
-                + " due to insufficient Torch version."
-            )
         x = torch.randn(1, 3, 224, 224).clamp(0, 1)
         model = googlenet(pretrained=False, aux_logits=True)
         outputs = model(x)
         self.assertEqual(len(outputs), 3)
 
     def test_inceptionv1_forward_cuda(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping pretrained InceptionV1 forward CUDA test due to insufficient"
-                + " Torch version."
-            )
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
                 "Skipping pretrained InceptionV1 forward CUDA test due to not"

--- a/tests/optim/models/test_models_common.py
+++ b/tests/optim/models/test_models_common.py
@@ -85,10 +85,6 @@ class TestReplaceLayers(BaseTest):
 
 class TestGetLayers(BaseTest):
     def test_get_layers_pretrained_inceptionv1(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping get_layers test due to insufficient Torch version."
-            )
         expected_list = [
             "conv1",
             "conv1_relu",
@@ -248,10 +244,6 @@ class TestGetLayers(BaseTest):
 
 class TestCollectActivations(BaseTest):
     def test_collect_activations(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping collect_activations test due to insufficient Torch version."
-            )
         model = googlenet(pretrained=True)
 
         activ_out = model_utils.collect_activations(

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -381,7 +381,7 @@ class TestPixelImage(BaseTest):
         self.assertEqual(image_param.image.size(1), channels)
         self.assertEqual(image_param.image.size(2), size[0])
         self.assertEqual(image_param.image.size(3), size[1])
-        assertTensorAlmostEqual(self, image_param.image, init_tensor, 0)
+        assertTensorAlmostEqual(self, image_param.image, init_tensor[None, :], 0)
         self.assertTrue(image_param.image.requires_grad)
 
     def test_pixelimage_init_error(self) -> None:

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -88,7 +88,9 @@ class TestFFTImage(BaseTest):
     def test_pytorch_fftfreq(self) -> None:
         image = images.FFTImage((1, 1))
         _, _, fftfreq = image.get_fft_funcs()
-        assertTensorAlmostEqual(self, fftfreq(4, 4), torch.as_tensor(np.fft.fftfreq(4, 4)), mode="max")
+        assertTensorAlmostEqual(
+            self, fftfreq(4, 4), torch.as_tensor(np.fft.fftfreq(4, 4)), mode="max"
+        )
 
     def test_rfft2d_freqs(self) -> None:
         height = 2
@@ -303,7 +305,9 @@ class TestFFTImage(BaseTest):
 
         self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
-        assertTensorAlmostEqual(self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max")
+        assertTensorAlmostEqual(
+            self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max"
+        )
 
     def test_fftimage_forward_init_bchw(self) -> None:
         size = (224, 224)
@@ -318,7 +322,9 @@ class TestFFTImage(BaseTest):
 
         self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
-        assertTensorAlmostEqual(self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max")
+        assertTensorAlmostEqual(
+            self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max"
+        )
 
     def test_fftimage_forward_init_batch(self) -> None:
         size = (224, 224)
@@ -334,7 +340,9 @@ class TestFFTImage(BaseTest):
 
         self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
-        assertTensorAlmostEqual(self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max")
+        assertTensorAlmostEqual(
+            self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max"
+        )
 
 
 class TestPixelImage(BaseTest):
@@ -742,7 +750,9 @@ class TestNaturalImage(BaseTest):
     def test_natural_image_0(self) -> None:
         image_param = images.NaturalImage(size=(1, 1))
         image = image_param.forward().detach()
-        assertTensorAlmostEqual(self, image, torch.ones_like(image) * 0.5, mode="max", delta=0.001)
+        assertTensorAlmostEqual(
+            self, image, torch.ones_like(image) * 0.5, mode="max", delta=0.001
+        )
 
     def test_natural_image_1(self) -> None:
         image_param = images.NaturalImage(init=torch.ones(3, 1, 1))

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -291,10 +291,6 @@ class TestFFTImage(BaseTest):
         self.assertEqual(list(fftimage_tensor.shape), [1, 3, 512, 405])
 
     def test_fftimage_forward_init_chw(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping FFTImage test due to insufficient Torch version."
-            )
         size = (224, 224)
         init_tensor = torch.randn(1, 3, 224, 224)
         init_array = init_tensor.numpy()
@@ -310,10 +306,6 @@ class TestFFTImage(BaseTest):
         assertTensorAlmostEqual(self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max")
 
     def test_fftimage_forward_init_bchw(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping FFTImage test due to insufficient Torch version."
-            )
         size = (224, 224)
         init_tensor = torch.randn(1, 3, 224, 224)
         init_array = init_tensor.numpy()
@@ -329,10 +321,6 @@ class TestFFTImage(BaseTest):
         assertTensorAlmostEqual(self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max")
 
     def test_fftimage_forward_init_batch(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping FFTImage test due to insufficient Torch version."
-            )
         size = (224, 224)
         batch = 2
         init_tensor = torch.randn(1, 3, 224, 224)
@@ -351,10 +339,6 @@ class TestFFTImage(BaseTest):
 
 class TestPixelImage(BaseTest):
     def test_pixelimage_random(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping PixelImage random due to insufficient Torch version."
-            )
         size = (224, 224)
         channels = 3
         image_param = images.PixelImage(size=size, channels=channels)
@@ -367,10 +351,6 @@ class TestPixelImage(BaseTest):
         self.assertTrue(image_param.image.requires_grad)
 
     def test_pixelimage_init(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping PixelImage init due to insufficient Torch version."
-            )
         size = (224, 224)
         channels = 3
         init_tensor = torch.randn(channels, *size)
@@ -385,10 +365,6 @@ class TestPixelImage(BaseTest):
         self.assertTrue(image_param.image.requires_grad)
 
     def test_pixelimage_init_error(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping PixelImage init due to insufficient Torch version."
-            )
         size = (224, 224)
         channels = 2
         init_tensor = torch.randn(channels, *size)
@@ -396,10 +372,6 @@ class TestPixelImage(BaseTest):
             images.PixelImage(size=size, channels=channels, init=init_tensor)
 
     def test_pixelimage_random_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping PixelImage random due to insufficient Torch version."
-            )
         size = (224, 224)
         channels = 3
         image_param = images.PixelImage(size=size, channels=channels)
@@ -423,10 +395,6 @@ class TestPixelImage(BaseTest):
         self.assertTrue(torch.is_tensor(output_tensor))
 
     def test_pixelimage_init_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping PixelImage init due to insufficient Torch version."
-            )
         size = (224, 224)
         channels = 3
         init_tensor = torch.randn(3, 224, 224)
@@ -443,10 +411,6 @@ class TestPixelImage(BaseTest):
 
 class TestLaplacianImage(BaseTest):
     def test_laplacianimage_random_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping LaplacianImage random due to insufficient Torch version."
-            )
         size = (224, 224)
         channels = 3
         image_param = images.LaplacianImage(size=size, channels=channels)
@@ -459,10 +423,6 @@ class TestLaplacianImage(BaseTest):
         self.assertEqual(test_tensor.size(3), size[1])
 
     def test_laplacianimage_init(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping LaplacianImage random due to insufficient Torch version."
-            )
         init_t = torch.zeros(1, 224, 224)
         image_param = images.LaplacianImage(size=(224, 224), channels=3, init=init_t)
         output = image_param.forward().detach()
@@ -471,10 +431,6 @@ class TestLaplacianImage(BaseTest):
 
 class TestSharedImage(BaseTest):
     def test_sharedimage_get_offset_single_number(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
         shared_shapes = (128 // 2, 128 // 2)
         test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
         image_param = images.SharedImage(
@@ -487,10 +443,6 @@ class TestSharedImage(BaseTest):
         self.assertEqual(offset, [[4, 4, 4, 4]] * 3)
 
     def test_sharedimage_get_offset_exact(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
         shared_shapes = (128 // 2, 128 // 2)
         test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
         image_param = images.SharedImage(
@@ -504,10 +456,6 @@ class TestSharedImage(BaseTest):
         self.assertEqual(offset, [[int(o) for o in v] for v in offset_vals])
 
     def test_sharedimage_get_offset_single_set_four_numbers(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
         shared_shapes = (128 // 2, 128 // 2)
         test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
         image_param = images.SharedImage(
@@ -521,10 +469,6 @@ class TestSharedImage(BaseTest):
         self.assertEqual(offset, [list(offset_vals)] * 3)
 
     def test_sharedimage_get_offset_single_set_three_numbers(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
         shared_shapes = (128 // 2, 128 // 2)
         test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
         image_param = images.SharedImage(
@@ -538,10 +482,6 @@ class TestSharedImage(BaseTest):
         self.assertEqual(offset, [[0] + list(offset_vals)] * 3)
 
     def test_sharedimage_get_offset_single_set_two_numbers(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
         shared_shapes = (128 // 2, 128 // 2)
         test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
         image_param = images.SharedImage(
@@ -579,10 +519,6 @@ class TestSharedImage(BaseTest):
         return A
 
     def test_apply_offset(self):
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
         size = (4, 3, 224, 224)
         shared_shapes = (128 // 2, 128 // 2)
         offset_vals = (2, 3, 4, 5)
@@ -604,10 +540,6 @@ class TestSharedImage(BaseTest):
             assertTensorAlmostEqual(self, t_expected, t_output)
 
     def test_interpolate_tensor(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
         shared_shapes = (128 // 2, 128 // 2)
         test_param = lambda: torch.ones(3, 3, 224, 224)  # noqa: E731
         image_param = images.SharedImage(
@@ -630,11 +562,6 @@ class TestSharedImage(BaseTest):
         self.assertEqual(output_tensor.size(3), size[1])
 
     def test_sharedimage_single_shape_hw_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
-
         shared_shapes = (128 // 2, 128 // 2)
         batch = 6
         channels = 3
@@ -657,11 +584,6 @@ class TestSharedImage(BaseTest):
         self.assertEqual(test_tensor.size(3), size[1])
 
     def test_sharedimage_single_shape_chw_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
-
         shared_shapes = (3, 128 // 2, 128 // 2)
         batch = 6
         channels = 3
@@ -684,11 +606,6 @@ class TestSharedImage(BaseTest):
         self.assertEqual(test_tensor.size(3), size[1])
 
     def test_sharedimage_single_shape_bchw_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
-
         shared_shapes = (1, 3, 128 // 2, 128 // 2)
         batch = 6
         channels = 3
@@ -709,11 +626,6 @@ class TestSharedImage(BaseTest):
         self.assertEqual(test_tensor.size(3), size[1])
 
     def test_sharedimage_multiple_shapes_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
-
         shared_shapes = (
             (1, 3, 128 // 2, 128 // 2),
             (1, 3, 128 // 4, 128 // 4),
@@ -744,11 +656,6 @@ class TestSharedImage(BaseTest):
         self.assertEqual(test_tensor.size(3), size[1])
 
     def test_sharedimage_multiple_shapes_diff_len_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping SharedImage test due to insufficient Torch version."
-            )
-
         shared_shapes = (
             (128 // 2, 128 // 2),
             (7, 3, 128 // 4, 128 // 4),
@@ -782,34 +689,18 @@ class TestSharedImage(BaseTest):
 
 class TestNaturalImage(BaseTest):
     def test_natural_image_init_func_default(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping NaturalImage FFTImage init func test due to insufficient"
-                + " Torch version."
-            )
         image_param = images.NaturalImage(size=(4, 4))
         self.assertIsInstance(image_param.parameterization, images.FFTImage)
         self.assertIsInstance(image_param.decorrelate, ToRGB)
         self.assertEqual(image_param.squash_func, torch.sigmoid)
 
     def test_natural_image_init_func_fftimage(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping NaturalImage FFTImage init func test due to insufficient"
-                + " Torch version."
-            )
         image_param = images.NaturalImage(size=(4, 4), parameterization=images.FFTImage)
         self.assertIsInstance(image_param.parameterization, images.FFTImage)
         self.assertIsInstance(image_param.decorrelate, ToRGB)
         self.assertEqual(image_param.squash_func, torch.sigmoid)
 
     def test_natural_image_init_func_fftimage_instance(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping NaturalImage FFTImage init func FFTImage instance test due"
-                + " to insufficient Torch version."
-            )
-
         fft_param = images.FFTImage(size=(4, 4))
         image_param = images.NaturalImage(parameterization=fft_param)
         self.assertIsInstance(image_param.parameterization, images.FFTImage)
@@ -817,11 +708,6 @@ class TestNaturalImage(BaseTest):
         self.assertEqual(image_param.squash_func, torch.sigmoid)
 
     def test_natural_image_init_func_pixelimage(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping NaturalImage PixelImage init func test due to insufficient"
-                + " Torch version."
-            )
         image_param = images.NaturalImage(
             size=(4, 4), parameterization=images.PixelImage
         )
@@ -830,11 +716,6 @@ class TestNaturalImage(BaseTest):
         self.assertEqual(image_param.squash_func, torch.sigmoid)
 
     def test_natural_image_init_func_default_init_tensor(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping NaturalImage FFTImage init func test due to insufficient"
-                + " Torch version."
-            )
         image_param = images.NaturalImage(init=torch.ones(1, 3, 1, 1))
         self.assertIsInstance(image_param.parameterization, images.FFTImage)
         self.assertIsInstance(image_param.decorrelate, ToRGB)
@@ -859,19 +740,11 @@ class TestNaturalImage(BaseTest):
         )
 
     def test_natural_image_0(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping NaturalImage test due to insufficient Torch version."
-            )
         image_param = images.NaturalImage(size=(1, 1))
         image = image_param.forward().detach()
         assertTensorAlmostEqual(self, image, torch.ones_like(image) * 0.5, mode="max")
 
     def test_natural_image_1(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping NaturalImage test due to insufficient Torch version."
-            )
         image_param = images.NaturalImage(init=torch.ones(3, 1, 1))
         image = image_param.forward().detach()
         assertTensorAlmostEqual(self, image, torch.ones_like(image), mode="max")
@@ -920,10 +793,6 @@ class TestNaturalImage(BaseTest):
         assertTensorAlmostEqual(self, output_tensor, torch.ones_like(output_tensor))
 
     def test_natural_image_decorrelation_module_none(self) -> None:
-        if torch.__version__ <= "1.3.0":
-            raise unittest.SkipTest(
-                "Skipping NaturalImage test due to insufficient Torch version."
-            )
         image_param = images.NaturalImage(
             init=torch.ones(1, 3, 4, 4), decorrelation_module=None
         )

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -70,7 +70,7 @@ class TestImageTensor(BaseTest):
 
         filename = "image_tensor.jpg"
         image_tensor.export(filename)
-        new_tensor = images.ImageTensor().open(filename)
+        new_tensor = images.ImageTensor().open(filename)[None, :]
 
         self.assertTrue(torch.is_tensor(new_tensor))
         assertTensorAlmostEqual(self, image_tensor, new_tensor)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -426,7 +426,7 @@ class TestLaplacianImage(BaseTest):
         init_t = torch.zeros(1, 224, 224)
         image_param = images.LaplacianImage(size=(224, 224), channels=3, init=init_t)
         output = image_param.forward().detach()
-        assertTensorAlmostEqual(torch.ones_like(output) * 0.5, output, mode="max")
+        assertTensorAlmostEqual(self, torch.ones_like(output) * 0.5, output, mode="max")
 
 
 class TestSharedImage(BaseTest):
@@ -742,7 +742,7 @@ class TestNaturalImage(BaseTest):
     def test_natural_image_0(self) -> None:
         image_param = images.NaturalImage(size=(1, 1))
         image = image_param.forward().detach()
-        assertTensorAlmostEqual(self, image, torch.ones_like(image) * 0.5, mode="max")
+        assertTensorAlmostEqual(self, image, torch.ones_like(image) * 0.5, mode="max", delta=0.001)
 
     def test_natural_image_1(self) -> None:
         image_param = images.NaturalImage(init=torch.ones(3, 1, 1))

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -438,7 +438,7 @@ class TestPixelImage(BaseTest):
         self.assertEqual(test_tensor.size(1), channels)
         self.assertEqual(test_tensor.size(2), size[0])
         self.assertEqual(test_tensor.size(3), size[1])
-        assertTensorAlmostEqual(self, test_tensor, init_tensor.squeeze(0), 0)
+        assertTensorAlmostEqual(self, test_tensor, init_tensor[None, :], 0)
 
 
 class TestLaplacianImage(BaseTest):

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -7,11 +7,7 @@ import torch
 
 from captum.optim._param.image import images
 from captum.optim._param.image.transforms import SymmetricPadding, ToRGB
-from tests.helpers.basic import (
-    BaseTest,
-    assertArraysAlmostEqual,
-    assertTensorAlmostEqual,
-)
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.optim.helpers import numpy_image
 
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -92,7 +92,7 @@ class TestFFTImage(BaseTest):
     def test_pytorch_fftfreq(self) -> None:
         image = images.FFTImage((1, 1))
         _, _, fftfreq = image.get_fft_funcs()
-        assertArraysAlmostEqual(fftfreq(4, 4).numpy(), np.fft.fftfreq(4, 4))
+        assertTensorAlmostEqual(self, fftfreq(4, 4), torch.as_tensor(np.fft.fftfreq(4, 4)), mode="max")
 
     def test_rfft2d_freqs(self) -> None:
         height = 2
@@ -311,7 +311,7 @@ class TestFFTImage(BaseTest):
 
         self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
-        assertArraysAlmostEqual(fftimage_tensor.detach().numpy(), fftimage_array, 25.0)
+        assertTensorAlmostEqual(self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max")
 
     def test_fftimage_forward_init_bchw(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -330,7 +330,7 @@ class TestFFTImage(BaseTest):
 
         self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
-        assertArraysAlmostEqual(fftimage_tensor.detach().numpy(), fftimage_array, 25.0)
+        assertTensorAlmostEqual(self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max")
 
     def test_fftimage_forward_init_batch(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -350,7 +350,7 @@ class TestFFTImage(BaseTest):
 
         self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
-        assertArraysAlmostEqual(fftimage_tensor.detach().numpy(), fftimage_array, 25.0)
+        assertTensorAlmostEqual(self, fftimage_tensor.detach(), fftimage_array, 25.0, mode="max")
 
 
 class TestPixelImage(BaseTest):
@@ -469,8 +469,8 @@ class TestLaplacianImage(BaseTest):
             )
         init_t = torch.zeros(1, 224, 224)
         image_param = images.LaplacianImage(size=(224, 224), channels=3, init=init_t)
-        test_np = image_param.forward().detach().numpy()
-        assertArraysAlmostEqual(np.ones_like(test_np) * 0.5, test_np)
+        output = image_param.forward().detach()
+        assertTensorAlmostEqual(torch.ones_like(output) * 0.5, output, mode="max")
 
 
 class TestSharedImage(BaseTest):
@@ -868,8 +868,8 @@ class TestNaturalImage(BaseTest):
                 "Skipping NaturalImage test due to insufficient Torch version."
             )
         image_param = images.NaturalImage(size=(1, 1))
-        image_np = image_param.forward().detach().numpy()
-        assertArraysAlmostEqual(image_np, np.ones_like(image_np) * 0.5)
+        image = image_param.forward().detach()
+        assertTensorAlmostEqual(self, image, torch.ones_like(image) * 0.5, mode="max")
 
     def test_natural_image_1(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -877,8 +877,8 @@ class TestNaturalImage(BaseTest):
                 "Skipping NaturalImage test due to insufficient Torch version."
             )
         image_param = images.NaturalImage(init=torch.ones(3, 1, 1))
-        image_np = image_param.forward().detach().numpy()
-        assertArraysAlmostEqual(image_np, np.ones_like(image_np))
+        image = image_param.forward().detach()
+        assertTensorAlmostEqual(self, image, torch.ones_like(image), mode="max")
 
     def test_natural_image_cuda(self) -> None:
         if not torch.cuda.is_available():

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -7,11 +7,7 @@ import torch
 import torch.nn.functional as F
 
 import captum.optim._param.image.transforms as transforms
-from tests.helpers.basic import (
-    BaseTest,
-    assertArraysAlmostEqual,
-    assertTensorAlmostEqual,
-)
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.optim.helpers import numpy_transforms
 
 
@@ -646,10 +642,11 @@ class TestRandomSpatialJitter(BaseTest):
 
         spatial_mod_np = numpy_transforms.RandomSpatialJitter(t_val)
         jittered_array = spatial_mod_np.translate_array(np.eye(4, 4), translate_vals)
+        jittered_array = torch.as_tensor(jittered_array)
 
-        assertArraysAlmostEqual(jittered_tensor[0].numpy(), jittered_array, 0)
-        assertArraysAlmostEqual(jittered_tensor[1].numpy(), jittered_array, 0)
-        assertArraysAlmostEqual(jittered_tensor[2].numpy(), jittered_array, 0)
+        assertTensorAlmostEqual(self, jittered_tensor[0], jittered_array, 0, mode="max")
+        assertTensorAlmostEqual(self, jittered_tensor[1], jittered_array, 0, mode="max")
+        assertTensorAlmostEqual(self, jittered_tensor[2], jittered_array, 0, mode="max")
 
     def test_random_spatial_jitter_w(self) -> None:
         translate_vals = [0, 3]
@@ -663,10 +660,11 @@ class TestRandomSpatialJitter(BaseTest):
 
         spatial_mod_np = numpy_transforms.RandomSpatialJitter(t_val)
         jittered_array = spatial_mod_np.translate_array(np.eye(4, 4), translate_vals)
+        jittered_array = torch.as_tensor(jittered_array)
 
-        assertArraysAlmostEqual(jittered_tensor[0].numpy(), jittered_array, 0)
-        assertArraysAlmostEqual(jittered_tensor[1].numpy(), jittered_array, 0)
-        assertArraysAlmostEqual(jittered_tensor[2].numpy(), jittered_array, 0)
+        assertTensorAlmostEqual(self, jittered_tensor[0], jittered_array, 0, mode="max")
+        assertTensorAlmostEqual(self, jittered_tensor[1], jittered_array, 0, mode="max")
+        assertTensorAlmostEqual(self, jittered_tensor[2], jittered_array, 0, mode="max")
 
     def test_random_spatial_jitter_h(self) -> None:
         translate_vals = [3, 0]
@@ -680,10 +678,11 @@ class TestRandomSpatialJitter(BaseTest):
 
         spatial_mod_np = numpy_transforms.RandomSpatialJitter(t_val)
         jittered_array = spatial_mod_np.translate_array(np.eye(4, 4), translate_vals)
+        jittered_array = torch.as_tensor(jittered_array)
 
-        assertArraysAlmostEqual(jittered_tensor[0].numpy(), jittered_array, 0)
-        assertArraysAlmostEqual(jittered_tensor[1].numpy(), jittered_array, 0)
-        assertArraysAlmostEqual(jittered_tensor[2].numpy(), jittered_array, 0)
+        assertTensorAlmostEqual(self, jittered_tensor[0], jittered_array, 0, mode="max")
+        assertTensorAlmostEqual(self, jittered_tensor[1], jittered_array, 0, mode="max")
+        assertTensorAlmostEqual(self, jittered_tensor[2], jittered_array, 0, mode="max")
 
     def test_random_spatial_jitter_forward(self) -> None:
         t_val = 3
@@ -731,8 +730,9 @@ class TestCenterCrop(BaseTest):
 
         crop_mod_np = numpy_transforms.CenterCrop(crop_vals, True)
         cropped_array = crop_mod_np.forward(test_tensor.numpy())
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
         ).unsqueeze(0)
@@ -750,8 +750,9 @@ class TestCenterCrop(BaseTest):
 
         crop_mod_np = numpy_transforms.CenterCrop(crop_vals, True)
         cropped_array = crop_mod_np.forward(test_tensor.numpy())
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
         )
@@ -772,8 +773,9 @@ class TestCenterCrop(BaseTest):
 
         crop_mod_np = numpy_transforms.CenterCrop(crop_vals, True)
         cropped_array = crop_mod_np.forward(test_tensor.numpy())
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
         ).unsqueeze(0)
@@ -805,8 +807,9 @@ class TestCenterCrop(BaseTest):
 
         crop_mod_np = numpy_transforms.CenterCrop(crop_vals, True)
         cropped_array = crop_mod_np.forward(test_tensor.numpy())
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [torch.stack([torch.tensor([1.0, 0.0, 1.0, 1.0, 0.0, 1.0])] * 2)] * 3
         ).unsqueeze(0)
@@ -827,8 +830,9 @@ class TestCenterCrop(BaseTest):
 
         crop_mod_np = numpy_transforms.CenterCrop(crop_vals, False)
         cropped_array = crop_mod_np.forward(test_tensor.numpy())
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [
                 torch.tensor(
@@ -860,8 +864,9 @@ class TestCenterCrop(BaseTest):
 
         crop_mod_np = numpy_transforms.CenterCrop(crop_vals, False)
         cropped_array = crop_mod_np.forward(test_tensor.numpy())
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
 
         expected_tensor = torch.stack(
             [torch.tensor([[0.0, 0.0], [1.0, 1.0], [1.0, 1.0], [0.0, 0.0]])] * 3
@@ -1001,8 +1006,9 @@ class TestCenterCropFunction(BaseTest):
         cropped_array = numpy_transforms.center_crop(
             test_tensor.numpy(), crop_vals, True
         )
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
         ).unsqueeze(0)
@@ -1019,8 +1025,9 @@ class TestCenterCropFunction(BaseTest):
         cropped_array = numpy_transforms.center_crop(
             test_tensor.numpy(), crop_vals, True
         )
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
         )
@@ -1040,8 +1047,9 @@ class TestCenterCropFunction(BaseTest):
         cropped_array = numpy_transforms.center_crop(
             test_tensor.numpy(), crop_vals, True
         )
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])] * 3
         ).unsqueeze(0)
@@ -1084,8 +1092,9 @@ class TestCenterCropFunction(BaseTest):
         cropped_array = numpy_transforms.center_crop(
             test_tensor.numpy(), crop_vals, True
         )
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [torch.stack([torch.tensor([0.0, 1.0, 1.0, 0.0])] * 2)] * 3
         ).unsqueeze(0)
@@ -1105,8 +1114,9 @@ class TestCenterCropFunction(BaseTest):
         cropped_array = numpy_transforms.center_crop(
             test_tensor.numpy(), crop_vals, False
         )
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [
                 torch.tensor(
@@ -1137,8 +1147,9 @@ class TestCenterCropFunction(BaseTest):
         cropped_array = numpy_transforms.center_crop(
             test_tensor.numpy(), crop_vals, False
         )
+        cropped_array = torch.as_tensor(cropped_array)
 
-        assertArraysAlmostEqual(cropped_tensor.numpy(), cropped_array, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, cropped_array, 0, mode="max")
         expected_tensor = torch.stack(
             [torch.tensor([[0.0, 0.0], [1.0, 1.0], [1.0, 1.0], [0.0, 0.0]])] * 3
         ).unsqueeze(0)
@@ -1277,8 +1288,9 @@ class TestBlendAlpha(BaseTest):
         background_array = np.ones(rgb_array.shape) * 5
         blend_alpha_np = numpy_transforms.BlendAlpha(background=background_array)
         blended_array = blend_alpha_np.blend_alpha(test_array)
+        belnded_array = torch.as_tensor(blended_array)
 
-        assertArraysAlmostEqual(blended_tensor.numpy(), blended_array, 0)
+        assertTensorAlmostEqual(self, blended_tensor, blended_array, 0, mode="max")
 
     def test_blend_alpha_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
@@ -1302,8 +1314,9 @@ class TestBlendAlpha(BaseTest):
         background_array = np.ones(rgb_array.shape) * 5
         blend_alpha_np = numpy_transforms.BlendAlpha(background=background_array)
         blended_array = blend_alpha_np.blend_alpha(test_array)
+        belnded_array = torch.as_tensor(blended_array)
 
-        assertArraysAlmostEqual(blended_tensor.numpy(), blended_array, 0)
+        assertTensorAlmostEqual(self, blended_tensor, blended_array, 0, mode="max")
 
 
 class TestIgnoreAlpha(BaseTest):
@@ -1355,7 +1368,8 @@ class TestToRGB(BaseTest):
     def test_to_rgb_klt(self) -> None:
         to_rgb = transforms.ToRGB(transform="klt")
         to_rgb_np = numpy_transforms.ToRGB(transform="klt")
-        assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
+        
+        assertTensorAlmostEqual(self, to_rgb.transform, to_rgb_np.transform, mode="max")
         transform = torch.tensor(
             [
                 [0.5628, 0.1948, 0.0433],

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -979,7 +979,7 @@ class TestCenterCrop(BaseTest):
                 [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             ]
         )
-        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor[None, None, :], 0)
 
 
 class TestCenterCropFunction(BaseTest):

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1355,7 +1355,7 @@ class TestToRGB(BaseTest):
     def test_to_rgb_i1i2i3(self) -> None:
         to_rgb = transforms.ToRGB(transform="i1i2i3")
         to_rgb_np = numpy_transforms.ToRGB(transform="i1i2i3")
-        assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
+        assertTensorAlmostEqual(self, to_rgb.transform, torch.as_tensor(to_rgb_np.transform), mode="max")
         transform = torch.tensor(
             [
                 [0.3333, 0.3333, 0.3333],
@@ -1369,7 +1369,7 @@ class TestToRGB(BaseTest):
         to_rgb = transforms.ToRGB(transform="klt")
         to_rgb_np = numpy_transforms.ToRGB(transform="klt")
         
-        assertTensorAlmostEqual(self, to_rgb.transform, to_rgb_np.transform, mode="max")
+        assertTensorAlmostEqual(self, to_rgb.transform, torch.as_tensor(to_rgb_np.transform), mode="max")
         transform = torch.tensor(
             [
                 [0.5628, 0.1948, 0.0433],
@@ -1383,7 +1383,7 @@ class TestToRGB(BaseTest):
         matrix = torch.eye(3, 3)
         to_rgb = transforms.ToRGB(transform=matrix)
         to_rgb_np = numpy_transforms.ToRGB(transform=matrix.numpy())
-        assertArraysAlmostEqual(to_rgb.transform.numpy(), to_rgb_np.transform)
+        assertTensorAlmostEqual(self, to_rgb.transform, torch.as_tensor(to_rgb_np.transform), mode="max")
         assertTensorAlmostEqual(self, to_rgb.transform, matrix, 0.0)
 
     def test_to_rgb_init_value_error(self) -> None:
@@ -1561,7 +1561,7 @@ class TestToRGB(BaseTest):
         test_array = np.ones((1, 3, 4, 4))
         rgb_array = to_rgb_np.to_rgb(test_array)
 
-        assertArraysAlmostEqual(rgb_tensor.numpy(), rgb_array)
+        assertTensorAlmostEqual(self, rgb_tensor, torch.as_tensor(rgb_array), mode="max")
 
         inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
         assertTensorAlmostEqual(

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -162,11 +162,6 @@ class TestRandomScale(BaseTest):
         )
 
     def test_random_scale_forward_exact_align_corners(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping RandomScale exact align corners forward due to"
-                + " insufficient Torch version."
-            )
         scale_module = transforms.RandomScale(scale=[0.5], align_corners=True)
         self.assertTrue(scale_module.align_corners)
 
@@ -504,11 +499,6 @@ class TestRandomRotation(BaseTest):
         assertTensorAlmostEqual(self, test_output, expected_output, 0.005)
 
     def test_random_rotation_forward_exact_nearest_reflection(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping RandomRotation forward due exact nearest relfection"
-                + " to insufficient Torch version."
-            )
         rotation_module = transforms.RandomRotation(
             [45.0], mode="nearest", padding_mode="reflection"
         )
@@ -1391,10 +1381,6 @@ class TestToRGB(BaseTest):
             transforms.ToRGB(transform="error")
 
     def test_to_rgb_klt_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping ToRGB forward due to insufficient Torch version."
-            )
         to_rgb = transforms.ToRGB(transform="klt")
         test_tensor = torch.ones(1, 3, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
@@ -1413,10 +1399,6 @@ class TestToRGB(BaseTest):
         )
 
     def test_to_rgb_alpha_klt_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping ToRGB with Alpha forward due to insufficient Torch version."
-            )
         to_rgb = transforms.ToRGB(transform="klt")
         test_tensor = torch.ones(1, 4, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
@@ -1436,11 +1418,6 @@ class TestToRGB(BaseTest):
         )
 
     def test_to_rgb_alpha_klt_forward_dim_3(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping ToRGB with Alpha forward dim 3 due to"
-                + " insufficient Torch version."
-            )
         to_rgb = transforms.ToRGB(transform="klt")
         test_tensor = torch.ones(4, 4, 4).refine_names("C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
@@ -1460,10 +1437,6 @@ class TestToRGB(BaseTest):
         )
 
     def test_to_rgb_klt_forward_no_named_dims(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping ToRGB forward due to insufficient Torch version."
-            )
         to_rgb = transforms.ToRGB(transform="klt")
         test_tensor = torch.ones(1, 3, 4, 4)
         rgb_tensor = to_rgb(test_tensor)
@@ -1482,10 +1455,6 @@ class TestToRGB(BaseTest):
         )
 
     def test_to_rgb_alpha_klt_forward_no_named_dims(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping ToRGB with Alpha forward due to insufficient Torch version."
-            )
         to_rgb = transforms.ToRGB(transform="klt")
         test_tensor = torch.ones(1, 4, 4, 4)
         rgb_tensor = to_rgb(test_tensor)
@@ -1505,10 +1474,6 @@ class TestToRGB(BaseTest):
         )
 
     def test_to_rgb_i1i2i3_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping ToRGB forward due to insufficient Torch version."
-            )
         to_rgb = transforms.ToRGB(transform="i1i2i3")
         test_tensor = torch.ones(1, 3, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
@@ -1526,10 +1491,6 @@ class TestToRGB(BaseTest):
         )
 
     def test_to_rgb_alpha_i1i2i3_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping ToRGB with Alpha forward due to insufficient Torch version."
-            )
         to_rgb = transforms.ToRGB(transform="i1i2i3")
         test_tensor = torch.ones(1, 4, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
@@ -1548,10 +1509,6 @@ class TestToRGB(BaseTest):
         )
 
     def test_to_rgb_custom_forward(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping ToRGB forward due to insufficient Torch version."
-            )
         matrix = torch.eye(3, 3)
         to_rgb = transforms.ToRGB(transform=matrix)
         test_tensor = torch.ones(1, 3, 4, 4).refine_names("B", "C", "H", "W")

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1288,7 +1288,7 @@ class TestBlendAlpha(BaseTest):
         background_array = np.ones(rgb_array.shape) * 5
         blend_alpha_np = numpy_transforms.BlendAlpha(background=background_array)
         blended_array = blend_alpha_np.blend_alpha(test_array)
-        belnded_array = torch.as_tensor(blended_array)
+        blended_array = torch.as_tensor(blended_array)
 
         assertTensorAlmostEqual(self, blended_tensor, blended_array, 0, mode="max")
 
@@ -1314,7 +1314,7 @@ class TestBlendAlpha(BaseTest):
         background_array = np.ones(rgb_array.shape) * 5
         blend_alpha_np = numpy_transforms.BlendAlpha(background=background_array)
         blended_array = blend_alpha_np.blend_alpha(test_array)
-        belnded_array = torch.as_tensor(blended_array)
+        blended_array = torch.as_tensor(blended_array)
 
         assertTensorAlmostEqual(self, blended_tensor, blended_array, 0, mode="max")
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -898,7 +898,7 @@ class TestCenterCrop(BaseTest):
                 [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             ]
         )
-        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor[None, None, :], 0)
 
     def test_center_crop_forward_padding_prime_num_pad(self) -> None:
         test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
@@ -1177,7 +1177,7 @@ class TestCenterCropFunction(BaseTest):
                 [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             ]
         )
-        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor[None, None, :], 0)
 
     def test_center_crop_padding_prime_num_pad(self) -> None:
         test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
@@ -1254,7 +1254,7 @@ class TestCenterCropFunction(BaseTest):
                 [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             ]
         )
-        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor[None, None, :], 0)
 
 
 class TestBlendAlpha(BaseTest):

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1345,7 +1345,9 @@ class TestToRGB(BaseTest):
     def test_to_rgb_i1i2i3(self) -> None:
         to_rgb = transforms.ToRGB(transform="i1i2i3")
         to_rgb_np = numpy_transforms.ToRGB(transform="i1i2i3")
-        assertTensorAlmostEqual(self, to_rgb.transform, torch.as_tensor(to_rgb_np.transform), mode="max")
+        assertTensorAlmostEqual(
+            self, to_rgb.transform, torch.as_tensor(to_rgb_np.transform), mode="max"
+        )
         transform = torch.tensor(
             [
                 [0.3333, 0.3333, 0.3333],
@@ -1358,8 +1360,10 @@ class TestToRGB(BaseTest):
     def test_to_rgb_klt(self) -> None:
         to_rgb = transforms.ToRGB(transform="klt")
         to_rgb_np = numpy_transforms.ToRGB(transform="klt")
-        
-        assertTensorAlmostEqual(self, to_rgb.transform, torch.as_tensor(to_rgb_np.transform), mode="max")
+
+        assertTensorAlmostEqual(
+            self, to_rgb.transform, torch.as_tensor(to_rgb_np.transform), mode="max"
+        )
         transform = torch.tensor(
             [
                 [0.5628, 0.1948, 0.0433],
@@ -1373,7 +1377,9 @@ class TestToRGB(BaseTest):
         matrix = torch.eye(3, 3)
         to_rgb = transforms.ToRGB(transform=matrix)
         to_rgb_np = numpy_transforms.ToRGB(transform=matrix.numpy())
-        assertTensorAlmostEqual(self, to_rgb.transform, torch.as_tensor(to_rgb_np.transform), mode="max")
+        assertTensorAlmostEqual(
+            self, to_rgb.transform, torch.as_tensor(to_rgb_np.transform), mode="max"
+        )
         assertTensorAlmostEqual(self, to_rgb.transform, matrix, 0.0)
 
     def test_to_rgb_init_value_error(self) -> None:
@@ -1518,7 +1524,9 @@ class TestToRGB(BaseTest):
         test_array = np.ones((1, 3, 4, 4))
         rgb_array = to_rgb_np.to_rgb(test_array)
 
-        assertTensorAlmostEqual(self, rgb_tensor, torch.as_tensor(rgb_array), mode="max")
+        assertTensorAlmostEqual(
+            self, rgb_tensor, torch.as_tensor(rgb_array), mode="max"
+        )
 
         inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
         assertTensorAlmostEqual(

--- a/tests/optim/utils/test_circuits.py
+++ b/tests/optim/utils/test_circuits.py
@@ -10,10 +10,6 @@ from tests.helpers.basic import BaseTest
 
 class TestGetExpandedWeights(BaseTest):
     def test_get_expanded_weights(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping get_expanded_weights test due to insufficient Torch version."
-            )
         model = googlenet(pretrained=True, use_linear_modules_only=True)
         output_tensor = circuits.extract_expanded_weights(
             model, model.mixed3a, model.mixed3b
@@ -22,11 +18,6 @@ class TestGetExpandedWeights(BaseTest):
         self.assertEqual(list(output_tensor.shape), [480, 256, 28, 28])
 
     def test_get_expanded_weights_crop_int(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping get_expanded_weights crop test due to insufficient Torch"
-                + " version."
-            )
         model = googlenet(pretrained=True, use_linear_modules_only=True)
         output_tensor = circuits.extract_expanded_weights(
             model, model.mixed3a, model.mixed3b, 5
@@ -34,11 +25,6 @@ class TestGetExpandedWeights(BaseTest):
         self.assertEqual(list(output_tensor.shape), [480, 256, 5, 5])
 
     def test_get_expanded_weights_crop_two_int(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping get_expanded_weights two int crop test due to insufficient"
-                + " Torch version."
-            )
         model = googlenet(pretrained=True, use_linear_modules_only=True)
         output_tensor = circuits.extract_expanded_weights(
             model, model.mixed3a, model.mixed3b, (5, 5)
@@ -46,16 +32,6 @@ class TestGetExpandedWeights(BaseTest):
         self.assertEqual(list(output_tensor.shape), [480, 256, 5, 5])
 
     def test_get_expanded_nonlinear_top_connections(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping get_expanded_weights nonlinear_top_connections test"
-                + " due to insufficient Torch version."
-            )
-
-        if torch.__version__ <= "1.3.0":
-            norm_func = torch.norm
-        else:
-            norm_func = torch.linalg.norm
         model = googlenet(pretrained=True, use_linear_modules_only=True)
         output_tensor = circuits.extract_expanded_weights(
             model, model.pool3, model.mixed4a, 5
@@ -65,7 +41,7 @@ class TestGetExpandedWeights(BaseTest):
         top_connected_neurons = torch.argsort(
             torch.stack(
                 [
-                    -norm_func(output_tensor[i, 379, :, :])
+                    -torch.linalg.norm(output_tensor[i, 379, :, :])
                     for i in range(output_tensor.shape[0])
                 ]
             )
@@ -75,10 +51,6 @@ class TestGetExpandedWeights(BaseTest):
         self.assertEqual(top_connected_neurons, expected_list)
 
     def test_get_expanded_weights_cuda(self) -> None:
-        if torch.__version__ <= "1.2.0":
-            raise unittest.SkipTest(
-                "Skipping get_expanded_weights test due to insufficient Torch version."
-            )
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
                 "Skipping Circuits CUDA test due to not supporting CUDA."


### PR DESCRIPTION
* Removed test version checks for versions below 1.6.0.
* `AssertArrayAlmostEqual` -> `AssertTensorAlmostEqual`
* General linting changes / fixes.