### PR TITLE
Improve loss objective docs + batch_index

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -608,21 +608,6 @@ class NeuronDirection(BaseLoss):
     https://distill.pub/2019/activation-atlas/#Aggregating-Multiple-Images
     Extends Direction loss by focusing on visualizing a single neuron within the
     kernel.
-
-    Args:
-        target (nn.Module):  The layer to optimize for.
-        vec (torch.Tensor):  Vector representing direction to align to.
-        x (int, optional):  The x coordinate of the neuron to optimize for. If
-            unspecified, defaults to center, or one unit left of center for even
-            lengths.
-        y (int, optional):  The y coordinate of the neuron to optimize for. If
-            unspecified, defaults to center, or one unit up of center for even
-            heights.
-        channel_index (int):  The index of the channel to optimize for.
-        cossim_pow (float, optional):  The desired cosine similarity power to use.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
     """
 
     def __init__(
@@ -635,6 +620,30 @@ class NeuronDirection(BaseLoss):
         cossim_pow: Optional[float] = 0.0,
         batch_index: Optional[int] = None,
     ) -> None:
+        """
+        Args:
+
+            target (nn.Module): A target layer, transform, or image parameterization
+                instance to optimize the output of.
+            vec (torch.Tensor): Vector representing direction to align to.
+            x (int, optional): The x coordinate of the neuron to optimize for. If
+                set to None, defaults to center, or one unit left of center for even
+                lengths.
+                Default: None
+            y (int, optional): The y coordinate of the neuron to optimize for. If
+                set to None, defaults to center, or one unit up of center for even
+                heights.
+                Default: None
+            channel_index (int): The index of the channel to optimize for. If set to
+                None, then all channels will be used.
+                Default: None
+            cossim_pow (float, optional): The desired cosine similarity power to use.
+                Default: 0.0
+            batch_index (int, optional): The index of activations to optimize if
+                optimizing a batch of activations. If set to None, defaults to all
+                activations in the batch.
+                Default: None
+        """
         BaseLoss.__init__(self, target, batch_index)
         self.vec = vec.reshape((1, -1, 1, 1))
         self.x = x
@@ -700,16 +709,25 @@ class AngledNeuronDirection(BaseLoss):
     ) -> None:
         """
         Args:
-            target (nn.Module): A target layer instance.
+
+            target (nn.Module): A target layer, transform, or image parameterization
+                instance to optimize the output of.
             vec (torch.Tensor): A neuron direction vector to use.
             vec_whitened (torch.Tensor, optional): A whitened neuron direction vector.
+                If set to None, then no whitened vec will be used.
+                Default: None
             cossim_pow (float, optional): The desired cosine similarity power to use.
-            x (int, optional): Optionally provide a specific x position for the target
-                neuron.
-            y (int, optional): Optionally provide a specific y position for the target
-                neuron.
+            x (int, optional): The x coordinate of the neuron to optimize for. If
+                set to None, defaults to center, or one unit left of center for even
+                lengths.
+                Default: None
+            y (int, optional): The y coordinate of the neuron to optimize for. If
+                set to None, defaults to center, or one unit up of center for even
+                heights.
+                Default: None
             eps (float, optional): If cossim_pow is greater than zero, the desired
                 epsilon value to use for cosine similarity calculations.
+                Default: 1.0e-4
         """
         BaseLoss.__init__(self, target, batch_index)
         self.vec = vec.unsqueeze(0) if vec.dim() == 1 else vec
@@ -753,14 +771,6 @@ class TensorDirection(BaseLoss):
     Carter, et al., "Activation Atlas", Distill, 2019.
     https://distill.pub/2019/activation-atlas/#Aggregating-Multiple-Images
     Extends Direction loss by allowing batch-wise direction visualization.
-
-    Args:
-        target (nn.Module):  The layer to optimize for.
-        vec (torch.Tensor):  Vector representing direction to align to.
-        cossim_pow (float, optional):  The desired cosine similarity power to use.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
     """
 
     def __init__(
@@ -770,6 +780,19 @@ class TensorDirection(BaseLoss):
         cossim_pow: Optional[float] = 0.0,
         batch_index: Optional[int] = None,
     ) -> None:
+        """
+        Args:
+
+            target (nn.Module): A target layer, transform, or image parameterization
+                instance to optimize the output of.
+            vec (torch.Tensor):  Vector representing direction to align to.
+            cossim_pow (float, optional):  The desired cosine similarity power to use.
+                Default: 0.0
+            batch_index (int, optional): The index of activations to optimize if
+                optimizing a batch of activations. If set to None, defaults to all
+                activations in the batch.
+                Default: None
+        """
         BaseLoss.__init__(self, target, batch_index)
         assert vec.dim() == 4
         self.vec = vec
@@ -801,21 +824,6 @@ class ActivationWeights(BaseLoss):
     Apply weights to channels, neurons, or spots in the target.
     This loss weighs specific channels or neurons in a given layer, via a weight
     vector.
