### PR TITLE
Add missing type hints in accordance with PEP-0484

### DIFF
--- a/captum/_utils/av.py
+++ b/captum/_utils/av.py
@@ -47,7 +47,7 @@ class AV:
             identifier: Optional[str] = None,
             layer: Optional[str] = None,
             num_id: Optional[str] = None,
-        ):
+        ) -> None:
             r"""
             Loads into memory the list of all activation file paths associated
             with the input `model_id`.

--- a/captum/_utils/progress.py
+++ b/captum/_utils/progress.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 class DisableErrorIOWrapper(object):
-    def __init__(self, wrapped: TextIO):
+    def __init__(self, wrapped: TextIO) -> None:
         """
         The wrapper around a TextIO object to ignore write errors like tqdm
         https://github.com/tqdm/tqdm/blob/bcce20f771a16cb8e4ac5cc5b2307374a2c0e535/tqdm/utils.py#L131
@@ -48,7 +48,7 @@ class SimpleProgress:
         total: int = None,
         file: TextIO = None,
         mininterval: float = 0.5,
-    ):
+    ) -> None:
         """
         Simple progress output used when tqdm is unavailable.
         Same as tqdm, output to stderr channel

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from enum import Enum
-from typing import cast, Callable, DefaultDict, Iterable, List, Tuple, Union
+from typing import cast, DefaultDict, Iterable, List, Tuple, Union
 
 import torch
 from captum._utils.common import _format_tensor_into_tuples, _register_backward_hook

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from enum import Enum
-from typing import cast, DefaultDict, Iterable, List, Tuple, Union
+from typing import cast, Callable, DefaultDict, Iterable, List, Tuple, Union
 
 import torch
 from captum._utils.common import _format_tensor_into_tuples, _register_backward_hook
@@ -103,8 +103,8 @@ class SampleGradientWrapper:
     def __init__(self, model) -> None:
         self.model = model
         self.hooks_added = False
-        self.activation_dict: DefaultDict[Module, Tensor] = defaultdict(list)
-        self.gradient_dict: DefaultDict[Module, Tensor] = defaultdict(list)
+        self.activation_dict: DefaultDict[Module, List[Tensor]] = defaultdict(list)
+        self.gradient_dict: DefaultDict[Module, List[Tensor]] = defaultdict(list)
         self.forward_hooks: List[Callable] = []
         self.backward_hooks: List[Callable] = []
 
@@ -152,8 +152,8 @@ class SampleGradientWrapper:
         self.backward_hooks: List[Callable] = []
 
     def _reset(self) -> None:
-        self.activation_dict: DefaultDict[Module, Tensor] = defaultdict(list)
-        self.gradient_dict: DefaultDict[Module, Tensor] = defaultdict(list)
+        self.activation_dict: DefaultDict[Module, List[Tensor]] = defaultdict(list)
+        self.gradient_dict: DefaultDict[Module, List[Tensor]] = defaultdict(list)
 
     def compute_param_sample_gradients(self, loss_blob, loss_mode="mean") -> None:
         assert (

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -100,7 +100,7 @@ class SampleGradientWrapper:
     - https://github.com/pytorch/opacus/tree/main/opacus/grad_sample
     """
 
-    def __init__(self, model):
+    def __init__(self, model) -> None:
         self.model = model
         self.hooks_added = False
         self.activation_dict = defaultdict(list)

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -148,8 +148,8 @@ class SampleGradientWrapper:
         for hook in self.backward_hooks:
             hook.remove()
 
-        self.forward_hooks: List[Callable] = []
-        self.backward_hooks: List[Callable] = []
+        self.forward_hooks = []
+        self.backward_hooks = []
 
     def _reset(self) -> None:
         self.activation_dict: DefaultDict[Module, List[Tensor]] = defaultdict(list)

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -105,8 +105,8 @@ class SampleGradientWrapper:
         self.hooks_added = False
         self.activation_dict: DefaultDict[Module, List[Tensor]] = defaultdict(list)
         self.gradient_dict: DefaultDict[Module, List[Tensor]] = defaultdict(list)
