### PR TITLE
NaturalImage dtype test fix

### DIFF
--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -1307,9 +1307,11 @@ class TestNaturalImage(BaseTest):
             raise unittest.SkipTest(
                 "Skipping NaturalImage float16 dtype test due to not supporting CUDA."
             )
-        image_param = images.NaturalImage(
-            size=(256, 256), decorrelation_module=ToRGB("klt")
-        ).cuda().to(dtype=torch.float16)
+        image_param = (
+            images.NaturalImage(size=(256, 256), decorrelation_module=ToRGB("klt"))
+            .cuda()
+            .to(dtype=torch.float16)
+        )
         output = image_param()
         self.assertEqual(output.dtype, torch.float16)
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -1297,7 +1297,8 @@ class TestNaturalImage(BaseTest):
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
                 "Skipping NaturalImage float16 dtype test due to not supporting CUDA."
-            )        image_param = images.NaturalImage(
+            )
+        image_param = images.NaturalImage(
             size=(256, 256), decorrelation_module=ToRGB("KLT")
         ).to(dtype=torch.float16)
         output = image_param()

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -1314,10 +1314,3 @@ class TestNaturalImage(BaseTest):
         )
         output = image_param()
         self.assertEqual(output.dtype, torch.float16)
-
-    def test_natural_image_forward_dtype_bfloat16(self) -> None:
-        image_param = images.NaturalImage(
-            size=(224, 224), decorrelation_module=ToRGB("klt")
-        ).to(dtype=torch.bfloat16)
-        output = image_param()
-        self.assertEqual(output.dtype, torch.bfloat16)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -1287,3 +1287,18 @@ class TestNaturalImage(BaseTest):
         ).to(dtype=torch.float32)
         output = image_param()
         self.assertEqual(output.dtype, torch.float32)
+
+    def test_fftimage_forward_dtype_float16(self) -> None:
+        if version.parse(torch.__version__) <= version.parse("1.12.0"):
+            raise unittest.SkipTest(
+                "Skipping NaturalImage float16 dtype test due to"
+                + "  insufficient Torch version."
+            )
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping NaturalImage float16 dtype test due to not supporting CUDA."
+            )        image_param = images.NaturalImage(
+            size=(256, 256), decorrelation_module=ToRGB("KLT")
+        ).to(dtype=torch.float16)
+        output = image_param()
+        self.assertEqual(output.dtype, torch.float16)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -1275,13 +1275,15 @@ class TestNaturalImage(BaseTest):
         assertTensorAlmostEqual(self, image, torch.sigmoid(init_tensor))
 
     def test_natural_image_forward_dtype_float64(self) -> None:
-        raise unittest.SkipTest("Skipping test due to bug")
-        image_param = images.NaturalImage(size=(224, 224), decorrelation_module=ToRGB("KLT")).to(dtype=torch.float64)
+        image_param = images.NaturalImage(
+            size=(224, 224), decorrelation_module=ToRGB("KLT")
+        ).to(dtype=torch.float64)
         output = image_param()
         self.assertEqual(output.dtype, torch.float64)
 
     def test_natural_image_forward_dtype_float32(self) -> None:
-        raise unittest.SkipTest("Skipping test due to bug")
-        image_param = images.NaturalImage(size=(224, 224), decorrelation_module=ToRGB("KLT")).to(dtype=torch.float32)
+        image_param = images.NaturalImage(
+            size=(224, 224), decorrelation_module=ToRGB("KLT")
+        ).to(dtype=torch.float32)
         output = image_param()
         self.assertEqual(output.dtype, torch.float32)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -1276,14 +1276,14 @@ class TestNaturalImage(BaseTest):
 
     def test_natural_image_forward_dtype_float64(self) -> None:
         image_param = images.NaturalImage(
-            size=(224, 224), decorrelation_module=ToRGB("KLT")
+            size=(224, 224), decorrelation_module=ToRGB("klt")
         ).to(dtype=torch.float64)
         output = image_param()
         self.assertEqual(output.dtype, torch.float64)
 
     def test_natural_image_forward_dtype_float32(self) -> None:
         image_param = images.NaturalImage(
-            size=(224, 224), decorrelation_module=ToRGB("KLT")
+            size=(224, 224), decorrelation_module=ToRGB("klt")
         ).to(dtype=torch.float32)
         output = image_param()
         self.assertEqual(output.dtype, torch.float32)