-
-    Args:
-        target (nn.Module):  The layer to optimize for.
-        weights (torch.Tensor): Weights to apply to targets.
-        neuron (bool): Whether target is a neuron. Defaults to False.
-        x (int, optional):  The x coordinate of the neuron to optimize for. If
-            unspecified, defaults to center, or one unit left of center for even
-            lengths.
-        y (int, optional):  The y coordinate of the neuron to optimize for. If
-            unspecified, defaults to center, or one unit up of center for even
-            heights.
-        wx (int, optional):  Length of neurons to apply the weights to, along the
-            x-axis.
-        wy (int, optional):  Length of neurons to apply the weights to, along the
-            y-axis.
     """
 
     def __init__(
@@ -828,6 +836,29 @@ class ActivationWeights(BaseLoss):
         wx: Optional[int] = None,
         wy: Optional[int] = None,
     ) -> None:
+        """
+        Args:
+
+            target (nn.Module): A target layer, transform, or image parameterization
+                instance to optimize the output of.
+            weights (torch.Tensor): Weights to apply to targets.
+            neuron (bool): Whether target is a neuron.
+                Default: False
+            x (int, optional): The x coordinate of the neuron to optimize for. If
+                set to None, defaults to center, or one unit left of center for even
+                lengths.
+                Default: None
+            y (int, optional): The y coordinate of the neuron to optimize for. If
+                set to None, defaults to center, or one unit up of center for even
+                heights.
+                Default: None
+            wx (int, optional):  Length of neurons to apply the weights to, along the
+                x-axis. Set to None for the full length.
+                Default: None
+            wy (int, optional):  Length of neurons to apply the weights to, along the
+                y-axis. Set to None for the full length.
+                Default: None
+        """
         BaseLoss.__init__(self, target)
         self.x = x
         self.y = y

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -141,14 +141,18 @@ class BaseLoss(Loss):
     def __init__(
         self,
         target: Union[nn.Module, List[nn.Module]] = [],
-        batch_index: Optional[int] = None,
+        batch_index: Optional[Union[int, List[int]]] = None,
     ) -> None:
         super(BaseLoss, self).__init__()
         self._target = target
         if batch_index is None:
             self._batch_index = (None, None)
+        elif isinstance(batch_index, (list, tuple)):
+            self._batch_index = tuple(batch_index)
         else:
             self._batch_index = (batch_index, batch_index + 1)
+        assert all([isinstance(b, (int, type(None))) for b in self._batch_index])
+        assert len(self._batch_index) == 2
 
     @property
     def target(self) -> Union[nn.Module, List[nn.Module]]:
@@ -200,9 +204,10 @@ class LayerActivation(BaseLoss):
 
         target (nn.Module): A target layer, transform, or image parameterization
             instance to optimize the output of.
-        batch_index (int, optional): The index of activations to optimize if
-            optimizing a batch of activations. If set to None, defaults to all
-            activations in the batch.
+        batch_index (int or list of int, optional): The index or indice range of
+            activations to optimize if optimizing a batch of activations. If set to
+            None, defaults to all activations in the batch. Indice ranges should be
+            in the format of: [start, end].
             Default: None
     """
 
@@ -221,17 +226,21 @@ class ChannelActivation(BaseLoss):
     """
 
     def __init__(
-        self, target: nn.Module, channel_index: int, batch_index: Optional[int] = None
+        self,
+        target: nn.Module,
+        channel_index: int,
+        batch_index: Optional[Union[int, List[int]]] = None,
     ) -> None:
-        """ 
+        """
         Args:
 
             target (nn.Module): A target layer, transform, or image parameterization
                 instance to optimize the output of.
-            channel_index (int):  The index of the channel to optimize for.
-            batch_index (int, optional): The index of activations to optimize if
-                optimizing a batch of activations. If set to None, defaults to all
-                activations in the batch.
+            channel_index (int): The index of the channel to optimize for.
+            batch_index (int or list of int, optional): The index or indice range of
+                activations to optimize if optimizing a batch of activations. If set to
+                None, defaults to all activations in the batch. Indice ranges should be
+                in the format of: [start, end].
                 Default: None
         """
         BaseLoss.__init__(self, target, batch_index)
@@ -265,9 +274,9 @@ class NeuronActivation(BaseLoss):
         channel_index: int,
         x: Optional[int] = None,
         y: Optional[int] = None,
-        batch_index: Optional[int] = None,
+        batch_index: Optional[Union[int, List[int]]] = None,
     ) -> None:
-        """ 
+        """
         Args:
 
             target (nn.Module):  The layer to containing the channel to optimize for.
@@ -280,9 +289,10 @@ class NeuronActivation(BaseLoss):
                 unspecified, defaults to center, or one unit up of center for even
                 heights.
                 Default: None