-        self.forward_hooks: List[Callable] = []
-        self.backward_hooks: List[Callable] = []
+        self.forward_hooks: List[torch.utils.hooks.RemovableHandle] = []
+        self.backward_hooks: List[torch.utils.hooks.RemovableHandle] = []
 
     def add_hooks(self) -> None:
         self.hooks_added = True
@@ -152,8 +152,8 @@ class SampleGradientWrapper:
         self.backward_hooks = []
 
     def _reset(self) -> None:
-        self.activation_dict: DefaultDict[Module, List[Tensor]] = defaultdict(list)
-        self.gradient_dict: DefaultDict[Module, List[Tensor]] = defaultdict(list)
+        self.activation_dict = defaultdict(list)
+        self.gradient_dict = defaultdict(list)
 
     def compute_param_sample_gradients(self, loss_blob, loss_mode="mean") -> None:
         assert (

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from enum import Enum
-from typing import cast, Iterable, Tuple, Union
+from typing import cast, DefaultDict, Iterable, List, Tuple, Union
 
 import torch
 from captum._utils.common import _format_tensor_into_tuples, _register_backward_hook
@@ -8,7 +8,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
-def _reset_sample_grads(module: Module):
+def _reset_sample_grads(module: Module) -> None:
     module.weight.sample_grad = 0  # type: ignore
     if module.bias is not None:
         module.bias.sample_grad = 0  # type: ignore
@@ -103,16 +103,16 @@ class SampleGradientWrapper:
     def __init__(self, model) -> None:
         self.model = model
         self.hooks_added = False
-        self.activation_dict = defaultdict(list)
-        self.gradient_dict = defaultdict(list)
-        self.forward_hooks = []
-        self.backward_hooks = []
+        self.activation_dict: DefaultDict[Module, Tensor] = defaultdict(list)
+        self.gradient_dict: DefaultDict[Module, Tensor] = defaultdict(list)
+        self.forward_hooks: List[Callable] = []
+        self.backward_hooks: List[Callable] = []
 
-    def add_hooks(self):
+    def add_hooks(self) -> None:
         self.hooks_added = True
         self.model.apply(self._register_module_hooks)
 
-    def _register_module_hooks(self, module: torch.nn.Module):
+    def _register_module_hooks(self, module: torch.nn.Module) -> None:
         if isinstance(module, tuple(SUPPORTED_MODULES.keys())):
             self.forward_hooks.append(
                 module.register_forward_hook(self._forward_hook_fn)
@@ -126,7 +126,7 @@ class SampleGradientWrapper:
         module: Module,
         module_input: Union[Tensor, Tuple[Tensor, ...]],
         module_output: Union[Tensor, Tuple[Tensor, ...]],
-    ):
+    ) -> None:
         inp_tuple = _format_tensor_into_tuples(module_input)
         self.activation_dict[module].append(inp_tuple[0].clone().detach())
 
@@ -135,11 +135,11 @@ class SampleGradientWrapper:
         module: Module,
         grad_input: Union[Tensor, Tuple[Tensor, ...]],
         grad_output: Union[Tensor, Tuple[Tensor, ...]],
-    ):
+    ) -> None:
         grad_output_tuple = _format_tensor_into_tuples(grad_output)
         self.gradient_dict[module].append(grad_output_tuple[0].clone().detach())
 
-    def remove_hooks(self):
+    def remove_hooks(self) -> None:
         self.hooks_added = False
 
         for hook in self.forward_hooks:
@@ -148,14 +148,14 @@ class SampleGradientWrapper:
         for hook in self.backward_hooks:
             hook.remove()
 
-        self.forward_hooks = []
-        self.backward_hooks = []
+        self.forward_hooks: List[Callable] = []
+        self.backward_hooks: List[Callable] = []
 