@@ -1299,7 +1299,7 @@ class TestNaturalImage(BaseTest):
                 "Skipping NaturalImage float16 dtype test due to not supporting CUDA."
             )
         image_param = images.NaturalImage(
-            size=(256, 256), decorrelation_module=ToRGB("KLT")
+            size=(256, 256), decorrelation_module=ToRGB("klt")
         ).to(dtype=torch.float16)
         output = image_param()
         self.assertEqual(output.dtype, torch.float16)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -1303,3 +1303,10 @@ class TestNaturalImage(BaseTest):
         ).to(dtype=torch.float16)
         output = image_param()
         self.assertEqual(output.dtype, torch.float16)
+
+    def test_natural_image_forward_dtype_bfloat16(self) -> None:
+        image_param = images.NaturalImage(
+            size=(224, 224), decorrelation_module=ToRGB("klt")
+        ).to(dtype=torch.bfloat16)
+        output = image_param()
+        self.assertEqual(output.dtype, torch.bfloat16)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -327,14 +327,16 @@ class TestFFTImage(BaseTest):
         )
 
     def test_fftimage_forward_dtype_float64(self) -> None:
-        image_param = images.FFTImage(size=(224, 224)).to(dtype=torch.float64)
+        dtype = torch.float64
+        image_param = images.FFTImage(size=(224, 224)).to(dtype=dtype)
         output = image_param()
-        self.assertEqual(output.dtype, torch.float64)
+        self.assertEqual(output.dtype, dtype)
 
     def test_fftimage_forward_dtype_float32(self) -> None:
-        image_param = images.FFTImage(size=(224, 224)).to(dtype=torch.float32)
+        dtype = torch.float32
+        image_param = images.FFTImage(size=(224, 224)).to(dtype=dtype)
         output = image_param()
-        self.assertEqual(output.dtype, torch.float32)
+        self.assertEqual(output.dtype, dtype)
 
     def test_fftimage_forward_dtype_float16(self) -> None:
         if version.parse(torch.__version__) <= version.parse("1.12.0"):
@@ -342,13 +344,14 @@ class TestFFTImage(BaseTest):
                 "Skipping FFTImage float16 dtype test due to"
                 + "  insufficient Torch version."
             )
+        dtype = torch.float16
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
                 "Skipping FFTImage float16 dtype test due to not supporting CUDA."
             )
-        image_param = images.FFTImage(size=(256, 256)).to(dtype=torch.float16)
+        image_param = images.FFTImage(size=(256, 256)).to(dtype=dtype)
         output = image_param()
-        self.assertEqual(output.dtype, torch.float16)
+        self.assertEqual(output.dtype, dtype)
 
 
 class TestPixelImage(BaseTest):
@@ -500,14 +503,16 @@ class TestLaplacianImage(BaseTest):
         self.assertTrue(test_tensor.requires_grad)
 
     def test_laplcianimage_forward_dtype_float64(self) -> None:
-        image_param = images.LaplacianImage(size=(224, 224)).to(dtype=torch.float64)
+        dtype = torch.float64
+        image_param = images.LaplacianImage(size=(224, 224)).to(dtype=dtype)
         output = image_param()
-        self.assertEqual(output.dtype, torch.float64)
+        self.assertEqual(output.dtype, dtype)
 
     def test_laplcianimage_forward_dtype_float32(self) -> None:
-        image_param = images.LaplacianImage(size=(224, 224)).to(dtype=torch.float32)
+        dtype = torch.float32
+        image_param = images.LaplacianImage(size=(224, 224)).to(dtype=dtype)
         output = image_param()
-        self.assertEqual(output.dtype, torch.float32)
+        self.assertEqual(output.dtype, dtype)
 
 
 class TestSimpleTensorParameterization(BaseTest):
@@ -1284,18 +1289,20 @@ class TestNaturalImage(BaseTest):
         assertTensorAlmostEqual(self, image, torch.sigmoid(init_tensor))
 
     def test_natural_image_forward_dtype_float64(self) -> None:
+        dtype = torch.float64
         image_param = images.NaturalImage(
             size=(224, 224), decorrelation_module=ToRGB("klt")
-        ).to(dtype=torch.float64)
+        ).to(dtype=dtype)
         output = image_param()
-        self.assertEqual(output.dtype, torch.float64)
+        self.assertEqual(output.dtype, dtype)
 
     def test_natural_image_forward_dtype_float32(self) -> None:
+        dtype = torch.float32
         image_param = images.NaturalImage(
             size=(224, 224), decorrelation_module=ToRGB("klt")
-        ).to(dtype=torch.float32)
+        ).to(dtype=dtype)
         output = image_param()