-            batch_index (int, optional): The index of activations to optimize if
-                optimizing a batch of activations. If set to None, defaults to all
-                activations in the batch.
+            batch_index (int or list of int, optional): The index or indice range of
+                activations to optimize if optimizing a batch of activations. If set to
+                None, defaults to all activations in the batch. Indice ranges should be
+                in the format of: [start, end].
                 Default: None
         """
         BaseLoss.__init__(self, target, batch_index)
@@ -320,9 +330,10 @@ class DeepDream(BaseLoss):
 
         target (nn.Module): A target layer, transform, or image parameterization
             instance to optimize the output of.
-        batch_index (int, optional): The index of activations to optimize if
-            optimizing a batch of activations. If set to None, defaults to all
-            activations in the batch.
+        batch_index (int or list of int, optional): The index or indice range of
+            activations to optimize if optimizing a batch of activations. If set to
+            None, defaults to all activations in the batch. Indice ranges should be
+            in the format of: [start, end].
             Default: None
     """
 
@@ -346,9 +357,10 @@ class TotalVariation(BaseLoss):
 
         target (nn.Module): A target layer, transform, or image parameterization
             instance to optimize the output of.
-        batch_index (int, optional): The index of activations to optimize if
-            optimizing a batch of activations. If set to None, defaults to all
-            activations in the batch.
+        batch_index (int or list of int, optional): The index or indice range of
+            activations to optimize if optimizing a batch of activations. If set to
+            None, defaults to all activations in the batch. Indice ranges should be
+            in the format of: [start, end].
             Default: None
     """
 
@@ -370,17 +382,18 @@ class L1(BaseLoss):
         self,
         target: nn.Module,
         constant: float = 0.0,
-        batch_index: Optional[int] = None,
+        batch_index: Optional[Union[int, List[int]]] = None,
     ) -> None:
-        """ 
+        """
         Args:
 
             target (nn.Module): A target layer, transform, or image parameterization
                 instance to optimize the output of.
-            constant (float):  Constant threshold to deduct from the activations.
-            batch_index (int, optional): The index of activations to optimize if
-                optimizing a batch of activations. If set to None, defaults to all
-                activations in the batch.
+            constant (float): Constant threshold to deduct from the activations.
+            batch_index (int or list of int, optional): The index or indice range of
+                activations to optimize if optimizing a batch of activations. If set to
+                None, defaults to all activations in the batch. Indice ranges should be
+                in the format of: [start, end].
                 Default: None
         """
         BaseLoss.__init__(self, target, batch_index)
@@ -403,20 +416,21 @@ class L2(BaseLoss):
         target: nn.Module,
         constant: float = 0.0,
         epsilon: float = 1e-6,
-        batch_index: Optional[int] = None,
+        batch_index: Optional[Union[int, List[int]]] = None,
     ) -> None:
-        """ 
+        """
         Args:
 
             target (nn.Module): A target layer, transform, or image parameterization
                 instance to optimize the output of.
-            constant (float):  Constant threshold to deduct from the activations.
+            constant (float): Constant threshold to deduct from the activations.
                 Default: 0.0
-            epsilon (float):  Small value to add to L2 prior to sqrt.
+            epsilon (float): Small value to add to L2 prior to sqrt.
                 Default: 1e-6
-            batch_index (int, optional): The index of activations to optimize if
-                optimizing a batch of activations. If set to None, defaults to all
-                activations in the batch.
+            batch_index (int or list of int, optional): The index or indice range of
+                activations to optimize if optimizing a batch of activations. If set to
+                None, defaults to all activations in the batch. Indice ranges should be
+                in the format of: [start, end].
                 Default: None
         """
         BaseLoss.__init__(self, target, batch_index)
@@ -445,15 +459,15 @@ class Diversity(BaseLoss):
 
         target (nn.Module): A target layer, transform, or image parameterization
             instance to optimize the output of.
-        batch_index (int or list of int, optional): The index or indice range of
-            activations to optimize if optimizing a batch of activations. If set to
-            None, defaults to all activations in the batch. Indice ranges should be
-            in the format of: [start, end].
+        batch_index (list of int, optional): The indice range of activations to
+            optimize. If set to None, defaults to all activations in the batch. Indice
+            ranges should be in the format of: [start, end].
             Default: None
     """
 
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
         activations = targets_to_values[self.target]
+        activations = activations[self.batch_index[0] : self.batch_index[1]]
         batch, channels = activations.shape[:2]
         flattened = activations.view(batch, channels, -1)
         grams = torch.matmul(flattened, torch.transpose(flattened, 1, 2))
@@ -490,10 +504,24 @@ class ActivationInterpolation(BaseLoss):
     def __init__(
         self,
         target1: nn.Module = None,
-        channel_index1: int = -1,
+        channel_index1: Optional[int] = None,
         target2: nn.Module = None,
-        channel_index2: int = -1,
+        channel_index2: Optional[int] = None,
     ) -> None:
+        """
+        Args:
+
+            target1 (nn.Module): The first layer, transform, or image parameterization
+                instance to optimize the output for.
+            channel_index1 (int, optional): Index of channel in first target to
+                optimize. Default is set to None for all channels.
+                Default: None
+            target2 (nn.Module): The second layer, transform, or image parameterization
+                instance to optimize the output for.
+            channel_index2 (int, optional): Index of channel in second target to
+                optimize. Default is set to None for all channels.
+                Default: None
+        """
         self.target_one = target1
         self.channel_index_one = channel_index1
         self.target_two = target2
