### PR TITLE
Fix class variable position for Sphinx

### DIFF
--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -318,11 +318,12 @@ class PerturbationAttribution(Attribution):
 
 
 class InternalAttribution(Attribution, Generic[ModuleOrModuleList]):
-    layer: ModuleOrModuleList
     r"""
     Shared base class for LayerAttrubution and NeuronAttribution,
     attribution types that require a model and a particular layer.
     """
+
+    layer: ModuleOrModuleList
 
     def __init__(
         self,


### PR DESCRIPTION
* Later versions of Sphinx thought that the class description below was the docstring for the variable.