-        self.assertEqual(output.dtype, torch.float32)
+        self.assertEqual(output.dtype, dtype)
 
     def test_fftimage_forward_dtype_float16(self) -> None:
         if version.parse(torch.__version__) <= version.parse("1.12.0"):
@@ -1307,10 +1314,11 @@ class TestNaturalImage(BaseTest):
             raise unittest.SkipTest(
                 "Skipping NaturalImage float16 dtype test due to not supporting CUDA."
             )
+        dtype = torch.float16
         image_param = (
             images.NaturalImage(size=(256, 256), decorrelation_module=ToRGB("klt"))
             .cuda()
-            .to(dtype=torch.float16)
+            .to(dtype=dtype)
         )
         output = image_param()
-        self.assertEqual(output.dtype, torch.float16)
+        self.assertEqual(output.dtype, dtype)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -1276,12 +1276,12 @@ class TestNaturalImage(BaseTest):
 
     def test_natural_image_forward_dtype_float64(self) -> None:
         raise unittest.SkipTest("Skipping test due to bug")
-        image_param = images.NaturalImage(size=(224, 224)).to(dtype=torch.float64)
+        image_param = images.NaturalImage(size=(224, 224), decorrelation_module=ToRGB("KLT")).to(dtype=torch.float64)
         output = image_param()
         self.assertEqual(output.dtype, torch.float64)
 
     def test_natural_image_forward_dtype_float32(self) -> None:
         raise unittest.SkipTest("Skipping test due to bug")
-        image_param = images.NaturalImage(size=(224, 224)).to(dtype=torch.float32)
+        image_param = images.NaturalImage(size=(224, 224), decorrelation_module=ToRGB("KLT")).to(dtype=torch.float32)
         output = image_param()
         self.assertEqual(output.dtype, torch.float32)

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -1309,7 +1309,7 @@ class TestNaturalImage(BaseTest):
             )
         image_param = images.NaturalImage(
             size=(256, 256), decorrelation_module=ToRGB("klt")
-        ).to(dtype=torch.float16)
+        ).cuda().to(dtype=torch.float16)
         output = image_param()
         self.assertEqual(output.dtype, torch.float16)
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -419,19 +419,28 @@ class TestPixelImage(BaseTest):
         assertTensorAlmostEqual(self, test_tensor, init_tensor[None, :], 0)
 
     def test_pixelimage_forward_dtype_float64(self) -> None:
-        image_param = images.PixelImage(size=(224, 224)).to(dtype=torch.float64)
+        dtype = torch.float64
+        image_param = images.PixelImage(size=(224, 224)).to(dtype=dtype)
         output = image_param()
         self.assertEqual(output.dtype, torch.float64)
 
     def test_pixelimage_forward_dtype_float32(self) -> None:
-        image_param = images.PixelImage(size=(224, 224)).to(dtype=torch.float32)
+        dtype = torch.float32
+        image_param = images.PixelImage(size=(224, 224)).to(dtype=dtype)
         output = image_param()
         self.assertEqual(output.dtype, torch.float32)
 
     def test_pixelimage_forward_dtype_float16(self) -> None:
-        image_param = images.PixelImage(size=(224, 224)).to(dtype=torch.float16)
+        dtype = torch.float16
+        image_param = images.PixelImage(size=(224, 224)).to(dtype)
         output = image_param()
-        self.assertEqual(output.dtype, torch.float16)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_pixelimage_forward_dtype_bfloat16(self) -> None:
+        dtype = torch.bfloat16
+        image_param = images.PixelImage(size=(224, 224)).to(dtype=dtype)
+        output = image_param()
+        self.assertEqual(output.dtype, dtype)
 
 
 class TestLaplacianImage(BaseTest):

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -275,13 +275,6 @@ class TestRandomScale(BaseTest):
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
-    def test_random_scale_dtype_float16(self) -> None:
-        dtype = torch.float16
-        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
-        x = torch.ones([1, 3, 224, 224], dtype=dtype)
-        output = scale_module(x)
-        self.assertEqual(output.dtype, dtype)
-
 
 class TestRandomScaleAffine(BaseTest):
     def test_random_scale_affine_init(self) -> None:
@@ -460,13 +453,6 @@ class TestRandomScaleAffine(BaseTest):
 
     def test_random_scale_affine_dtype_float32(self) -> None:
         dtype = torch.float32
-        scale_module = transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
-        x = torch.ones([1, 3, 224, 224], dtype=dtype)
-        output = scale_module(x)
-        self.assertEqual(output.dtype, dtype)
-
-    def test_random_scale_affine_dtype_float16(self) -> None:
-        dtype = torch.float16
         scale_module = transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