@@ -507,15 +535,16 @@ class ActivationInterpolation(BaseLoss):
 
         assert activations_one is not None and activations_two is not None
         # ensure channel indices are valid
-        assert (
-            self.channel_index_one < activations_one.shape[1]
-            and self.channel_index_two < activations_two.shape[1]
-        )
+        if self.channel_index_one:
+            assert self.channel_index_one < activations_one.shape[1]
+        if self.channel_index_two:
+            assert self.channel_index_two < activations_two.shape[1]
+
         assert activations_one.size(0) == activations_two.size(0)
 
-        if self.channel_index_one > -1:
+        if self.channel_index_one:
             activations_one = activations_one[:, self.channel_index_one]
-        if self.channel_index_two > -1:
+        if self.channel_index_two:
             activations_two = activations_two[:, self.channel_index_two]
         B = activations_one.size(0)
 
@@ -541,7 +570,12 @@ class Alignment(BaseLoss):
     between neighbouring images.
     """
 
-    def __init__(self, target: nn.Module, decay_ratio: float = 2.0) -> None:
+    def __init__(
+        self,
+        target: nn.Module,
+        decay_ratio: float = 2.0,
+        batch_index: Optional[List[int]] = None,
+    ) -> None:
         """
         Args:
 
@@ -550,17 +584,19 @@ class Alignment(BaseLoss):
             decay_ratio (float): How much to decay penalty as images move apart in
                 the batch.
                 Default: 2.0
-            batch_index (int or list of int, optional): The index or indice range of
-                activations to optimize if optimizing a batch of activations. If set to
-                to None, defaults to all activations in the batch. Indice ranges should
-                be in the format of: [start, end].
+            batch_index (list of int, optional): The indice range of activations to
+                optimize. If set to None, defaults to all activations in the batch.
+                Indice ranges should be in the format of: [start, end].
                 Default: None
         """
-        BaseLoss.__init__(self, target)
+        if batch_index:
+            assert len(batch_index) == 2
+        BaseLoss.__init__(self, target, batch_index)
         self.decay_ratio = decay_ratio
 
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
         activations = targets_to_values[self.target]
+        activations = activations[self.batch_index[0] : self.batch_index[1]]
         B = activations.size(0)
 
         sum_tensor = torch.zeros(1, device=activations.device)

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -279,9 +279,9 @@ class NeuronActivation(BaseLoss):
         """
         Args:
 
-            target (nn.Module):  The layer to containing the channel to optimize for.
-            channel_index (int):  The index of the channel to optimize for.
-            x (int, optional):  The x coordinate of the neuron to optimize for. If
+            target (nn.Module): The layer instance containing the channel to optimize for.
+            channel_index (int): The index of the channel to optimize for.
+            x (int, optional): The x coordinate of the neuron to optimize for. If
                 unspecified, defaults to center, or one unit left of center for even
                 lengths.
                 Default: None

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -491,14 +491,6 @@ class ActivationInterpolation(BaseLoss):
     https://distill.pub/2017/feature-visualization/#Interaction-between-Neurons
     This loss helps to interpolate or mix visualizations from two activations (layer or
     channel) by interpolating a linear sum between the two activations.
-
-    Args:
-        target1 (nn.Module):  The first layer to optimize for.
-        channel_index1 (int):  Index of channel in first layer to optimize. Defaults to
-            all channels.
-        target2 (nn.Module):  The first layer to optimize for.
-        channel_index2 (int):  Index of channel in first layer to optimize. Defaults to
-            all channels.
     """
 
     def __init__(

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -204,9 +204,9 @@ class LayerActivation(BaseLoss):
 
         target (nn.Module): A target layer, transform, or image parameterization
             instance to optimize the output of.
-        batch_index (int or list of int, optional): The index or indice range of
+        batch_index (int or list of int, optional): The index or index range of
             activations to optimize if optimizing a batch of activations. If set to
-            None, defaults to all activations in the batch. Indice ranges should be
+            None, defaults to all activations in the batch. index ranges should be
             in the format of: [start, end].
             Default: None
     """
@@ -237,9 +237,9 @@ class ChannelActivation(BaseLoss):
             target (nn.Module): A target layer, transform, or image parameterization
                 instance to optimize the output of.
             channel_index (int): The index of the channel to optimize for.
-            batch_index (int or list of int, optional): The index or indice range of
+            batch_index (int or list of int, optional): The index or index range of
                 activations to optimize if optimizing a batch of activations. If set to
