### PR TITLE
Wrap all remaining `torch.__version__` calls in `version.parse`

### DIFF
--- a/captum/optim/__init__.py
+++ b/captum/optim/__init__.py
@@ -7,6 +7,7 @@ from captum.optim._param.image import images, transforms  # noqa: F401
 from captum.optim._param.image.images import ImageTensor  # noqa: F401
 from captum.optim._utils import circuits, reducer  # noqa: F401
 from captum.optim._utils.image import atlas  # noqa: F401
+from captum.optim._utils.image import dataset  # noqa: F401
 from captum.optim._utils.image.common import (  # noqa: F401
     hue_to_rgb,
     make_grid_image,
@@ -28,6 +29,7 @@ __all__ = [
     "reducer",
     "make_grid_image",
     "atlas",
+    "dataset",
     "hue_to_rgb",
     "nchannels_to_rgb",
     "save_tensor_as_image",

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -117,10 +117,11 @@ class ImageTensor(torch.Tensor):
                 grid image. Default is set to None for no grid image creation.
                 Default: None
             padding (int, optional): The amount of padding between images in the grid
-                images. This parameter only has an effect if `nrow` is not None.
+                images. This parameter only has an effect if `images_per_row` is not
+                None.
                 Default: 2
             pad_value (float, optional): The value to use for the padding. This
-                parameter only has an effect if `nrow` is not None.
+                parameter only has an effect if `images_per_row` is not None.
                 Default: 0.0
         """
         show(
@@ -158,10 +159,10 @@ class ImageTensor(torch.Tensor):
                 grid image. Default is set to None for no grid image creation.
                 Default: None
             padding (int, optional): The amount of padding between images in the grid
-                images. This parameter only has an effect if `nrow` is not None.
-                Default: 2
+                images. This parameter only has an effect if `images_per_row` is not
+                None.
             pad_value (float, optional): The value to use for the padding. This
-                parameter only has an effect if `nrow` is not None.
+                parameter only has an effect if `images_per_row` is not None.
                 Default: 0.0
         """
         save_tensor_as_image(

--- a/captum/optim/_utils/image/common.py
+++ b/captum/optim/_utils/image/common.py
@@ -90,10 +90,10 @@ def show(
             grid image. Default is set to None for no grid image creation.
             Default: None
         padding (int, optional): The amount of padding between images in the grid
-            images. This parameter only has an effect if nrow is not None.
+            images. This parameter only has an effect if `images_per_row` is not None.
             Default: 2
         pad_value (float, optional): The value to use for the padding. This parameter
-            only has an effect if nrow is not None.
+            only has an effect if `images_per_row` is not None.
             Default: 0.0
     """
 
@@ -140,10 +140,10 @@ def save_tensor_as_image(
             grid image. Default is set to None for no grid image creation.
             Default: None
         padding (int, optional): The amount of padding between images in the grid
-            images. This parameter only has an effect if `nrow` is not None.
+            images. This parameter only has an effect if `images_per_row` is not None.
             Default: 2
         pad_value (float, optional): The value to use for the padding. This parameter
-            only has an effect if `nrow` is not None.
+            only has an effect if `images_per_row` is not None.
             Default: 0.0
     """
 

--- a/captum/optim/_utils/typing.py
+++ b/captum/optim/_utils/typing.py
@@ -2,9 +2,9 @@ import sys
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from torch import Tensor
+from torch import distributions
 from torch.nn import Module
 from torch.optim import Optimizer
-from torch import distributions
 
 if sys.version_info >= (3, 8):
     from typing import Protocol

--- a/captum/optim/_utils/typing.py
+++ b/captum/optim/_utils/typing.py
@@ -1,9 +1,10 @@
 import sys
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
-from torch import Tensor, __version__
+from torch import Tensor
 from torch.nn import Module
 from torch.optim import Optimizer
+from torch import distributions
 
 if sys.version_info >= (3, 8):
     from typing import Protocol
@@ -33,16 +34,11 @@ StopCriteria = Callable[[int, Objective, Iterable[Tensor], Optimizer], bool]
 LossFunction = Callable[[ModuleOutputMapping], Tensor]
 SingleTargetLossFunction = Callable[[Tensor], Tensor]
 
-if __version__ < "1.4.0":
-    NumSeqOrTensorOrProbDistType = Union[Sequence[int], Sequence[float], Tensor]
-else:
-    from torch import distributions
-
-    NumSeqOrTensorOrProbDistType = Union[
-        Sequence[int],
-        Sequence[float],
-        Tensor,
-        distributions.distribution.Distribution,
-    ]
+NumSeqOrTensorOrProbDistType = Union[
+    Sequence[int],
+    Sequence[float],
+    Tensor,
+    distributions.distribution.Distribution,
+]
 IntSeqOrIntType = Union[List[int], Tuple[int], Tuple[int, int], int]
 TupleOfTensorsOrTensorType = Union[Tuple[Tensor, ...], Tensor]

--- a/captum/optim/models/__init__.py
+++ b/captum/optim/models/__init__.py
@@ -1,4 +1,5 @@
 from ._common import (  # noqa: F401
+    MaxPool2dRelaxed,
     RedirectedReluLayer,
     SkipLayer,
     collect_activations,
@@ -17,6 +18,7 @@ from ._image.inception_v1_places365_classes import (  # noqa: F401
 )
 
 __all__ = [
+    "MaxPool2dRelaxed",
     "RedirectedReluLayer",
     "SkipLayer",
     "collect_activations",

--- a/tests/optim/models/test_googlenet_places365.py
+++ b/tests/optim/models/test_googlenet_places365.py
@@ -11,7 +11,7 @@ from tests.optim.helpers.models import check_layer_in_model
 
 class TestInceptionV1Places365(BaseTest):
     def test_load_inceptionv1_places365_with_redirected_relu(self) -> None:
-        if torch.__version__ <= "1.6.0":
+        if version.parse(torch.__version__) <= version.parse("1.6.0"):
             raise unittest.SkipTest(
                 "Skipping load pretrained InceptionV1 Places365 due to insufficient"
                 + " Torch version."
@@ -22,7 +22,7 @@ class TestInceptionV1Places365(BaseTest):
         self.assertTrue(check_layer_in_model(model, RedirectedReluLayer))
 
     def test_load_inceptionv1_places365_no_redirected_relu(self) -> None:
-        if torch.__version__ <= "1.6.0":
+        if version.parse(torch.__version__) <= version.parse("1.6.0"):
             raise unittest.SkipTest(
                 "Skipping load pretrained InceptionV1 Places365 RedirectedRelu test"
                 + " due to insufficient Torch version."
@@ -34,7 +34,7 @@ class TestInceptionV1Places365(BaseTest):
         self.assertTrue(check_layer_in_model(model, torch.nn.ReLU))
 
     def test_load_inceptionv1_places365_linear(self) -> None:
-        if torch.__version__ <= "1.6.0":
+        if version.parse(torch.__version__) <= version.parse("1.6.0"):
             raise unittest.SkipTest(
                 "Skipping load pretrained InceptionV1 Places365 linear test due to"
                 + " insufficient Torch version."
@@ -47,7 +47,7 @@ class TestInceptionV1Places365(BaseTest):
         self.assertTrue(check_layer_in_model(model, torch.nn.AvgPool2d))
 
     def test_inceptionv1_places365_transform(self) -> None:
-        if torch.__version__ <= "1.6.0":
+        if version.parse(torch.__version__) <= version.parse("1.6.0"):
             raise unittest.SkipTest(
                 "Skipping InceptionV1 Places365 internal transform test due to"
                 + " insufficient Torch version."
@@ -62,7 +62,7 @@ class TestInceptionV1Places365(BaseTest):
         assertTensorAlmostEqual(self, output, expected_output, 0)
 
     def test_inceptionv1_places365_transform_warning(self) -> None:
-        if torch.__version__ <= "1.6.0":
+        if version.parse(torch.__version__) <= version.parse("1.6.0"):
             raise unittest.SkipTest(
                 "Skipping InceptionV1 Places365 internal transform warning test due"
                 + " to insufficient Torch version."
@@ -75,7 +75,7 @@ class TestInceptionV1Places365(BaseTest):
             model._transform_input(x)
 
     def test_inceptionv1_places365_load_and_forward(self) -> None:
-        if torch.__version__ <= "1.6.0":
+        if version.parse(torch.__version__) <= version.parse("1.6.0"):
             raise unittest.SkipTest(
                 "Skipping basic pretrained InceptionV1 Places365 forward test due to"
                 + " insufficient Torch version."
@@ -86,7 +86,7 @@ class TestInceptionV1Places365(BaseTest):
         self.assertEqual([list(o.shape) for o in outputs], [[1, 365]] * 3)
 
     def test_inceptionv1_places365_load_and_forward_diff_sizes(self) -> None:
-        if torch.__version__ <= "1.6.0":
+        if version.parse(torch.__version__) <= version.parse("1.6.0"):
             raise unittest.SkipTest(
                 "Skipping pretrained InceptionV1 Places365 forward with different"
                 + " sized inputs test due to insufficient Torch version."
@@ -102,7 +102,7 @@ class TestInceptionV1Places365(BaseTest):
         self.assertEqual([list(o.shape) for o in outputs2], [[1, 365]] * 3)
 
     def test_inceptionv1_places365_forward_no_aux(self) -> None:
-        if torch.__version__ <= "1.6.0":
+        if version.parse(torch.__version__) <= version.parse("1.6.0"):
             raise unittest.SkipTest(
                 "Skipping pretrained InceptionV1 Places365 with aux logits forward"
                 + " test due to insufficient Torch version."
@@ -113,7 +113,7 @@ class TestInceptionV1Places365(BaseTest):
         self.assertEqual(list(outputs.shape), [1, 365])
 
     def test_inceptionv1_places365_forward_cuda(self) -> None:
-        if torch.__version__ <= "1.6.0":
+        if version.parse(torch.__version__) <= version.parse("1.6.0"):
             raise unittest.SkipTest(
                 "Skipping pretrained InceptionV1 Places365 forward CUDA test due to"
                 + " insufficient Torch version."

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -443,7 +443,7 @@ class TestSimpleTensorParameterization(BaseTest):
         self.assertTrue(image_param.tensor.requires_grad)
 
     def test_simple_tensor_parameterization_jit_module_with_grad(self) -> None:
-        if torch.__version__ <= "1.8.0":
+        if version.parse(torch.__version__) <= version.parse("1.8.0"):
             raise unittest.SkipTest(
                 "Skipping SimpleTensorParameterization JIT module test due to"
                 + "  insufficient Torch version."

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1335,7 +1335,7 @@ class TestIgnoreAlpha(BaseTest):
         assert rgb_tensor.size(1) == 3
 
     def test_ignore_alpha_jit_module(self) -> None:
-        if torch.__version__ <= "1.8.0":
+        if version.parse(torch.__version__) <= version.parse("1.8.0"):
             raise unittest.SkipTest(
                 "Skipping IgnoreAlpha JIT module test due to insufficient"
                 + " Torch version."


### PR DESCRIPTION
* Wrap all remaining `torch.__version__` calls in `version.parse`.
* Remove unused version check in `typing.py`.
* Expose `MaxPool2dRelaxed` to users so that tutorials using it work.
* Expose `dataset` module to users.
* Fixed `show` & `save_tensor_as_image` docs.