@@ -687,14 +673,6 @@ class TestRandomRotation(BaseTest):
         output = rotation_module(x)
         self.assertEqual(output.dtype, dtype)
 
-    def test_random_rotation_dtype_float16(self) -> None:
-        dtype = torch.float16
-        degrees = list(range(-25, -5)) + list(range(5, 25))
-        rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
-        x = torch.ones([1, 3, 224, 224], dtype=dtype)
-        output = rotation_module(x)
-        self.assertEqual(output.dtype, dtype)
-
 
 class TestRandomSpatialJitter(BaseTest):
     def test_random_spatial_jitter_init(self) -> None:
@@ -789,13 +767,6 @@ class TestRandomSpatialJitter(BaseTest):
 
     def test_random_spatial_jitter_dtype_float32(self) -> None:
         dtype = torch.float32
-        spatialjitter = transforms.RandomSpatialJitter(5).to(dtype=dtype)
-        x = torch.ones([1, 3, 224, 224], dtype=dtype)
-        output = spatialjitter(x)
-        self.assertEqual(output.dtype, dtype)
-
-    def test_random_spatial_jitter_dtype_float16(self) -> None:
-        dtype = torch.float16
         spatialjitter = transforms.RandomSpatialJitter(5).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = spatialjitter(x)
@@ -1685,8 +1656,6 @@ class TestToRGB(BaseTest):
         test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
         output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
         self.assertEqual(output.dtype, dtype)
-        inverse_output = to_rgb(output, inverse=True)
-        self.assertEqual(inverse_output.dtype, dtype)
 
 
 class TestGaussianSmoothing(BaseTest):
@@ -2165,13 +2134,6 @@ class TestTransformationRobustness(BaseTest):
 
     def test_transform_robustness_dtype_float32(self) -> None:
         dtype = torch.float32
-        transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
-        x = torch.ones([1, 3, 224, 224], dtype=dtype)
-        output = transform_robustness(x)
-        self.assertEqual(output.dtype, dtype)
-
-    def test_transform_robustness_dtype_float16(self) -> None:
-        dtype = torch.float16
         transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = transform_robustness(x)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1640,6 +1640,33 @@ class TestToRGB(BaseTest):
             self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
         )
 
+    def test_to_rgb_dtype_float64(self) -> None:
+        dtype = torch.float64
+        to_rgb = transforms.ToRGB(transform="klt").to(dtype=dtype)
+        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
+        output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
+        self.assertEqual(output.dtype, dtype)
+        inverse_output = to_rgb(output, inverse=True)
+        self.assertEqual(inverse_output.dtype, dtype)
+
+    def test_to_rgb_dtype_float32(self) -> None:
+        dtype = torch.float32
+        to_rgb = transforms.ToRGB(transform="klt").to(dtype=dtype)
+        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
+        output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
+        self.assertEqual(output.dtype, dtype)
+        inverse_output = to_rgb(output, inverse=True)
+        self.assertEqual(inverse_output.dtype, dtype)
+
+    def test_to_rgb_dtype_float16(self) -> None:
+        dtype = torch.float16
+        to_rgb = transforms.ToRGB(transform="klt").to(dtype=dtype)
+        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
+        output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
+        self.assertEqual(output.dtype, dtype)
+        inverse_output = to_rgb(output, inverse=True)
+        self.assertEqual(inverse_output.dtype, dtype)
+
 
 class TestGaussianSmoothing(BaseTest):
     def test_gaussian_smoothing_init_1d(self) -> None:

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -458,6 +458,18 @@ class TestRandomScaleAffine(BaseTest):
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
+    def test_random_scale_affine_dtype_float16(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping RandomScaleAffine float16 dtype test due to not supporting"
+                + " CUDA."
+            )
+        dtype = torch.float16
+        scale_module = transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05]).cuda().to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype).cuda()
+        output = scale_module(x)
+        self.assertEqual(output.dtype, dtype)
+
 
 class TestRandomRotation(BaseTest):
     def test_random_rotation_init(self) -> None:
@@ -670,6 +682,19 @@ class TestRandomRotation(BaseTest):
         degrees = list(range(-25, -5)) + list(range(5, 25))
         rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = rotation_module(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_rotation_dtype_float16(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping RandomRotation float16 dtype test due to not supporting"
+                + " CUDA."
+            )
+        dtype = torch.float16
+        degrees = list(range(-25, -5)) + list(range(5, 25))
+        rotation_module = transforms.RandomRotation(degrees=degrees).cuda().to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype).cuda()
         output = rotation_module(x)
         self.assertEqual(output.dtype, dtype)
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -265,7 +265,7 @@ class TestRandomScale(BaseTest):
         dtype = torch.float64
         scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