-                None, defaults to all activations in the batch. Indice ranges should be
+                None, defaults to all activations in the batch. index ranges should be
                 in the format of: [start, end].
                 Default: None
         """
@@ -289,9 +289,9 @@ class NeuronActivation(BaseLoss):
                 unspecified, defaults to center, or one unit up of center for even
                 heights.
                 Default: None
-            batch_index (int or list of int, optional): The index or indice range of
+            batch_index (int or list of int, optional): The index or index range of
                 activations to optimize if optimizing a batch of activations. If set to
-                None, defaults to all activations in the batch. Indice ranges should be
+                None, defaults to all activations in the batch. index ranges should be
                 in the format of: [start, end].
                 Default: None
         """
@@ -330,9 +330,9 @@ class DeepDream(BaseLoss):
 
         target (nn.Module): A target layer, transform, or image parameterization
             instance to optimize the output of.
-        batch_index (int or list of int, optional): The index or indice range of
+        batch_index (int or list of int, optional): The index or index range of
             activations to optimize if optimizing a batch of activations. If set to
-            None, defaults to all activations in the batch. Indice ranges should be
+            None, defaults to all activations in the batch. index ranges should be
             in the format of: [start, end].
             Default: None
     """
@@ -357,9 +357,9 @@ class TotalVariation(BaseLoss):
 
         target (nn.Module): A target layer, transform, or image parameterization
             instance to optimize the output of.
-        batch_index (int or list of int, optional): The index or indice range of
+        batch_index (int or list of int, optional): The index or index range of
             activations to optimize if optimizing a batch of activations. If set to
-            None, defaults to all activations in the batch. Indice ranges should be
+            None, defaults to all activations in the batch. index ranges should be
             in the format of: [start, end].
             Default: None
     """
@@ -390,9 +390,9 @@ class L1(BaseLoss):
             target (nn.Module): A target layer, transform, or image parameterization
                 instance to optimize the output of.
             constant (float): Constant threshold to deduct from the activations.
-            batch_index (int or list of int, optional): The index or indice range of
+            batch_index (int or list of int, optional): The index or index range of
                 activations to optimize if optimizing a batch of activations. If set to
-                None, defaults to all activations in the batch. Indice ranges should be
+                None, defaults to all activations in the batch. index ranges should be
                 in the format of: [start, end].
                 Default: None
         """
@@ -427,9 +427,9 @@ class L2(BaseLoss):
                 Default: 0.0
             eps (float): Small value to add to L2 prior to sqrt.
                 Default: 1e-6
-            batch_index (int or list of int, optional): The index or indice range of
+            batch_index (int or list of int, optional): The index or index range of
                 activations to optimize if optimizing a batch of activations. If set to
-                None, defaults to all activations in the batch. Indice ranges should be
+                None, defaults to all activations in the batch. index ranges should be
                 in the format of: [start, end].
                 Default: None
         """
@@ -459,8 +459,8 @@ class Diversity(BaseLoss):
 
         target (nn.Module): A target layer, transform, or image parameterization
             instance to optimize the output of.
-        batch_index (list of int, optional): The indice range of activations to
-            optimize. If set to None, defaults to all activations in the batch. Indice
+        batch_index (list of int, optional): The index range of activations to
+            optimize. If set to None, defaults to all activations in the batch. index
             ranges should be in the format of: [start, end].
             Default: None
     """
@@ -576,9 +576,9 @@ class Alignment(BaseLoss):
             decay_ratio (float): How much to decay penalty as images move apart in
                 the batch.
                 Default: 2.0
-            batch_index (list of int, optional): The indice range of activations to
+            batch_index (list of int, optional): The index range of activations to
                 optimize. If set to None, defaults to all activations in the batch.
-                Indice ranges should be in the format of: [start, end].
+                index ranges should be in the format of: [start, end].
                 Default: None
         """
         if batch_index:

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -442,6 +442,7 @@ class Diversity(BaseLoss):
     loss.
 
     Args:
+
         target (nn.Module): A target layer, transform, or image parameterization
             instance to optimize the output of.
         batch_index (int or list of int, optional): The index or indice range of
@@ -549,6 +550,11 @@ class Alignment(BaseLoss):
             decay_ratio (float): How much to decay penalty as images move apart in
                 the batch.
                 Default: 2.0