-    def _reset(self):
-        self.activation_dict = defaultdict(list)
-        self.gradient_dict = defaultdict(list)
+    def _reset(self) -> None:
+        self.activation_dict: DefaultDict[Module, Tensor] = defaultdict(list)
+        self.gradient_dict: DefaultDict[Module, Tensor] = defaultdict(list)
 
-    def compute_param_sample_gradients(self, loss_blob, loss_mode="mean"):
+    def compute_param_sample_gradients(self, loss_blob, loss_mode="mean") -> None:
         assert (
             loss_mode.upper() in LossMode.__members__
         ), f"Provided loss mode {loss_mode} is not valid"

--- a/captum/concept/_core/tcav.py
+++ b/captum/concept/_core/tcav.py
@@ -27,7 +27,7 @@ class LabelledDataset(Dataset):
     It is used to train a classifier in train_tcav
     """
 
-    def __init__(self, datasets: List[AV.AVDataset], labels: List[int]):
+    def __init__(self, datasets: List[AV.AVDataset], labels: List[int]) -> None:
         """
         Creates the LabelledDataset given a list of K Datasets, and a length K
         list of integer labels representing K different concepts.

--- a/captum/concept/_utils/classifier.py
+++ b/captum/concept/_utils/classifier.py
@@ -178,7 +178,7 @@ class DefaultClassifier(Classifier):
 
         predict = self.lm(x_test)
 
-        predict = self.lm.classes()[torch.argmax(predict, dim=1)]
+        predict = self.lm.classes()[torch.argmax(predict, dim=1)]  # type: ignore
         score = predict.long() == y_test.long().cpu()
 
         accs = score.float().mean()
@@ -217,7 +217,7 @@ class DefaultClassifier(Classifier):
             classes (list): The list of classes used by the classifier to train
             the model in the `train_and_eval` method.
         """
-        return self.lm.classes().detach().numpy()
+        return self.lm.classes().detach().numpy()  # type: ignore
 
 
 def _train_test_split(

--- a/captum/concept/_utils/classifier.py
+++ b/captum/concept/_utils/classifier.py
@@ -126,7 +126,7 @@ class DefaultClassifier(Classifier):
     class and handles large concept datasets accordingly.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         warnings.warn(
             "Using default classifier for TCAV which keeps input"
             " both train and test datasets in the memory. Consider defining"

--- a/captum/influence/_core/similarity_influence.py
+++ b/captum/influence/_core/similarity_influence.py
@@ -77,7 +77,7 @@ class SimilarityInfluence(DataInfluence):
         similarity_direction: str = "max",
         batch_size: int = 1,
         **kwargs: Any,
-    ):
+    ) -> None:
         r"""
         Args:
             module (torch.nn.Module): An instance of pytorch model. This model should

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -305,7 +305,7 @@ def _get_k_most_influential_helper(
 
 
 class _DatasetFromList(Dataset):
-    def __init__(self, _l: List[Any]):
+    def __init__(self, _l: List[Any]) -> None:
         self._l = _l
 
     def __getitem__(self, i: int) -> Any:

--- a/captum/influence/_utils/nearest_neighbors.py
+++ b/captum/influence/_utils/nearest_neighbors.py
@@ -92,7 +92,7 @@ class AnnoyNearestNeighbors(NearestNeighbors):
     but arbitrary shape *, and flatten them before storing in the Annoy data structure.
     """
 
-    def __init__(self, num_trees: int = 10):
+    def __init__(self, num_trees: int = 10) -> None:
         """
         Args:
             num_trees (int): The number of trees to use. Increasing this number gives

--- a/captum/log/__init__.py
+++ b/captum/log/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
 
     # bug with mypy: https://github.com/python/mypy/issues/1153
     class TimedLog:  # type: ignore
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args, **kwargs) -> None:
             pass
 
         def __enter__(self):

--- a/captum/robust/_core/metrics/min_param_perturbation.py
+++ b/captum/robust/_core/metrics/min_param_perturbation.py
@@ -51,7 +51,7 @@ class MinParamPerturbation:
         preproc_fn: Optional[Callable] = None,
         apply_before_preproc: bool = False,
         correct_fn: Optional[Callable] = None,