-        output_tensor = scale_module(x)
+        output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
     def test_random_scale_dtype_float32(self) -> None:
@@ -673,7 +673,7 @@ class TestRandomRotation(BaseTest):
 
     def test_random_rotation_dtype_float64(self) -> None:
         dtype = torch.float64
-        degrees = list(range(-25, 25))
+        degrees = list(range(-25, -5)) + list(range(5, 25))
         rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = rotation_module(x)
@@ -681,15 +681,15 @@ class TestRandomRotation(BaseTest):
 
     def test_random_rotation_dtype_float32(self) -> None:
         dtype = torch.float32
-        degrees = list(range(-25, 25))
+        degrees = list(range(-25, -5)) + list(range(5, 25))
         rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = rotation_module(x)
         self.assertEqual(output.dtype, dtype)
 
     def test_random_rotation_dtype_float16(self) -> None:
-        dtype = float16
-        degrees = list(range(-25, 25))
+        dtype = torch.float16
+        degrees = list(range(-25, -5)) + list(range(5, 25))
         rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = rotation_module(x)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -780,6 +780,27 @@ class TestRandomSpatialJitter(BaseTest):
         jittered_tensor = jit_spatialjitter(test_input)
         self.assertEqual(list(jittered_tensor.shape), list(test_input.shape))
 
+    def test_random_spatial_jitter_dtype_float64(self) -> None:
+        dtype = torch.float64
+        spatialjitter = transforms.RandomSpatialJitter(5).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = spatialjitter(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_spatial_jitter_dtype_float32(self) -> None:
+        dtype = torch.float32
+        spatialjitter = transforms.RandomSpatialJitter(5).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = spatialjitter(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_spatial_jitter_dtype_float16(self) -> None:
+        dtype = torch.float16
+        spatialjitter = transforms.RandomSpatialJitter(5).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = spatialjitter(x)
+        self.assertEqual(output.dtype, dtype)
+
 
 class TestCenterCrop(BaseTest):
     def test_center_crop_init(self) -> None:

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -263,21 +263,21 @@ class TestRandomScale(BaseTest):
 
     def test_random_scale_dtype_float64(self) -> None:
         dtype = torch.float64
-        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output_tensor = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
     def test_random_scale_dtype_float32(self) -> None:
         dtype = torch.float32
-        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
     def test_random_scale_dtype_float16(self) -> None:
         dtype = torch.float16
-        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
@@ -453,21 +453,21 @@ class TestRandomScaleAffine(BaseTest):
 
     def test_random_scale_affine_dtype_float64(self) -> None:
         dtype = torch.float64
-        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
     def test_random_scale_affine_dtype_float32(self) -> None:
         dtype = torch.float32
-        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
     def test_random_scale_affine_dtype_float16(self) -> None:
         dtype = torch.float16
-        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -263,14 +263,18 @@ class TestRandomScale(BaseTest):
 
     def test_random_scale_dtype_float64(self) -> None:
         dtype = torch.float64
-        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(
+            dtype=dtype
+        )
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
     def test_random_scale_dtype_float32(self) -> None:
         dtype = torch.float32
-        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(
+            dtype=dtype
+        )
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
@@ -446,14 +450,18 @@ class TestRandomScaleAffine(BaseTest):
 
     def test_random_scale_affine_dtype_float64(self) -> None:
         dtype = torch.float64
-        scale_module = transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScaleAffine(
+            scale=[0.975, 1.025, 0.95, 1.05]
+        ).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
     def test_random_scale_affine_dtype_float32(self) -> None:
         dtype = torch.float32
-        scale_module = transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        scale_module = transforms.RandomScaleAffine(
+            scale=[0.975, 1.025, 0.95, 1.05]
+        ).to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
@@ -465,7 +473,11 @@ class TestRandomScaleAffine(BaseTest):
                 + " CUDA."
             )
         dtype = torch.float16
-        scale_module = transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05]).cuda().to(dtype=dtype)
+        scale_module = (
+            transforms.RandomScaleAffine(scale=[0.975, 1.025, 0.95, 1.05])
+            .cuda()
+            .to(dtype=dtype)
+        )
         x = torch.ones([1, 3, 224, 224], dtype=dtype).cuda()
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
@@ -693,7 +705,9 @@ class TestRandomRotation(BaseTest):
             )
         dtype = torch.float16
         degrees = list(range(-25, -5)) + list(range(5, 25))