+            batch_index (int or list of int, optional): The index or indice range of
+                activations to optimize if optimizing a batch of activations. If set to
+                to None, defaults to all activations in the batch. Indice ranges should
+                be in the format of: [start, end].
+                Default: None
         """
         BaseLoss.__init__(self, target)
         self.decay_ratio = decay_ratio

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -285,7 +285,7 @@ class NeuronActivation(BaseLoss):
                 unspecified, defaults to center, or one unit left of center for even
                 lengths.
                 Default: None
-            y (int, optional):  The y coordinate of the neuron to optimize for. If
+            y (int, optional): The y coordinate of the neuron to optimize for. If
                 unspecified, defaults to center, or one unit up of center for even
                 heights.
                 Default: None
@@ -831,8 +831,8 @@ class TensorDirection(BaseLoss):
 
             target (nn.Module): A target layer, transform, or image parameterization
                 instance to optimize the output of.
-            vec (torch.Tensor):  Vector representing direction to align to.
-            cossim_pow (float, optional):  The desired cosine similarity power to use.
+            vec (torch.Tensor): Vector representing direction to align to.
+            cossim_pow (float, optional): The desired cosine similarity power to use.
                 Default: 0.0
             batch_index (int, optional): The index of activations to optimize if
                 optimizing a batch of activations. If set to None, defaults to all
@@ -898,10 +898,10 @@ class ActivationWeights(BaseLoss):
                 set to None, defaults to center, or one unit up of center for even
                 heights.
                 Default: None
-            wx (int, optional):  Length of neurons to apply the weights to, along the
+            wx (int, optional): Length of neurons to apply the weights to, along the
                 x-axis. Set to None for the full length.
                 Default: None
-            wy (int, optional):  Length of neurons to apply the weights to, along the
+            wy (int, optional): Length of neurons to apply the weights to, along the
                 y-axis. Set to None for the full length.
                 Default: None
         """

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -218,21 +218,22 @@ class ChannelActivation(BaseLoss):
     Maximize activations at the target layer and target channel.
     This loss maximizes the activations of a target channel in a specified target
     layer, and can be useful to determine what features the channel is excited by.
-
-    Args:
-
-        target (nn.Module): A target layer, transform, or image parameterization
-            instance to optimize the output of.
-        channel_index (int):  The index of the channel to optimize for.
-        batch_index (int, optional): The index of activations to optimize if
-            optimizing a batch of activations. If set to None, defaults to all
-            activations in the batch.
-            Default: None
     """
 
     def __init__(
         self, target: nn.Module, channel_index: int, batch_index: Optional[int] = None
     ) -> None:
+        """ 
+        Args:
+
+            target (nn.Module): A target layer, transform, or image parameterization
+                instance to optimize the output of.
+            channel_index (int):  The index of the channel to optimize for.
+            batch_index (int, optional): The index of activations to optimize if
+                optimizing a batch of activations. If set to None, defaults to all
+                activations in the batch.
+                Default: None
+        """
         BaseLoss.__init__(self, target, batch_index)
         self.channel_index = channel_index
 
@@ -256,23 +257,6 @@ class NeuronActivation(BaseLoss):
     from the specified layer. This loss is useful for determining the type of features
     that excite a neuron, and thus is often used for circuits and neuron related
     research.
-
-    Args:
-
-        target (nn.Module):  The layer to containing the channel to optimize for.
-        channel_index (int):  The index of the channel to optimize for.
-        x (int, optional):  The x coordinate of the neuron to optimize for. If
-            unspecified, defaults to center, or one unit left of center for even
-            lengths.
-            Default: None
-        y (int, optional):  The y coordinate of the neuron to optimize for. If
-            unspecified, defaults to center, or one unit up of center for even
-            heights.
-            Default: None
-        batch_index (int, optional): The index of activations to optimize if
-            optimizing a batch of activations. If set to None, defaults to all
-            activations in the batch.
-            Default: None
     """
 
     def __init__(
@@ -283,6 +267,24 @@ class NeuronActivation(BaseLoss):
         y: Optional[int] = None,
         batch_index: Optional[int] = None,
     ) -> None:
+        """ 
+        Args:
+
+            target (nn.Module):  The layer to containing the channel to optimize for.
+            channel_index (int):  The index of the channel to optimize for.
+            x (int, optional):  The x coordinate of the neuron to optimize for. If
+                unspecified, defaults to center, or one unit left of center for even
+                lengths.
+                Default: None
+            y (int, optional):  The y coordinate of the neuron to optimize for. If
+                unspecified, defaults to center, or one unit up of center for even
+                heights.
+                Default: None
+            batch_index (int, optional): The index of activations to optimize if
+                optimizing a batch of activations. If set to None, defaults to all
+                activations in the batch.
+                Default: None
+        """
         BaseLoss.__init__(self, target, batch_index)
         self.channel_index = channel_index
         self.x = x
@@ -362,17 +364,6 @@ class TotalVariation(BaseLoss):
 class L1(BaseLoss):
     """
     L1 norm of the target layer, generally used as a penalty.
-
-    Args:
-
-        target (nn.Module): A target layer, transform, or image parameterization
-            instance to optimize the output of.
-        constant (float):  Constant threshold to deduct from the activations.
-            Default: 0.0
-        batch_index (int, optional): The index of activations to optimize if
-            optimizing a batch of activations. If set to None, defaults to all
-            activations in the batch.
-            Default: None
     """
 
     def __init__(
@@ -381,6 +372,17 @@ class L1(BaseLoss):
         constant: float = 0.0,
         batch_index: Optional[int] = None,
     ) -> None:
+        """ 
+        Args:
+
+            target (nn.Module): A target layer, transform, or image parameterization
+                instance to optimize the output of.
+            constant (float):  Constant threshold to deduct from the activations.
+            batch_index (int, optional): The index of activations to optimize if
+                optimizing a batch of activations. If set to None, defaults to all
+                activations in the batch.
+                Default: None
+        """
         BaseLoss.__init__(self, target, batch_index)
         self.constant = constant
 