-    ):
+    ) -> None:
         r"""
         Identifies minimal perturbation based on target variable which causes
         misclassification (or other incorrect prediction) of target input.

--- a/tests/attr/test_hook_removal.py
+++ b/tests/attr/test_hook_removal.py
@@ -45,7 +45,7 @@ class HookRemovalMode(Enum):
 class ErrorModule(Module):
     def __init__(
         self,
-    ):
+    ) -> None:
         super().__init__()
         self.relu = torch.nn.ReLU()
 

--- a/tests/concept/test_concept.py
+++ b/tests/concept/test_concept.py
@@ -14,7 +14,7 @@ class CustomIterableDataset(IterableDataset):
     An auxiliary class for iterating through an image dataset.
     """
 
-    def __init__(self, get_tensor_from_filename_func, path):
+    def __init__(self, get_tensor_from_filename_func, path) -> None:
         r"""
         Args:
 

--- a/tests/helpers/basic_models.py
+++ b/tests/helpers/basic_models.py
@@ -16,7 +16,7 @@ the relevant type hints.
 
 
 class BasicLinearReLULinear(nn.Module):
-    def __init__(self, in_features, out_features=5, bias=False):
+    def __init__(self, in_features, out_features=5, bias=False) -> None:
         super().__init__()
         self.fc1 = nn.Linear(in_features, out_features, bias=bias)
         self.relu1 = nn.ReLU()
@@ -30,7 +30,7 @@ class BasicLinearReLULinear(nn.Module):
 
 
 class MixedKwargsAndArgsModule(nn.Module):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def forward(self, x, y=None):
@@ -135,7 +135,7 @@ class BasicLinearModel(nn.Module):
 
 
 class BasicLinearModel2(nn.Module):
-    def __init__(self, in_features, out_features):
+    def __init__(self, in_features, out_features) -> None:
         super().__init__()
         self.linear = nn.Linear(in_features, out_features, bias=False)
 
@@ -144,7 +144,7 @@ class BasicLinearModel2(nn.Module):
 
 
 class BasicLinearModel_Multilayer(nn.Module):
-    def __init__(self, in_features, hidden_nodes, out_features):
+    def __init__(self, in_features, hidden_nodes, out_features) -> None:
         super().__init__()
         self.linear1 = nn.Linear(in_features, hidden_nodes, bias=False)
         self.linear2 = nn.Linear(hidden_nodes, out_features, bias=False)
@@ -433,7 +433,7 @@ class BasicModel_MultiLayer_MultiInput(nn.Module):
 
 
 class BasicModel_MultiLayer_TrueMultiInput(nn.Module):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.m1 = BasicModel_MultiLayer()
         self.m234 = BasicModel_MultiLayer_MultiInput()

--- a/tests/influence/_core/test_similarity_influence.py
+++ b/tests/influence/_core/test_similarity_influence.py
@@ -13,7 +13,7 @@ from torch.utils.data import Dataset
 
 
 class BasicLinearNet(nn.Module):
-    def __init__(self, num_features):
+    def __init__(self, num_features) -> None:
         super().__init__()
         self.fc1 = nn.Linear(num_features, 5, bias=False)
         self.fc1.weight.data.fill_(0.02)
@@ -29,7 +29,7 @@ class BasicLinearNet(nn.Module):
 
 
 class RangeDataset(Dataset):
-    def __init__(self, low, high, num_features):
+    def __init__(self, low, high, num_features) -> None:
         self.samples = (
             torch.arange(start=low, end=high, dtype=torch.float)
             .repeat(num_features, 1)

--- a/tests/influence/_utils/common.py
+++ b/tests/influence/_utils/common.py
@@ -26,7 +26,7 @@ def isSorted(x, key=lambda x: x, descending=True):
 
 
 class ExplicitDataset(Dataset):
-    def __init__(self, samples, labels):
+    def __init__(self, samples, labels) -> None:
         self.samples, self.labels = samples, labels
 
     def __len__(self):
@@ -37,7 +37,7 @@ class ExplicitDataset(Dataset):
 
 
 class UnpackDataset(Dataset):
-    def __init__(self, samples, labels):
+    def __init__(self, samples, labels) -> None:
         self.samples, self.labels = samples, labels
 
     def __len__(self):
@@ -52,13 +52,13 @@ class UnpackDataset(Dataset):
 
 
 class IdentityDataset(ExplicitDataset):
-    def __init__(self, num_features):
+    def __init__(self, num_features) -> None:
         self.samples = torch.diag(torch.ones(num_features))
         self.labels = torch.zeros(num_features).unsqueeze(1)
 
 
 class RangeDataset(ExplicitDataset):
-    def __init__(self, low, high, num_features):
+    def __init__(self, low, high, num_features) -> None:
         self.samples = (
             torch.arange(start=low, end=high, dtype=torch.float)
             .repeat(num_features, 1)
@@ -68,7 +68,7 @@ class RangeDataset(ExplicitDataset):
 
 
 class BinaryDataset(ExplicitDataset):
-    def __init__(self):
+    def __init__(self) -> None:
         self.samples = F.normalize(
             torch.stack(
                 (
@@ -108,7 +108,7 @@ class BinaryDataset(ExplicitDataset):
 
 
 class CoefficientNet(nn.Module):
-    def __init__(self, in_features=1):
+    def __init__(self, in_features=1) -> None:
         super().__init__()
         self.fc1 = nn.Linear(in_features, 1, bias=False)
         self.fc1.weight.data.fill_(0.01)
@@ -119,7 +119,7 @@ class CoefficientNet(nn.Module):
 
 
 class BasicLinearNet(nn.Module):
-    def __init__(self, in_features, hidden_nodes, out_features):
+    def __init__(self, in_features, hidden_nodes, out_features) -> None:
         super().__init__()
         self.linear1 = nn.Linear(in_features, hidden_nodes)
         self.linear2 = nn.Linear(hidden_nodes, out_features)
@@ -130,7 +130,7 @@ class BasicLinearNet(nn.Module):
 
 
 class MultLinearNet(nn.Module):
-    def __init__(self, in_features, hidden_nodes, out_features, num_inputs):
+    def __init__(self, in_features, hidden_nodes, out_features, num_inputs) -> None:
         super().__init__()
         self.pre = nn.Linear(in_features * num_inputs, in_features)
         self.linear1 = nn.Linear(in_features, hidden_nodes)
@@ -206,7 +206,7 @@ class DataInfluenceConstructor:
 
     def __init__(
         self, data_influence_class: type, name: Optional[str] = None, **kwargs
-    ):
+    ) -> None:
         self.data_influence_class = data_influence_class
         self.name = name if name else data_influence_class.__name__
         self.kwargs = kwargs

--- a/tests/robust/test_attack_comparator.py
+++ b/tests/robust/test_attack_comparator.py
@@ -51,7 +51,7 @@ def string_batch_perturb(inp: List[List[str]]) -> List[List[str]]:
 
 
 class SamplePerturb:
-    def __init__(self):
+    def __init__(self) -> None:
         self.count = 0
 
     def perturb(self, inp: Tensor) -> Tensor:

--- a/tests/utils/test_av.py
+++ b/tests/utils/test_av.py
@@ -13,7 +13,7 @@ DEFAULT_IDENTIFIER = "default_identifier"
 
 
 class RangeDataset(Dataset):
-    def __init__(self, low, high, num_features):
+    def __init__(self, low, high, num_features) -> None:
         self.samples = (
             torch.arange(start=low, end=high, dtype=torch.float)
             .repeat(num_features, 1)


### PR DESCRIPTION
Adding `-> None` to `__init__` functions is specified by [PEP-0484](https://www.python.org/dev/peps/pep-0484/) and is really easy to do with regex, so I went ahead and did it for the `captum/` & `tests/` directories.

https://stackoverflow.com/questions/64948233/how-to-add-none-to-the-end-of-init-functions-with-notepad