-        rotation_module = transforms.RandomRotation(degrees=degrees).cuda().to(dtype=dtype)
+        rotation_module = (
+            transforms.RandomRotation(degrees=degrees).cuda().to(dtype=dtype)
+        )
         x = torch.ones([1, 3, 224, 224], dtype=dtype).cuda()
         output = rotation_module(x)
         self.assertEqual(output.dtype, dtype)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -2156,21 +2156,21 @@ class TestTransformationRobustness(BaseTest):
         test_output = transform_robustness(test_input)
         self.assertEqual(test_output.shape, test_input.shape)
 
-    def test_random_scale_dtype_float64(self) -> None:
+    def test_transform_robustness_dtype_float64(self) -> None:
         dtype = torch.float64
         transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = transform_robustness(x)
         self.assertEqual(output.dtype, dtype)
 
-    def test_random_scale_dtype_float32(self) -> None:
+    def test_transform_robustness_dtype_float32(self) -> None:
         dtype = torch.float32
         transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = transform_robustness(x)
         self.assertEqual(output.dtype, dtype)
 
-    def test_random_scale_dtype_float16(self) -> None:
+    def test_transform_robustness_dtype_float16(self) -> None:
         dtype = torch.float16
         transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -2107,3 +2107,24 @@ class TestTransformationRobustness(BaseTest):
         test_input = torch.ones(1, 3, 224, 224)
         test_output = transform_robustness(test_input)
         self.assertEqual(test_output.shape, test_input.shape)