@@ -394,19 +396,6 @@ class L1(BaseLoss):
 class L2(BaseLoss):
     """
     L2 norm of the target layer, generally used as a penalty.
-
-    Args:
-
-        target (nn.Module): A target layer, transform, or image parameterization
-            instance to optimize the output of.
-        constant (float):  Constant threshold to deduct from the activations.
-            Default: 0.0
-        epsilon (float):  Small value to add to L2 prior to sqrt.
-            Default: 1e-6
-        batch_index (int, optional): The index of activations to optimize if
-            optimizing a batch of activations. If set to None, defaults to all
-            activations in the batch.
-            Default: None
     """
 
     def __init__(
@@ -416,6 +405,20 @@ class L2(BaseLoss):
         epsilon: float = 1e-6,
         batch_index: Optional[int] = None,
     ) -> None:
+        """ 
+        Args:
+
+            target (nn.Module): A target layer, transform, or image parameterization
+                instance to optimize the output of.
+            constant (float):  Constant threshold to deduct from the activations.
+                Default: 0.0
+            epsilon (float):  Small value to add to L2 prior to sqrt.
+                Default: 1e-6
+            batch_index (int, optional): The index of activations to optimize if
+                optimizing a batch of activations. If set to None, defaults to all
+                activations in the batch.
+                Default: None
+        """
         BaseLoss.__init__(self, target, batch_index)
         self.constant = constant
         self.epsilon = epsilon

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -535,14 +535,18 @@ class Alignment(BaseLoss):
     When interpolating between activations, it may be desirable to keep image landmarks
     in the same position for visual comparison. This loss helps to minimize L2 distance
     between neighbouring images.
-
-    Args:
-        target (nn.Module):  The layer to optimize for.
-        decay_ratio (float):  How much to decay penalty as images move apart in batch.
-            Defaults to 2.
     """
 
     def __init__(self, target: nn.Module, decay_ratio: float = 2.0) -> None:
+        """
+        Args:
+
+            target (nn.Module): A target layer, transform, or image parameterization
+                instance to optimize the output of.
+            decay_ratio (float): How much to decay penalty as images move apart in
+                the batch.
+                Default: 2.0
+        """
         BaseLoss.__init__(self, target)
         self.decay_ratio = decay_ratio
 
@@ -572,14 +576,6 @@ class Direction(BaseLoss):
     the alignment between the input vector and the layer’s activation vector. The
     dimensionality of the vector should correspond to the number of channels in the
     layer.
-
-    Args:
-        target (nn.Module):  The layer to optimize for.
-        vec (torch.Tensor):  Vector representing direction to align to.
-        cossim_pow (float, optional):  The desired cosine similarity power to use.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
     """
 
     def __init__(
@@ -589,6 +585,19 @@ class Direction(BaseLoss):
         cossim_pow: Optional[float] = 0.0,
         batch_index: Optional[int] = None,
     ) -> None:
+        """
+        Args:
+
+            target (nn.Module): A target layer, transform, or image parameterization
+                instance to optimize the output of.
+            vec (torch.Tensor): Vector representing direction to align to.
+            cossim_pow (float, optional): The desired cosine similarity power to use.
+                Default: 0.0
+            batch_index (int, optional): The index of activations to optimize if
+                optimizing a batch of activations. If set to None, defaults to all
+                activations in the batch.
+                Default: None
+        """
         BaseLoss.__init__(self, target, batch_index)
         self.vec = vec.reshape((1, -1, 1, 1))
         self.cossim_pow = cossim_pow

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -197,10 +197,13 @@ class LayerActivation(BaseLoss):
     their original form.
 
     Args:
