### PR TITLE
Improve version checking

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -6,7 +6,6 @@ from inspect import signature
 from typing import Any, Callable, cast, Dict, List, overload, Tuple, Union
 
 import numpy as np
-from packaging import version
 import torch
 from captum._utils.typing import (
     BaselineType,
@@ -15,6 +14,7 @@ from captum._utils.typing import (
     TensorOrTupleOfTensorsGeneric,
     TupleOrTensorOrBoolGeneric,
 )
+from packaging import version
 from torch import device, Tensor
 from torch.nn import Module
 

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -6,6 +6,7 @@ from inspect import signature
 from typing import Any, Callable, cast, Dict, List, overload, Tuple, Union
 
 import numpy as np
+from packaging import version
 import torch
 from captum._utils.typing import (
     BaselineType,
@@ -671,7 +672,7 @@ def _register_backward_hook(
     ):
         return module.register_backward_hook(hook)
 
-    if torch.__version__ >= "1.9":
+    if version.parse(torch.__version__) >= version.parse("1.9.0"):
         # Only supported for torch >= 1.9
         return module.register_full_backward_hook(hook)
     else:

--- a/captum/influence/_core/similarity_influence.py
+++ b/captum/influence/_core/similarity_influence.py
@@ -9,6 +9,7 @@ import torch
 from captum._utils.av import AV
 from captum.attr import LayerActivation
 from captum.influence._core.influence import DataInfluence
+from packaging import version
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader, Dataset
@@ -40,7 +41,7 @@ def cosine_similarity(test, train, replace_nan=0) -> Tensor:
     test = test.view(test.shape[0], -1)
     train = train.view(train.shape[0], -1)
 
-    if torch.__version__ <= "1.6.0":
+    if version.parse(torch.__version__) <= version.parse("1.6.0"):
         test_norm = torch.norm(test, p=None, dim=1, keepdim=True)
         train_norm = torch.norm(train, p=None, dim=1, keepdim=True)
     else:

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -2,10 +2,11 @@
 
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-from packaging import version
 import torch
 import torch.nn as nn
 from captum._utils.progress import progress
+
+from packaging import version
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader, Dataset

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Callable, List, Optional, Tuple, Union
 
+from packaging import version
 import torch
 import torch.nn as nn
 from captum._utils.progress import progress
@@ -125,7 +126,7 @@ def _jacobian_loss_wrt_inputs(
             "Must be either 'sum' or 'mean'."
         )
 
-    if torch.__version__ >= "1.8":
+    if version.parse(torch.__version__) >= version.parse("1.8.0"):
         input_jacobians = torch.autograd.functional.jacobian(
             lambda out: loss_fn(out, targets), out, vectorize=vectorize
         )

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         long_description=long_description,
         long_description_content_type="text/markdown",
         python_requires=">=3.6",
-        install_requires=["matplotlib", "numpy", "torch>=1.6"],
+        install_requires=["matplotlib", "numpy", "packaging", "torch>=1.6"],
         packages=find_packages(exclude=("tests", "tests.*")),
         extras_require={
             "dev": DEV_REQUIRES,


### PR DESCRIPTION
The `packaging` library will in some cases not be installed on a user's device. It's one of the core libraries from the Python Packaging Authority, but it's not included with the base Python installation: https://packaging.python.org/en/latest/key_projects/#pypa-projects