+
+    def test_random_scale_dtype_float64(self) -> None:
+        dtype = torch.float64
+        transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = transform_robustness(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_scale_dtype_float32(self) -> None:
+        dtype = torch.float32
+        transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = transform_robustness(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_scale_dtype_float16(self) -> None:
+        dtype = torch.float16
+        transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = transform_robustness(x)
+        self.assertEqual(output.dtype, dtype)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -279,6 +279,15 @@ class TestRandomScale(BaseTest):
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
+    def test_random_scale_dtype_bfloat16(self) -> None:
+        dtype = torch.bfloat16
+        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(
+            dtype=dtype
+        )
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = scale_module(x)
+        self.assertEqual(output.dtype, dtype)
+
 
 class TestRandomScaleAffine(BaseTest):
     def test_random_scale_affine_init(self) -> None:
@@ -709,6 +718,14 @@ class TestRandomRotation(BaseTest):
             transforms.RandomRotation(degrees=degrees).cuda().to(dtype=dtype)
         )
         x = torch.ones([1, 3, 224, 224], dtype=dtype).cuda()
+        output = rotation_module(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_rotation_dtype_bfloat16(self) -> None:
+        dtype = torch.bfloat16
+        degrees = list(range(-25, -5)) + list(range(5, 25))
+        rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = rotation_module(x)
         self.assertEqual(output.dtype, dtype)
 
@@ -1696,6 +1713,15 @@ class TestToRGB(BaseTest):
         output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
         self.assertEqual(output.dtype, dtype)
 
+    def test_to_rgb_dtype_bfloat16(self) -> None:
+        dtype = torch.bfloat16
+        to_rgb = transforms.ToRGB(transform="klt").to(dtype=dtype)
+        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
+        output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
+        self.assertEqual(output.dtype, dtype)
+        inverse_output = to_rgb(output, inverse=True)
+        self.assertEqual(inverse_output.dtype, dtype)
+
 
 class TestGaussianSmoothing(BaseTest):
     def test_gaussian_smoothing_init_1d(self) -> None:
@@ -2173,6 +2199,13 @@ class TestTransformationRobustness(BaseTest):
 
     def test_transform_robustness_dtype_float32(self) -> None:
         dtype = torch.float32
+        transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = transform_robustness(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_transform_robustness_dtype_bfloat16(self) -> None:
+        dtype = torch.bfloat16
         transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = transform_robustness(x)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1699,8 +1699,7 @@ class TestToRGB(BaseTest):
     def test_to_rgb_dtype_float16_cuda(self) -> None:
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
-                "Skipping RandomRotation float16 dtype test due to not supporting"
-                + " CUDA."
+                "Skipping ToRGB float16 dtype test due to not supporting CUDA."
             )
         dtype = torch.float16
         to_rgb = transforms.ToRGB(transform="klt").cuda().to(dtype=dtype)
@@ -1720,8 +1719,7 @@ class TestToRGB(BaseTest):
     def test_to_rgb_dtype_bfloat16_cuda(self) -> None:
         if not torch.cuda.is_available():
             raise unittest.SkipTest(
-                "Skipping RandomRotation bfloat16 dtype test due to not supporting"
-                + " CUDA."
+                "Skipping ToRGB bfloat16 dtype test due to not supporting CUDA."
             )
         dtype = torch.bfloat16
         to_rgb = transforms.ToRGB(transform="klt").cuda().to(dtype=dtype)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -279,15 +279,6 @@ class TestRandomScale(BaseTest):
         output = scale_module(x)
         self.assertEqual(output.dtype, dtype)
 
-    def test_random_scale_dtype_bfloat16(self) -> None:
-        dtype = torch.bfloat16
-        scale_module = transforms.RandomScale(scale=[0.975, 1.025, 0.95, 1.05]).to(
-            dtype=dtype
-        )
-        x = torch.ones([1, 3, 224, 224], dtype=dtype)
-        output = scale_module(x)
-        self.assertEqual(output.dtype, dtype)
-
 
 class TestRandomScaleAffine(BaseTest):
     def test_random_scale_affine_init(self) -> None:
@@ -722,10 +713,17 @@ class TestRandomRotation(BaseTest):
         self.assertEqual(output.dtype, dtype)
 
     def test_random_rotation_dtype_bfloat16(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping RandomRotation bfloat16 dtype test due to not supporting"
+                + " CUDA."
+            )
         dtype = torch.bfloat16
         degrees = list(range(-25, -5)) + list(range(5, 25))
-        rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
-        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        rotation_module = (
+            transforms.RandomRotation(degrees=degrees).cuda().to(dtype=dtype)
+        )
+        x = torch.ones([1, 3, 224, 224], dtype=dtype).cuda()
         output = rotation_module(x)
         self.assertEqual(output.dtype, dtype)
 
@@ -1713,7 +1711,33 @@ class TestToRGB(BaseTest):
         output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
         self.assertEqual(output.dtype, dtype)
 
+    def test_to_rgb_dtype_float16_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping RandomRotation float16 dtype test due to not supporting"
+                + " CUDA."
+            )
+        dtype = torch.float16
+        to_rgb = transforms.ToRGB(transform="klt").to(dtype=dtype)
+        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
+        output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
+        self.assertEqual(output.dtype, dtype)
+        inverse_output = to_rgb(output, inverse=True)
+        self.assertEqual(inverse_output.dtype, dtype)
+
     def test_to_rgb_dtype_bfloat16(self) -> None:
+        dtype = torch.bfloat16
+        to_rgb = transforms.ToRGB(transform="klt").to(dtype=dtype)
+        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
+        output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
+        self.assertEqual(output.dtype, dtype)
+
+    def test_to_rgb_dtype_bfloat16_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest(
+                "Skipping RandomRotation bfloat16 dtype test due to not supporting"
+                + " CUDA."
+            )
         dtype = torch.bfloat16
         to_rgb = transforms.ToRGB(transform="klt").to(dtype=dtype)
         test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
@@ -2199,13 +2223,6 @@ class TestTransformationRobustness(BaseTest):
 
     def test_transform_robustness_dtype_float32(self) -> None:
         dtype = torch.float32
-        transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
-        x = torch.ones([1, 3, 224, 224], dtype=dtype)
-        output = transform_robustness(x)
-        self.assertEqual(output.dtype, dtype)
-
-    def test_transform_robustness_dtype_bfloat16(self) -> None:
-        dtype = torch.bfloat16
         transform_robustness = transforms.TransformationRobustness().to(dtype=dtype)
         x = torch.ones([1, 3, 224, 224], dtype=dtype)
         output = transform_robustness(x)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -712,21 +712,6 @@ class TestRandomRotation(BaseTest):
         output = rotation_module(x)
         self.assertEqual(output.dtype, dtype)
 
-    def test_random_rotation_dtype_bfloat16(self) -> None:
-        if not torch.cuda.is_available():
-            raise unittest.SkipTest(
-                "Skipping RandomRotation bfloat16 dtype test due to not supporting"
-                + " CUDA."
-            )
-        dtype = torch.bfloat16
-        degrees = list(range(-25, -5)) + list(range(5, 25))
-        rotation_module = (
-            transforms.RandomRotation(degrees=degrees).cuda().to(dtype=dtype)
-        )
-        x = torch.ones([1, 3, 224, 224], dtype=dtype).cuda()
-        output = rotation_module(x)
-        self.assertEqual(output.dtype, dtype)
-
 
 class TestRandomSpatialJitter(BaseTest):
     def test_random_spatial_jitter_init(self) -> None:
@@ -1718,8 +1703,8 @@ class TestToRGB(BaseTest):
                 + " CUDA."
             )
         dtype = torch.float16