-        target (nn.Module):  The layer to optimize for.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
+
+        target (nn.Module): A target layer, transform, or image parameterization
+            instance to optimize the output of.
+        batch_index (int, optional): The index of activations to optimize if
+            optimizing a batch of activations. If set to None, defaults to all
+            activations in the batch.
+            Default: None
     """
 
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
@@ -217,11 +220,14 @@ class ChannelActivation(BaseLoss):
     layer, and can be useful to determine what features the channel is excited by.
 
     Args:
-        target (nn.Module):  The layer to containing the channel to optimize for.
+
+        target (nn.Module): A target layer, transform, or image parameterization
+            instance to optimize the output of.
         channel_index (int):  The index of the channel to optimize for.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
+        batch_index (int, optional): The index of activations to optimize if
+            optimizing a batch of activations. If set to None, defaults to all
+            activations in the batch.
+            Default: None
     """
 
     def __init__(
@@ -252,17 +258,21 @@ class NeuronActivation(BaseLoss):
     research.
 
     Args:
+
         target (nn.Module):  The layer to containing the channel to optimize for.
         channel_index (int):  The index of the channel to optimize for.
         x (int, optional):  The x coordinate of the neuron to optimize for. If
             unspecified, defaults to center, or one unit left of center for even
             lengths.
+            Default: None
         y (int, optional):  The y coordinate of the neuron to optimize for. If
             unspecified, defaults to center, or one unit up of center for even
             heights.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
+            Default: None
+        batch_index (int, optional): The index of activations to optimize if
+            optimizing a batch of activations. If set to None, defaults to all
+            activations in the batch.
+            Default: None
     """
 
     def __init__(
@@ -305,10 +315,13 @@ class DeepDream(BaseLoss):
     referred to as 'Deep Dream'.
 
     Args:
-        target (nn.Module):  The layer to optimize for.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
+
+        target (nn.Module): A target layer, transform, or image parameterization
+            instance to optimize the output of.
+        batch_index (int, optional): The index of activations to optimize if
+            optimizing a batch of activations. If set to None, defaults to all
+            activations in the batch.
+            Default: None
     """
 
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
@@ -328,10 +341,13 @@ class TotalVariation(BaseLoss):
     often used to remove unwanted visual artifacts.
 
     Args:
-        target (nn.Module):  The layer to optimize for.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
+
+        target (nn.Module): A target layer, transform, or image parameterization
+            instance to optimize the output of.
+        batch_index (int, optional): The index of activations to optimize if
+            optimizing a batch of activations. If set to None, defaults to all
+            activations in the batch.
+            Default: None
     """
 
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
@@ -348,12 +364,15 @@ class L1(BaseLoss):
     L1 norm of the target layer, generally used as a penalty.
 
     Args:
-        target (nn.Module):  The layer to optimize for.
+
+        target (nn.Module): A target layer, transform, or image parameterization
+            instance to optimize the output of.
         constant (float):  Constant threshold to deduct from the activations.
-            Defaults to 0.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
+            Default: 0.0
+        batch_index (int, optional): The index of activations to optimize if
+            optimizing a batch of activations. If set to None, defaults to all
+            activations in the batch.
+            Default: None
     """
 
     def __init__(
@@ -377,13 +396,17 @@ class L2(BaseLoss):
     L2 norm of the target layer, generally used as a penalty.
 
     Args:
-        target (nn.Module):  The layer to optimize for.
+
+        target (nn.Module): A target layer, transform, or image parameterization
+            instance to optimize the output of.
         constant (float):  Constant threshold to deduct from the activations.
-            Defaults to 0.
-        epsilon (float):  Small value to add to L2 prior to sqrt. Defaults to 1e-6.
-        batch_index (int, optional):  The index of the image to optimize if we
-            optimizing a batch of images. If unspecified, defaults to all images
-            in the batch.
+            Default: 0.0
+        epsilon (float):  Small value to add to L2 prior to sqrt.
+            Default: 1e-6
+        batch_index (int, optional): The index of activations to optimize if
+            optimizing a batch of activations. If set to None, defaults to all
+            activations in the batch.
+            Default: None
     """
 
     def __init__(
@@ -416,9 +439,13 @@ class Diversity(BaseLoss):
     loss.
 
     Args:
-        target (nn.Module):  The layer to optimize for.
-        batch_index (int, optional):  Unused here since we are optimizing for diversity
-            across the batch.
+        target (nn.Module): A target layer, transform, or image parameterization
+            instance to optimize the output of.
+        batch_index (int or list of int, optional): The index or indice range of
+            activations to optimize if optimizing a batch of activations. If set to
+            None, defaults to all activations in the batch. Indice ranges should be
+            in the format of: [start, end].
+            Default: None
     """
 
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -415,7 +415,7 @@ class L2(BaseLoss):
         self,
         target: nn.Module,
         constant: float = 0.0,
-        epsilon: float = 1e-6,
+        eps: float = 1e-6,
         batch_index: Optional[Union[int, List[int]]] = None,
     ) -> None:
         """
@@ -425,7 +425,7 @@ class L2(BaseLoss):
                 instance to optimize the output of.
             constant (float): Constant threshold to deduct from the activations.
                 Default: 0.0
-            epsilon (float): Small value to add to L2 prior to sqrt.
+            eps (float): Small value to add to L2 prior to sqrt.
                 Default: 1e-6
             batch_index (int or list of int, optional): The index or indice range of
                 activations to optimize if optimizing a batch of activations. If set to
@@ -435,14 +435,14 @@ class L2(BaseLoss):
         """
         BaseLoss.__init__(self, target, batch_index)
         self.constant = constant
-        self.epsilon = epsilon
+        self.eps = eps
 
     def __call__(self, targets_to_values: ModuleOutputMapping) -> torch.Tensor:
         activations = targets_to_values[self.target][
             self.batch_index[0] : self.batch_index[1]
         ]
         activations = ((activations - self.constant) ** 2).sum()
-        return torch.sqrt(self.epsilon + activations)
+        return torch.sqrt(self.eps + activations)
 
 
 @loss_wrapper


### PR DESCRIPTION
This PR does the following:

* Implement the suggested changed from 831.
* Ensures that variable names are consistent across objectives.
* Let `batch_index` support 2 values instead of just 1.
* Fix grammar, spelling, and doc info.
* Make docs consistent across objectives.