-        to_rgb = transforms.ToRGB(transform="klt").to(dtype=dtype)
-        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
+        to_rgb = transforms.ToRGB(transform="klt").cuda().to(dtype=dtype)
+        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype).cuda()
         output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
         self.assertEqual(output.dtype, dtype)
         inverse_output = to_rgb(output, inverse=True)
@@ -1739,8 +1724,8 @@ class TestToRGB(BaseTest):
                 + " CUDA."
             )
         dtype = torch.bfloat16
-        to_rgb = transforms.ToRGB(transform="klt").to(dtype=dtype)
-        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype)
+        to_rgb = transforms.ToRGB(transform="klt").cuda().to(dtype=dtype)
+        test_tensor = torch.ones(1, 3, 224, 224, dtype=dtype).cuda()
         output = to_rgb(test_tensor.refine_names("B", "C", "H", "W"))
         self.assertEqual(output.dtype, dtype)
         inverse_output = to_rgb(output, inverse=True)

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -261,6 +261,27 @@ class TestRandomScale(BaseTest):
             0,
         )
 
+    def test_random_scale_dtype_float64(self) -> None:
+        dtype = torch.float64
+        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output_tensor = scale_module(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_scale_dtype_float32(self) -> None:
+        dtype = torch.float32
+        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = scale_module(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_scale_dtype_float16(self) -> None:
+        dtype = torch.float16
+        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = scale_module(x)
+        self.assertEqual(output.dtype, dtype)
+
 
 class TestRandomScaleAffine(BaseTest):
     def test_random_scale_affine_init(self) -> None:
@@ -429,6 +450,27 @@ class TestRandomScaleAffine(BaseTest):
             .unsqueeze(0),
             0,
         )
+
+    def test_random_scale_affine_dtype_float64(self) -> None:
+        dtype = torch.float64
+        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = scale_module(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_scale_affine_dtype_float32(self) -> None:
+        dtype = torch.float32
+        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = scale_module(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_scale_affine_dtype_float16(self) -> None:
+        dtype = torch.float16
+        scale_module = transforms.RandomScale(scale=[1, 0.975, 1.025, 0.95, 1.05]).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = scale_module(x)
+        self.assertEqual(output.dtype, dtype)
 
 
 class TestRandomRotation(BaseTest):
@@ -628,6 +670,30 @@ class TestRandomRotation(BaseTest):
             .unsqueeze(0)
         )
         assertTensorAlmostEqual(self, test_output, expected_output, 0.005)
+
+    def test_random_rotation_dtype_float64(self) -> None:
+        dtype = torch.float64
+        degrees = list(range(-25, 25))
+        rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = rotation_module(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_rotation_dtype_float32(self) -> None:
+        dtype = torch.float32
+        degrees = list(range(-25, 25))
+        rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = rotation_module(x)
+        self.assertEqual(output.dtype, dtype)
+
+    def test_random_rotation_dtype_float16(self) -> None:
+        dtype = float16
+        degrees = list(range(-25, 25))
+        rotation_module = transforms.RandomRotation(degrees=degrees).to(dtype=dtype)
+        x = torch.ones([1, 3, 224, 224], dtype=dtype)
+        output = rotation_module(x)
+        self.assertEqual(output.dtype, dtype)
 
 
 class TestRandomSpatialJitter(BaseTest):


### PR DESCRIPTION
* `torch.float16` interpolate fails due to: `RuntimeError: "compute_indices_weights_linear" not implemented for 'Half'`, `RuntimeError: "compute_indices_weights_linear" not implemented for 'BFloat16'`
* `torch.float16` Affine Grid transforms fail due to: `RuntimeError: "linspace_cpu" not implemented for 'Half'`, `RuntimeError: "linalg_inv_out_cpu" not implemented for 'BFloat16'`, `RuntimeError: grid_sampler_2d_cpu not implemented for BFloat16`
* `torch.float16` jitter fails due to: `RuntimeError: "reflection_pad2d" not implemented for 'Half'`, `RuntimeError: "reflection_pad2d" not implemented for 'BFloat16'`
* `torch.float16` ToRGB inversse transforms fail due to lack of float16 support.


bfloat16 FFTImage: `RuntimeError: view_as_complex is only supported for float and double tensors, but got a tensor of scalar type: BFloat16`